### PR TITLE
Fix executable name

### DIFF
--- a/docs/bpftime/documents/usage.md
+++ b/docs/bpftime/documents/usage.md
@@ -29,7 +29,7 @@ bpftime load ./example/malloc/malloc
 In another shell, Run the target program with eBPF inside:
 
 ```console
-$ bpftime start ./example/malloc/test
+$ bpftime start ./example/malloc/victim
 Hello malloc!
 malloc called from pid 250215
 continue malloc...
@@ -39,7 +39,7 @@ malloc called from pid 250215
 You can also dynamically attach the eBPF program with a running process:
 
 ```console
-$ ./example/malloc/test & echo $! # The pid is 101771
+$ ./example/malloc/victim & echo $! # The pid is 101771
 [1] 101771
 101771
 continue malloc...


### PR DESCRIPTION
Renamed to `victim` in https://github.com/eunomia-bpf/bpftime/commit/d6a1f570f0bf413c226105ae3f75b031fff2ef3d