### PR TITLE
Update build-and-test.md with cloning instructions

### DIFF
--- a/docs/bpftime/documents/build-and-test.md
+++ b/docs/bpftime/documents/build-and-test.md
@@ -28,6 +28,8 @@
 We provide a docker image for building and testing bpftime.
 
 ```bash
+# clone the bpftime repository
+git clone https://github.com/eunomia-bpf/bpftime
 # run the container
 docker run -it --rm --name test_bpftime -v "$(pwd)":/workdir -w /workdir ghcr.io/eunomia-bpf/bpftime:latest /bin/bash
 # start another shell in the container (If needed)


### PR DESCRIPTION
## Description
The documentation is insufficient regarding post-installation steps.
Specifically, it assumes that the repository has already been cloned.
To address this, I added the repository cloning step before the Docker installation instructions.

## Type of change


- [v ] Bug fix (non-breaking change which fixes an issue)
- [v] Breaking change (fix or feature that would cause existing functionality to not work as expected)

