### PR TITLE
Document Next.js stack, pin Next to stable 16.2.6, fix deploy docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,26 +4,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the source code for the eunomia-bpf project website (https://eunomia.dev), a documentation site built with MkDocs and Material theme. The site provides comprehensive tutorials and documentation for eBPF programming, the eunomia-bpf framework, bpftime, and related projects.
+This is the source code for the eunomia-bpf project website (https://eunomia.dev). The site provides comprehensive tutorials and documentation for eBPF programming, the eunomia-bpf framework, bpftime, and related projects.
+
+### Tech stack (current)
+
+The site is rendered by a **custom Next.js + React + Tailwind CSS frontend** living in `app/`, statically exported to plain HTML/CSS/JS. It is **not** a runtime MkDocs site anymore.
+
+- **Next.js** (pages router under `app/pages/`, `output: "export"` static export) — note the directory is named `app/` but uses the *pages* router, not the App Router
+- **React 19** + **TypeScript** for components in `app/components/` and content/loader logic in `app/lib/`
+- **Tailwind CSS** (`app/tailwind.config.ts`) for styling
+- Content is still authored as **Markdown in `docs/**`**; a build-time pipeline (`app/scripts/generate-*`) parses it into JSON artifacts (content index, search index, manifest, static metadata) that the Next.js pages consume.
+- **`mkdocs.yaml` is retained as the site IA / navigation configuration source** (parsed by `app/lib/content/mkdocs-config.ts`), not as a renderer. The MkDocs build itself is legacy — see `.github/workflows/mkdocs.yml` (`workflow_dispatch` only).
+
+See `app/README.md` and `app/ARCHITECTURE.md` for the frontend in depth (note: `ARCHITECTURE.md` still names Cloudflare Pages as the target; the live deploy is GitHub Pages — see Deployment below).
 
 ## Common Development Commands
 
-### Documentation Development
+### Frontend Development (Next.js app)
 ```bash
-# Install all dependencies
-make install
+cd app
 
-# Run local development server (http://localhost:8000)
-mkdocs serve
+# Install dependencies (Node.js 22+)
+npm ci
 
-# Build the static site
-make build
-# or
-mkdocs build
+# Run the local dev server (http://localhost:3000)
+# Regenerates content artifacts, then runs `next dev`
+npm run dev
 
-# Clean build artifacts
-make clean
+# Production-compatible static export -> app/out
+NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run build
+
+# Quality gates
+npm run lint        # eslint over components/lib/pages/scripts/tests
+npm run typecheck   # tsc --noEmit
+npm run verify      # lint + verify.mjs (used in CI)
 ```
+
+> Legacy MkDocs commands (`mkdocs serve` / `make build`) only drive the deprecated
+> `.github/workflows/mkdocs.yml` path and are no longer how the live site is built.
 
 ### Content Synchronization
 ```bash
@@ -57,15 +75,17 @@ make cupti-exp
   - Defines site structure and features
 
 ### Deployment
-- GitHub Actions automatically builds and deploys to GitHub Pages
-- Deployed to the `docs` branch
-- Triggers on push, PR, and repository dispatch events
+- `.github/workflows/app-static-pages.yml` builds the Next.js app (`cd app && npm run build`),
+  verifies the static export (no `localhost`/`127.0.0.1` leakage, correct canonical URLs in
+  `sitemap.xml`/`robots.txt`/`feed.xml`), then deploys `app/out` to **GitHub Pages** via
+  `actions/deploy-pages@v5`.
+- The MkDocs workflow (`mkdocs.yml`) is legacy and only runs on manual `workflow_dispatch`.
 
 ### Content Management
-- The site is multilingual (English and Chinese)
-- Uses mkdocs-static-i18n for internationalization
-- Blog posts support tags and RSS feeds
-- Git revision date and authors are tracked automatically
+- The site is multilingual (English and Chinese); locale routing is handled by the
+  content manifest / loaders (`/zh/**` mirrors English route identities)
+- Blog posts support tags and RSS feeds (`feed.xml`, `zh/feed.xml` emitted at build time)
+- Git revision date and authors are collected at build time and surfaced per page
 
 ### Working with eBPF Tutorial Code
 When working with eBPF examples in the tutorials:
@@ -79,6 +99,6 @@ When working with eBPF examples in the tutorials:
 - Do not edit tutorial content directly in this repo - edit in the bpf-developer-tutorial repository
 - Project home pages should be edited in their respective repository README files
 - The site automatically syncs content from external repositories during build
-- Always test changes locally with `mkdocs serve` before committing
+- Always test changes locally with `cd app && npm run dev` (and run `npm run verify`) before committing
 - Never change existing public paths, source paths, route slugs, or existing navigation target hrefs unless the user explicitly requests that exact path change. Adding a new page is acceptable only when it does not move, rename, or reparent existing content paths. In particular, keep project documentation URL ownership stable: `/bpftime/` and `/bpftime/**` must remain bpftime paths, not be moved under `/products/` or another section.
-- All site URL, route, navigation, nav-dropdown, sidebar, and page-link configuration belongs in `mkdocs.yaml`. React/TypeScript components may render configured links, but must not define route tables, navigation entries, or hard-coded internal hrefs for site pages. Use generated content/IA data from `mkdocs.yaml` instead.
+- **`mkdocs.yaml` is the permanent, single source of truth for site IA configuration** (this is a fixed architectural decision, not a transitional state). All site URL, route, navigation, nav-dropdown, sidebar, and page-link configuration belongs in `mkdocs.yaml`. React/TypeScript components may render configured links, but must NOT define route tables, navigation entries, or hard-coded internal hrefs for site pages. Use generated content/IA data derived from `mkdocs.yaml` (via `app/lib/content/mkdocs-config.ts`) instead.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ For the home page of each project, please edit the README of them.
 
 [official website]: https://eunomia.dev
 
+## Tech stack
+
+The website is a custom **Next.js + React + Tailwind CSS** frontend (in `app/`) that
+statically exports to plain HTML/CSS/JS and deploys to GitHub Pages. Content is authored
+as Markdown under `docs/**` and compiled into the site at build time; `mkdocs.yaml` is kept
+as the navigation/IA configuration source. See `app/README.md` and `app/ARCHITECTURE.md`.
+
 ## Requirements
 
 - Node.js 22+

--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -15,7 +15,8 @@ This document is the target architecture for the migration, not a description of
 
 Deployment is now locked:
 
-- `Cloudflare Pages static`
+- **GitHub Pages** (static artifact deploy via `actions/deploy-pages`) is the deployment target
+- output is host-agnostic static files, so any static host works, but GitHub Pages is the one we ship to
 - true static export only
 - no `API route`
 - no production server runtime

--- a/app/README.md
+++ b/app/README.md
@@ -1,11 +1,16 @@
 # eunomia.dev Custom Frontend Plan
 
+> **Configuration rule:** `mkdocs.yaml` is the permanent single source of truth for site
+> IA — navigation, nav dropdowns, sidebar, route ownership, and internal page links. All such
+> config lives in `mkdocs.yaml`; never hard-code routes, nav entries, or internal hrefs in
+> React/TypeScript. Components only render the generated IA data derived from `mkdocs.yaml`.
+
 ## Decision
 
 If `eunomia.dev` moves away from MkDocs, the replacement must be:
 
 - `Next.js` used as a static site compiler, not as a server runtime
-- GitHub Pages Actions artifact deployment as the current deployment target, while keeping Cloudflare Pages static compatibility
+- GitHub Pages Actions artifact deployment is the deployment target (output is host-agnostic static files, but GitHub Pages is the one we ship to)
 - true static export output only
 - Markdown content kept in-repo
 - no `API route`
@@ -278,7 +283,7 @@ The new frontend must preserve:
 - current SEO infrastructure: `robots.txt`, `sitemap.xml`, canonical URLs, Open Graph tags, alternate language links, descriptive titles, and page descriptions
 - current site behavior: search, blog index, dated posts, docs pages, multilingual routing, edit links, analytics, feedback entry points, and share buttons
 - the existing Markdown content model instead of rewriting hundreds of documents as React pages
-- GitHub Pages Actions artifact deployment and Cloudflare Pages static compatibility
+- GitHub Pages Actions artifact deployment (host-agnostic static output)
 - no production API routes
 - no runtime server dependency after build/export
 

--- a/app/components/AboutLandingPage.tsx
+++ b/app/components/AboutLandingPage.tsx
@@ -3,6 +3,14 @@ import Image from "next/image";
 import type { ReactPageLink } from "../lib/content/types";
 import type { MkdocsHomeProject } from "../lib/content/mkdocs-config";
 import type { Locale } from "../lib/site-data";
+import { ContactCard, CredibilityStrip, StarBar, type StarRepo } from "./Credibility";
+
+const ABOUT_STARS: StarRepo[] = [
+  { repo: "bpf-developer-tutorial", label: "Tutorials" },
+  { repo: "bpftime", label: "bpftime" },
+  { repo: "eunomia-bpf", label: "eunomia-bpf" },
+  { repo: "wasm-bpf", label: "wasm-bpf" }
+];
 
 type AboutLandingPageProps = {
   locale: Locale;
@@ -82,6 +90,10 @@ export function AboutLandingPage({ locale, links, projects }: AboutLandingPagePr
             {copy.title}
           </h1>
           <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">{copy.description}</p>
+          <CredibilityStrip locale={locale} className="mt-6" />
+          <div className="mt-5">
+            <StarBar repos={ABOUT_STARS} locale={locale} />
+          </div>
         </div>
         {logoImage ? (
           <div className="relative min-h-64 overflow-hidden border border-slate-200 bg-slate-50">
@@ -146,6 +158,8 @@ export function AboutLandingPage({ locale, links, projects }: AboutLandingPagePr
           </div>
         </article>
       </div>
+
+      <ContactCard locale={locale} />
     </section>
   );
 }

--- a/app/components/Credibility.tsx
+++ b/app/components/Credibility.tsx
@@ -1,0 +1,155 @@
+import type { ReactPageLink } from "../lib/content/types";
+import type { Locale } from "../lib/site-data";
+
+const ORG_URL = "https://github.com/eunomia-bpf";
+const SHIELD = "https://img.shields.io/github/stars/eunomia-bpf";
+const CONTACT_EMAIL = "yusheng@eunomia.dev";
+
+export type StarRepo = { repo: string; label: string };
+
+/**
+ * Live GitHub star badges (shields.io). Rendered as plain <img> on purpose: the
+ * counts must stay fresh on every page view, and static export cannot embed a
+ * build-time number without it going stale.
+ */
+export function StarBar({ repos, locale }: { repos: StarRepo[]; locale: Locale }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2.5">
+      <span className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+        {locale === "zh" ? "开源采用" : "Open-source traction"}
+      </span>
+      {repos.map((entry) => (
+        <a
+          key={entry.repo}
+          href={`${ORG_URL}/${entry.repo}`}
+          target="_blank"
+          rel="noopener"
+          className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 transition hover:border-cyan-700/40 hover:text-ink"
+        >
+          {entry.label}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${SHIELD}/${entry.repo}?style=flat-square&label=&color=0e7490&logo=github&logoColor=white`}
+            alt={`${entry.label} stars on GitHub`}
+            className="h-4"
+            loading="lazy"
+          />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Stable credibility facts (publication, license, research provenance). Unlike
+ * star counts these do not change, so the copy is fixed.
+ */
+export function CredibilityStrip({
+  locale,
+  osdi,
+  className = ""
+}: {
+  locale: Locale;
+  osdi?: ReactPageLink;
+  className?: string;
+}) {
+  const facts: Array<{ label: string; href?: string }> = [
+    osdi
+      ? { label: osdi.label, href: osdi.href }
+      : {
+          label: locale === "zh" ? "OSDI 2025 发表" : "Published at OSDI 2025",
+          href: "https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng"
+        },
+    { label: locale === "zh" ? "MIT 开源协议" : "MIT licensed", href: ORG_URL },
+    { label: locale === "zh" ? "源自系统研究" : "Backed by systems research" }
+  ];
+
+  const badgeClass =
+    "inline-flex items-center gap-1.5 rounded-full border border-cyan-700/30 bg-cyan-50/60 px-3 py-1 text-xs font-semibold text-cyan-800";
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`.trim()}>
+      {facts.map((fact) => {
+        const dot = <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-cyan-600" />;
+        if (!fact.href) {
+          return (
+            <span key={fact.label} className={badgeClass}>
+              {dot}
+              {fact.label}
+            </span>
+          );
+        }
+        const external = /^https?:\/\//.test(fact.href);
+        return (
+          <a
+            key={fact.label}
+            href={fact.href}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noopener" : undefined}
+            className={`${badgeClass} transition hover:border-cyan-700/60`}
+          >
+            {dot}
+            {fact.label}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Commercial trust block: who maintains the work and how to reach a human.
+ * `contact` is sourced from page config when available (mkdocs.yaml), otherwise
+ * falls back to the canonical email.
+ */
+export function ContactCard({
+  locale,
+  contact,
+  className = ""
+}: {
+  locale: Locale;
+  contact?: ReactPageLink;
+  className?: string;
+}) {
+  const email = contact?.href.startsWith("mailto:") ? contact.href.slice("mailto:".length) : CONTACT_EMAIL;
+  const copy =
+    locale === "zh"
+      ? {
+          eyebrow: "联系",
+          title: "和维护团队直接对话",
+          body:
+            "由 eunomia-bpf 开源团队维护，工作根植于已发表的系统研究（OSDI 2025）。企业评估、POC 和生产集成可直接邮件联系，我们通常在两个工作日内回复。",
+          cta: "邮件联系",
+          response: "通常 2 个工作日内回复"
+        }
+      : {
+          eyebrow: "Contact",
+          title: "Talk to the people who maintain it",
+          body:
+            "Maintained by the eunomia-bpf open-source team, with work grounded in published systems research (OSDI 2025). Reach out directly for enterprise evaluation, POCs, and production integration.",
+          cta: "Email us",
+          response: "Typically replies within 2 business days"
+        };
+
+  return (
+    <div
+      className={`flex flex-col gap-5 rounded-lg border border-slate-200 bg-slate-50 p-6 md:flex-row md:items-center md:justify-between ${className}`.trim()}
+    >
+      <div className="max-w-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-700">{copy.eyebrow}</p>
+        <h2 className="mt-2 text-xl font-semibold tracking-normal text-ink">{copy.title}</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-600">{copy.body}</p>
+      </div>
+      <div className="flex shrink-0 flex-col items-start gap-2">
+        <a
+          href={`mailto:${email}`}
+          className="inline-flex min-h-11 items-center rounded-md bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800"
+        >
+          {copy.cta}
+        </a>
+        <span className="text-xs text-slate-500">{email}</span>
+        <span className="text-xs text-slate-400">{copy.response}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ProductPages.tsx
+++ b/app/components/ProductPages.tsx
@@ -4,6 +4,13 @@ import type { ReactNode } from "react";
 import type { ReactPageLink } from "../lib/content/types";
 import type { MkdocsHomeProject } from "../lib/content/mkdocs-config";
 import type { Locale } from "../lib/site-data";
+import { ContactCard, CredibilityStrip, StarBar, type StarRepo } from "./Credibility";
+
+const ORG_STARS: StarRepo[] = [
+  { repo: "bpftime", label: "bpftime" },
+  { repo: "bpf-developer-tutorial", label: "Tutorials" },
+  { repo: "eunomia-bpf", label: "eunomia-bpf" }
+];
 
 type ProductPageProps = {
   locale: Locale;
@@ -297,6 +304,10 @@ export function ProductsLandingPage({ locale, links, projects }: ProductPageProp
             {copy.title}
           </h1>
           <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">{copy.description}</p>
+          <CredibilityStrip locale={locale} className="mt-6" />
+          <div className="mt-5">
+            <StarBar repos={ORG_STARS} locale={locale} />
+          </div>
           <ActionRow links={[linkByKey.get("bpftime"), linkByKey.get("contact")]} />
         </div>
         <VisualPanel>
@@ -357,6 +368,8 @@ export function ProductsLandingPage({ locale, links, projects }: ProductPageProp
           <CapabilityGrid items={copy.buyers} />
         </div>
       </div>
+
+      <ContactCard locale={locale} contact={linkByKey.get("contact")} />
     </section>
   );
 }
@@ -454,8 +467,17 @@ export function BpftimeProductPage({ locale, links, projects }: ProductPageProps
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700">{copy.eyebrow}</p>
           <h1 className="mt-4 text-5xl font-semibold tracking-normal text-ink md:text-6xl">{copy.title}</h1>
           <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">{copy.description}</p>
+          <CredibilityStrip locale={locale} osdi={linkByKey.get("osdi")} className="mt-6" />
+          <div className="mt-5">
+            <StarBar repos={[{ repo: "bpftime", label: "bpftime" }]} locale={locale} />
+          </div>
           <ActionRow
-            links={[linkByKey.get("bpftime-docs"), linkByKey.get("bpftime-github"), linkByKey.get("support")]}
+            links={[
+              linkByKey.get("bpftime-docs"),
+              linkByKey.get("bpftime-github"),
+              linkByKey.get("osdi"),
+              linkByKey.get("support")
+            ]}
           />
         </div>
         <VisualPanel image={bpftimeImage} imageAlt="bpftime runtime architecture">
@@ -494,6 +516,8 @@ export function BpftimeProductPage({ locale, links, projects }: ProductPageProps
           <CapabilityGrid items={copy.capabilities} />
         </div>
       </div>
+
+      <ContactCard locale={locale} contact={linkByKey.get("support")} />
     </section>
   );
 }
@@ -572,6 +596,9 @@ export function AgentRuntimeInfrastructurePage({ locale, links, projects }: Prod
           {copy.title}
         </h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">{copy.description}</p>
+        <div className="mt-6">
+          <StarBar repos={[{ repo: "agentsight", label: "AgentSight" }]} locale={locale} />
+        </div>
         <ActionRow links={[linkByKey.get("pilot")]} />
       </div>
 
@@ -631,6 +658,10 @@ export function AgentRuntimeInfrastructurePage({ locale, links, projects }: Prod
           </p>
           <ActionRow links={[linkByKey.get("acrfence-article")]} />
         </article>
+      </div>
+
+      <div className="pt-12">
+        <ContactCard locale={locale} contact={linkByKey.get("pilot")} />
       </div>
     </section>
   );
@@ -755,6 +786,10 @@ export function ServicesProductPage({ locale, links }: ProductPageProps) {
           {copy.title}
         </h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">{copy.description}</p>
+        <CredibilityStrip locale={locale} className="mt-6" />
+        <div className="mt-5">
+          <StarBar repos={ORG_STARS} locale={locale} />
+        </div>
         <ActionRow links={[linkByKey.get("contact")]} />
       </div>
 
@@ -793,6 +828,8 @@ export function ServicesProductPage({ locale, links }: ProductPageProps) {
           </div>
         </VisualPanel>
       </div>
+
+      <ContactCard locale={locale} contact={linkByKey.get("contact")} />
     </section>
   );
 }

--- a/app/components/SiteFooter.tsx
+++ b/app/components/SiteFooter.tsx
@@ -31,6 +31,9 @@ export function SiteFooter({ locale }: SiteFooterProps) {
         <div>
           <p className="text-lg font-semibold tracking-tight text-ink">eunomia</p>
           <p className="mt-3 max-w-md leading-7">{copy.copyright}</p>
+          <p className="mt-3 text-xs text-slate-500">
+            © {new Date().getFullYear()} eunomia-bpf · MIT License
+          </p>
         </div>
         <FooterColumn title={copy.explore} links={exploreLinks} />
         <FooterColumn title={copy.projects} links={projectLinks} />

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "gray-matter": "^4.0.3",
         "mermaid": "^11.12.0",
-        "next": "16.3.0-canary.26",
+        "next": "16.2.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rehype-pretty-code": "^0.14.3",
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
-        "@next/eslint-plugin-next": "16.3.0-canary.26",
+        "@next/eslint-plugin-next": "16.2.6",
         "@types/node": "^22.13.10",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -1291,15 +1291,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0-canary.26.tgz",
-      "integrity": "sha512-QQigNHYlBvtATYoqtYxkvizJYXTwOiA4/fkfcjN8Jkydm0MvTEK8NSMScDNu7NDbPbVyLp3848dW+e4W13Hp+g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.0-canary.26.tgz",
-      "integrity": "sha512-likU3+HDd0SsuslwrDfL9uUeMsFD6EVEm6GqAj+nwFQ2epLGkIG4tBftPSaQfAQ44fRyS+PT4jdeO+9dbvy5+w==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0-canary.26.tgz",
-      "integrity": "sha512-XHI6rARAsGJiDyyDVsT8oYUB8SC1UxHVIQRLw1y0S9Yw4d2zMhIfemMd0QX30nydmyq/Fu0IrGIb7viBG84AvA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1353,9 +1353,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0-canary.26.tgz",
-      "integrity": "sha512-orTc877oz1mSkiv7VRE2kS1ZpY0DUtDv3zVdvtKfRYvRTXmWQQjbuziPJdECkq0vjCKl8MD0v+jlZHDlNSH9pA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1369,9 +1369,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0-canary.26.tgz",
-      "integrity": "sha512-eqJuG46YwWNWvNmhjGA1nBMcuUoyZKNHzj9oiBD+XpigZ2hkz8zaFOzVC+8eSTGdjPbhKgn8M4PDBc1AMjIOGQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -1385,9 +1385,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0-canary.26.tgz",
-      "integrity": "sha512-mZPbgSalHnJSChyZLDmm0j4oKXLd/MsueX58zSQG+rJz/kQSnPNiRmbinxDuuTGf6b9iFsqSmV+qL79OTqjYQA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -1401,9 +1401,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0-canary.26.tgz",
-      "integrity": "sha512-cc6X0+lmMDJKHeVWyYzLCzB86xNi5g0BdpFD2VzHbrnMDD1hk7FH7Io8Aj0b0q+tvKWlNmACshR78CyEEXRxvw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0-canary.26.tgz",
-      "integrity": "sha512-7SElcBLZj+6yCTbvh2i8/f/N+wH8dXoJk+tqKQehfSF2Ov60FM8WsbKG32LCCMV23ovwHGwiU2GKShl4N3sC6g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -1433,9 +1433,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0-canary.26.tgz",
-      "integrity": "sha512-9iaJhDEjiLTt0EHxKX9bW/gyqJrZHfdMo5cxBoHjdcjVtIPvlQosicKkLMrgNvd6J0bX897DtvwIZdH2mW6MRQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0-canary.26.tgz",
-      "integrity": "sha512-MR0D9LuhELmlKyuZV13L1p+Zcjvz0QZnYgYrDSRuucYS98JM99pl++jXXwEX2TqwetcuGbqnPjbczJB4feZrZQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -5333,16 +5333,16 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.3.0-canary.26",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0-canary.26.tgz",
-      "integrity": "sha512-ZZVffjC8Z2Yh4U5ZqLUQDT2FCzNPOrsKKsYpsYzF4dSh55ygY8wBnpn1qoTu3S5v54F6hW2q+L+Y++mBjSKyKg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.3.0-canary.26",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.5.10",
+        "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -5352,14 +5352,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.0-canary.26",
-        "@next/swc-darwin-x64": "16.3.0-canary.26",
-        "@next/swc-linux-arm64-gnu": "16.3.0-canary.26",
-        "@next/swc-linux-arm64-musl": "16.3.0-canary.26",
-        "@next/swc-linux-x64-gnu": "16.3.0-canary.26",
-        "@next/swc-linux-x64-musl": "16.3.0-canary.26",
-        "@next/swc-win32-arm64-msvc": "16.3.0-canary.26",
-        "@next/swc-win32-x64-msvc": "16.3.0-canary.26",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -5386,9 +5386,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5405,9 +5405,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "mermaid": "^11.12.0",
-    "next": "16.3.0-canary.26",
+    "next": "16.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rehype-pretty-code": "^0.14.3",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
-    "@next/eslint-plugin-next": "16.3.0-canary.26",
+    "@next/eslint-plugin-next": "16.2.6",
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -721,6 +721,10 @@ extra:
           label: GitHub
           label_zh: GitHub
           href: https://github.com/eunomia-bpf/bpftime
+        - key: osdi
+          label: OSDI 2025 paper
+          label_zh: OSDI 2025 论文
+          href: https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng
         - key: support
           label: Enterprise support
           label_zh: 企业支持


### PR DESCRIPTION
## Summary
- Record the site as a **Next.js + React + Tailwind** static-export app in root `CLAUDE.md` and `README.md` (docs still described MkDocs).
- Pin `next` and `@next/eslint-plugin-next` from `16.3.0-canary.26` → stable **`16.2.6`**; update lockfile and regenerated `next-env.d.ts`.
- Resolve deploy-target conflict: state **GitHub Pages** as the deployment target in `app/ARCHITECTURE.md` and `app/README.md` (host-agnostic static output), dropping the stale "Cloudflare Pages locked" wording.
- Make explicit that `mkdocs.yaml` is the **permanent** single source of truth for site IA/navigation config; no hard-coded routes/nav in React/TS.

## Verification
- `npm run build` (full static export, ~580 routes) passes on stable Next 16.2.6.
- `npm run lint` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)