### PR TITLE
Sync external docs on repository dispatch

### DIFF
--- a/.github/workflows/app-static-pages.yml
+++ b/.github/workflows/app-static-pages.yml
@@ -21,7 +21,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  sync-external-docs:
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Sync external documentation
+        env:
+          DISPATCH_TYPE: ${{ github.event.action }}
+          SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
+          SOURCE_SHA: ${{ github.event.client_payload.source_sha }}
+        run: |
+          set -euo pipefail
+          case "${DISPATCH_TYPE}" in
+            trigger-document-sync)
+              make sync-external-docs
+              ;;
+            trigger-tutorial-sync)
+              make sync-external-docs
+              ;;
+            *)
+              echo "Unsupported repository_dispatch type: ${DISPATCH_TYPE}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Commit synced documentation
+        env:
+          SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
+          SOURCE_SHA: ${{ github.event.client_payload.source_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs
+          if git diff --cached --quiet; then
+            echo "External documentation is already up to date."
+            exit 0
+          fi
+          if [ -n "${SOURCE_SHA}" ]; then
+            git commit -m "sync external docs from ${SOURCE_REPO}@${SOURCE_SHA}"
+          else
+            git commit -m "sync external docs"
+          fi
+          git push origin HEAD:main
+
   deploy-static-app:
+    if: github.event_name != 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean install
+.PHONY: build clean install sync-external-docs
 
 VENV := .venv
 PYTHON := $(VENV)/bin/python
@@ -31,6 +31,10 @@ nvbit-tutorial:
 
 agentsight:
 	git clone https://github.com/eunomia-bpf/agentsight --depth=1
+
+sync-external-docs:
+	$(MAKE) clean
+	$(MAKE) docs/CNAME
 
 docs/CNAME: tutorial cuda-exp cupti-exp nvbit-tutorial bpftime agentsight
 	./rename.sh

--- a/docs/agentsight/agentpprof.md
+++ b/docs/agentsight/agentpprof.md
@@ -1,10 +1,3 @@
----
-date: 2026-06-23
-description: agentpprof turns local Codex and Claude Code sessions into pprof-compatible semantic profiles, folded stacks, SVG flamegraphs, and redacted JSON for analyzing AI coding-agent work.
-keywords: AgentSight, agentpprof, AI agent profiling, AI agent flamegraph, pprof, Codex, Claude Code, observability
-author: eunomia-bpf community
----
-
 # agentpprof: pprof-style profiles for AI coding-agent sessions
 
 An AI coding agent can finish a task and leave behind hundreds of events: user
@@ -105,10 +98,9 @@ agentpprof -o files.svg     --view files    # standalone SVG flamegraph
 agentpprof -o network.json  --view network  # redacted JSON summary and stacks
 ```
 
-The checked-in gallery under the AgentSight repository's `docs/flamegraph/`
-directory was generated from real local AgentSight development sessions, not toy
-transcripts. It includes task, system, token, file, and network flamegraphs. A
-task flamegraph looks like this:
+The checked-in gallery under `docs/flamegraph/` was generated from real local
+AgentSight development sessions, not toy transcripts. It includes task, system,
+token, file, and network flamegraphs. A task flamegraph looks like this:
 
 ![agentpprof task flamegraph](https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph/examples/tasks.svg)
 

--- a/docs/agentsight/agentpprof.md
+++ b/docs/agentsight/agentpprof.md
@@ -1,0 +1,313 @@
+---
+date: 2026-06-23
+description: agentpprof turns local Codex and Claude Code sessions into pprof-compatible semantic profiles, folded stacks, SVG flamegraphs, and redacted JSON for analyzing AI coding-agent work.
+keywords: AgentSight, agentpprof, AI agent profiling, AI agent flamegraph, pprof, Codex, Claude Code, observability
+author: eunomia-bpf community
+---
+
+# agentpprof: pprof-style profiles for AI coding-agent sessions
+
+An AI coding agent can finish a task and leave behind hundreds of events: user
+prompts, model calls, shell commands, file edits, package downloads, test runs,
+and retries. Traditional logs can answer "what happened next?" if you read them
+line by line. They are much weaker at answering the question developers usually
+ask after a long run: where did the agent spend its work, what repeated, and
+which prompts caused the expensive or risky system effects?
+
+`agentpprof` is a profiling tool for that question. It reads local Codex and
+Claude Code session history through the shared `agent-session` parser, projects
+the session into semantic stacks, and writes outputs that existing profiling
+tools already understand: Go pprof protobuf, folded stacks, SVG flamegraphs, and
+redacted JSON.
+
+The profiles are not CPU profiles. A wide frame does not mean the agent used
+more CPU. Width means the chosen view's weight: activity count, system-effect
+count, file-effect count, network-effect count, or model token count. The goal
+is to make an agent session browsable like a performance profile, without
+pretending that every question has the same metric.
+
+## Why a profiler instead of another trace view?
+
+Trace views are good when you already know where to look. If a single command
+failed at 14:03, a timeline can show the surrounding tool calls and model
+messages. Long agent sessions have a different failure mode: there is too much
+trace. The user wants to know whether the agent kept re-reading the same files,
+spent most of its model budget on review, retried tests in a loop, or contacted
+external services during one prompt.
+
+A flamegraph is useful here because it compresses repeated work. The stack says
+which context the event belongs to, and the width says how much weight that
+context accumulated. When many prompts share the same pattern, they merge. When
+one prompt creates a distinct system effect, it remains visible as a branch.
+
+`agentpprof` keeps this model explicit. It does not try to produce one universal
+"agent flamegraph". Instead, it exposes several projections over the same
+session:
+
+| View | Width means | Primary question |
+| --- | ---: | --- |
+| `tasks` | LLM-call plus tool-event count | What semantic work dominated the session? |
+| `system` | tool and system-effect count | Which tool, process, effect, path, or domain chains were heavy? |
+| `tools` | same projection as `system` | Compatibility alias for older examples. |
+| `tokens` | reported or bounded-estimated tokens | Which semantic regions consumed model budget? |
+| `files` | file/path effect count | Which prompts touched which parts of the repository? |
+| `network` | network/domain effect count | Which prompts contacted which domains, and through which process chain? |
+
+Start with `tasks`. When a wide prompt or session looks suspicious, switch to
+`system`, `files`, `network`, or `tokens` to explain the cause.
+
+## Install
+
+After release, install from crates.io:
+
+```bash
+cargo install agentpprof
+```
+
+You can also download the `agentpprof` binary from the AgentSight GitHub
+release artifacts. The AgentSight release pipeline builds and smoke-tests both
+`agentsight` and `agentpprof` from the same release tag.
+
+From a source checkout:
+
+```bash
+cargo run --manifest-path agentpprof/Cargo.toml -- --version
+cargo run --manifest-path agentpprof/Cargo.toml -- -o agent.pb.gz
+```
+
+## First profile
+
+Generate a task profile for the current repository:
+
+```bash
+agentpprof --project-root . --view tasks -o tasks.pb.gz
+```
+
+Open the pprof profile with standard Go tooling:
+
+```bash
+go tool pprof -top tasks.pb.gz
+go tool pprof -http=:0 tasks.pb.gz
+```
+
+Generate a browser-openable flamegraph instead:
+
+```bash
+agentpprof --project-root . --view tasks -o tasks.svg
+```
+
+The extension chooses the output format when `--format` is not provided:
+
+```bash
+agentpprof -o tasks.pb.gz   --view tasks    # pprof protobuf, gzip-compressed
+agentpprof -o system.folded --view system   # folded stack text
+agentpprof -o files.svg     --view files    # standalone SVG flamegraph
+agentpprof -o network.json  --view network  # redacted JSON summary and stacks
+```
+
+The checked-in gallery under the AgentSight repository's `docs/flamegraph/`
+directory was generated from real local AgentSight development sessions, not toy
+transcripts. It includes task, system, token, file, and network flamegraphs. A
+task flamegraph looks like this:
+
+![agentpprof task flamegraph](https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph/examples/tasks.svg)
+
+## What data does it read?
+
+`agentpprof` reads agent-native local session history. Today that means Codex
+and Claude Code JSONL session files parsed through the `agent-session` crate.
+It does not load eBPF probes, require root, or record a live process. It is the
+offline profiling side of AgentSight: use `agentsight` to observe live system
+behavior, and use `agentpprof` to aggregate already-recorded agent sessions.
+
+By default, it scans recent local sessions that match `--project-root`:
+
+```bash
+agentpprof --project-root /path/to/repo --view tasks -o tasks.svg
+```
+
+For repeatable analysis, pass explicit session files:
+
+```bash
+agentpprof \
+  --project-root /path/to/repo \
+  --session-file ~/.codex/sessions/.../session.jsonl \
+  --session-file ~/.claude/projects/.../session.jsonl \
+  --view system \
+  -o system.folded
+```
+
+Useful selectors:
+
+```bash
+agentpprof -o tasks.svg --agent codex
+agentpprof -o tasks.svg --session-id 019ec5
+agentpprof -o tasks.svg --session-tag debug
+agentpprof -o tasks.svg --prompt-tag review
+```
+
+## The stack model
+
+A stack is a projection, not a literal call stack. The lower frames provide
+context, and the upper frames describe the activity being counted. The exact
+shape depends on the view.
+
+The `tasks` view emphasizes semantic work:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:debug;kind:tool;call:tool/shell;effect:test;status:ok 1
+project:agentsight;agent:codex;session:release;prompt:debug;kind:llm;call:llm/review;model:gpt-5 1
+```
+
+The `system` view pushes below tool calls into process and effect structure:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:debug;call:tool/shell;process:bash;process:cargo;effect:test;path:collector;status:ok 1
+project:agentsight;agent:codex;session:release;prompt:debug;call:tool/shell;process:bash;process:git;effect:repo;path:repo;status:ok 1
+```
+
+The `files` view makes repository areas the main branch:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:docs;path:docs/flamegraph;effect:write;status:ok 1
+```
+
+The `network` view centers domains:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:publish;domain:crates.io;process:cargo;status:ok 1
+```
+
+The `tokens` view uses model budget as the width:
+
+```text
+project:agentsight;agent:codex;model:gpt-5;kind:input;session:release;prompt:debug;call:llm/review 4200
+project:agentsight;agent:codex;model:gpt-5;kind:output;session:release;prompt:debug;call:llm/review 980
+```
+
+This separation matters. A file flamegraph should not use token width, and a
+token flamegraph should not hide the model dimension. The right projection
+depends on the user's question.
+
+## Tagging
+
+The most important frames are `session:*`, `prompt:*`, and `call:llm/*`. Raw
+prompts are too long and too private to use as flamegraph labels, so
+`agentpprof` maps them to short one-word tags.
+
+The default tagger is deterministic and local:
+
+```bash
+agentpprof -o tasks.svg --tagger regex
+```
+
+It uses built-in keyword rules and produces stable tags such as `debug`,
+`review`, `test`, `docs`, `release`, `profile`, or `design`. This is the safest
+default for CI, public artifacts, and reproducible analysis.
+
+Project-specific rules can be layered on top:
+
+```bash
+agentpprof -o tasks.svg \
+  --tagger regex \
+  --tag-rule prompt:review='(?i)review|diff|regression' \
+  --tag-rule prompt:test='(?i)cargo test|pytest|unit test' \
+  --tag-rule session:release='(?i)release|publish|crates\\.io'
+```
+
+Rules use:
+
+```text
+KIND:TAG=REGEX
+```
+
+`KIND` may be `session`, `prompt`, `llm`, or `all`. `TAG` must be one lowercase
+English word between 3 and 12 letters. Rules are evaluated in command-line
+order before the built-in rules.
+
+For model-produced tags, run a llama.cpp-compatible server and use the LLM
+tagger:
+
+```bash
+llama-server -m /path/to/model.gguf --port 8080
+agentpprof -o tasks.svg --tagger llm --llama-url http://127.0.0.1:8080
+```
+
+LLM tags are cached under the user cache directory by default, for example
+`$XDG_CACHE_HOME/agentpprof/tags.json`. Use `--cache` to choose another file,
+or `--no-cache` to avoid saving new tags.
+
+The model is not asked to validate whether the agent was correct. It only names
+short semantic regions. Correctness and safety still require separate evidence.
+
+## Privacy and redaction
+
+Local agent histories can contain prompts, tool outputs, paths, commands,
+repository names, and model responses. `agentpprof` is conservative by default:
+
+- SVG, pprof, and folded outputs contain stack labels and weights, not raw
+  prompts or model responses.
+- JSON output redacts previews unless `--include-previews` is set.
+- Absolute paths outside the selected project root are grouped into stable
+  buckets such as `external/home`, `external/tmp`, `external/codex`, and
+  `external/claude`.
+- Private-looking domains are collapsed instead of exposing user-specific
+  hostnames.
+
+Use explicit `--session-file` inputs when you need repeatability. Use
+`--include-previews` only for private debugging or already-sanitized sessions.
+
+## Using agentpprof with AgentSight
+
+`agentpprof` and `agentsight` answer related but different questions.
+
+`agentsight` is the live and recorded system observer. It uses eBPF, TLS traffic
+capture, process monitoring, and materialized views to show what an agent does
+at runtime. Use it when you need live visibility, process trees, file effects,
+network destinations, or saved SQLite traces.
+
+`agentpprof` is the semantic profiler for local agent history. Use it when you
+want aggregation: repeated prompts, wide system-effect branches, token-heavy
+semantic regions, or folded stacks that can be compared across sessions.
+
+A practical workflow is:
+
+```bash
+sudo agentsight record -- claude
+agentsight report
+agentpprof --project-root . --view tasks -o tasks.svg
+agentpprof --project-root . --view system -o system.svg
+agentpprof --project-root . --view tokens -o tokens.pb.gz
+```
+
+## CI and release contract
+
+`agentpprof` is part of the AgentSight release surface. The CI pipeline should:
+
+- build, clippy-check, and test `agentpprof` on pull requests;
+- assign `agentpprof` the same release version as `agentsight`;
+- update its `agent-session` dependency to the newly published
+  `agent-session` version;
+- build the release binary and upload it to the GitHub Release;
+- publish the `agentpprof` crate to crates.io;
+- smoke-test `agentpprof --version`, `agentpprof --help`, and
+  `cargo install agentpprof --version <release>`.
+
+This keeps the command usable as an independent tool, not only as an
+AgentSight repository artifact.
+
+## Troubleshooting
+
+If no sessions are found, pass explicit `--session-file` paths and confirm the
+session `cwd` matches `--project-root`.
+
+If labels are too generic, add a few `--tag-rule` entries for the project. Do
+not try to make every prompt unique. Good tags preserve useful semantic
+diversity while merging meaningless long-tail fragments.
+
+If pprof output opens but looks unfamiliar, remember that the sample unit is
+not CPU time. Use `go tool pprof -top` to inspect the widest semantic frames,
+then generate SVG or folded output when you need the full stack shape.
+
+If a public artifact might contain sensitive information, prefer SVG, folded,
+or pprof output, and do not pass `--include-previews`.

--- a/docs/agentsight/agents.md
+++ b/docs/agentsight/agents.md
@@ -4,14 +4,6 @@ AgentSight works with any process that makes TLS-encrypted API calls. This page 
 
 For general usage and the `record` command, see the [README](https://github.com/eunomia-bpf/agentsight#quick-start).
 
-## Agent Discovery
-
-```bash
-./agentsight discover
-```
-
-Lists agents installed on the local machine. Built-in SQL adapters cover Anthropic, Claude Code, Gemini CLI, and OpenClaw sessions. Use `--no-adapters` to disable, or `agentsight db adapters list --json` to inspect.
-
 ## Zero-Config: `record`
 
 `record` is the simplest way to trace an agent. Put the command you want to run
@@ -42,7 +34,7 @@ What `record -- <command>` does automatically:
 > not a different one on root's `$PATH`.
 
 Useful flags: `--binary-path <path>` to override auto-discovery, `--no-server`
-to disable the web UI, `--server-port <port>`, `-o <log-file>`.
+to disable the web UI, and `--server-port <port>`.
 
 ## Claude Code
 
@@ -59,8 +51,8 @@ sudo ./agentsight record -c claude --binary-path "$CLAUDE_BIN"
 # Open http://127.0.0.1:7395 to view timeline
 
 # Advanced: full trace with custom filters
-sudo ./agentsight debug trace --ssl true --process true --comm claude \
-  --binary-path "$CLAUDE_BIN" --server true --server-port 8080
+sudo ./agentsight debug trace --comm claude \
+  --binary-path "$CLAUDE_BIN" --server --server-port 8080
 ```
 
 This captures:
@@ -79,8 +71,8 @@ This captures:
 # Monitor aider, open-interpreter, or any Python-based AI tool
 sudo ./agentsight record -c "python"
 
-# Custom port and log file
-sudo ./agentsight record -c "python" --server-port 8080 --log-file /tmp/agent.log
+# Custom web UI port
+sudo ./agentsight record -c "python" --server-port 8080
 ```
 
 ## Node.js AI Tools (Gemini CLI, etc.)
@@ -122,7 +114,7 @@ process tree and attaches sslsniff to the right binary automatically:
 # OpenClaw is a Node.js agent that runs in a container — works out of the box
 sudo ./agentsight record -c node --binary-path docker://openclaw
 
-# Accepts a container name or ID; supported by record / trace / ssl
+# Accepts a container name or ID; supported by record, debug trace, and debug ssl
 sudo ./agentsight debug trace --binary-path docker://openclaw --server
 ```
 
@@ -166,10 +158,10 @@ it into the Rust collector.
 
 ```bash
 # Combined SSL and process monitoring with web interface
-sudo ./agentsight debug trace --ssl true --process true --server true
+sudo ./agentsight debug trace --server
 
-# Custom port and log file
-sudo ./agentsight record -c "python" --server-port 8080 --log-file /tmp/agent.log
+# Custom web UI port
+sudo ./agentsight record -c "python" --server-port 8080
 ```
 
 ## Direct eBPF Program Usage

--- a/docs/agentsight/docker.md
+++ b/docs/agentsight/docker.md
@@ -19,9 +19,8 @@ For local day-to-day use, the release binary plus `sudo agentsight top` or
 ```bash
 docker run --privileged --pid=host --network=host \
   -v /sys:/sys:ro -v /usr:/usr:ro -v /lib:/lib:ro \
-  -v "$(pwd)/logs:/logs" \
   ghcr.io/eunomia-bpf/agentsight:latest \
-  record --comm python --log-file /logs/record.log
+  record --comm python
 ```
 
 ## Monitor Claude Code
@@ -32,9 +31,8 @@ Claude Code uses a user-local binary. Mount the Claude install directory and pas
 docker run --privileged --pid=host --network=host \
   -v /sys:/sys:ro -v /usr:/usr:ro -v /lib:/lib:ro \
   -v "$HOME/.local/share/claude:/claude:ro" \
-  -v "$(pwd)/logs:/logs" \
   ghcr.io/eunomia-bpf/agentsight:latest \
-  record --comm claude --binary-path /claude/versions/2.1.39 --log-file /logs/record.log
+  record --comm claude --binary-path /claude/versions/2.1.39
 ```
 
 Adjust `/claude/versions/2.1.39` to the version installed on the host.
@@ -43,4 +41,4 @@ Adjust `/claude/versions/2.1.39` to the version installed on the host.
 
 - A normal unprivileged Docker container cannot load eBPF probes or inspect host processes.
 - Docker's default seccomp profile can block eBPF-related syscalls; `--privileged` avoids that for local testing and CI runners where this is acceptable.
-- Captured logs can contain prompts, responses, file paths, headers, and network targets. Treat mounted log directories as sensitive.
+- Captured SQLite databases can contain prompts, responses, file paths, headers, and network targets. Treat saved session databases as sensitive.

--- a/docs/agentsight/index.md
+++ b/docs/agentsight/index.md
@@ -1,4 +1,4 @@
-# AgentSight: System-wide AI agent tracing and monitoring with eBPF
+# AgentSight: System-wide AI agent profiling and monitoring with eBPF
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/eunomia-bpf/agentsight/actions/workflows/ci.yml/badge.svg)](https://github.com/eunomia-bpf/agentsight/actions/workflows/ci.yml)
@@ -12,7 +12,7 @@ to your machine, and connect those actions back to the prompts, model calls, and
 tool decisions that triggered them.
 
 Run `agentsight` around Claude Code, Codex, Gemini CLI,
-OpenCode, OpenClaw, or any command. AgentSight records a local trace of:
+OpenCode, OpenClaw, or any command. AgentSight records:
 
 - processes and child processes, shell commands, cwd, argv, exit status, and duration
 - files created, written, truncated, renamed, or deleted
@@ -20,7 +20,7 @@ OpenCode, OpenClaw, or any command. AgentSight records a local trace of:
 - prompts, responses, tool intent, and LLM/model/token
 
 No SDK, no proxy, no vendor integration. AgentSight observes with eBPF and TLS traffic tracing, so it works even when the agent is a
-closed-source CLI. **✨ Zero Instrumentation Required**
+closed-source CLI. **✨ Zero SDK Required**
 
 ## Quick Start
 
@@ -34,11 +34,6 @@ sudo agentsight top
   <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/top-mode-demo.png" alt="AgentSight top live session view" width="1000">
   <p><em>Live sessions ranked by model, session tokens, health, process family, tool calls, file activity, and network activity</em></p>
 </div>
-
-If you downloaded the binary into the current directory, run `sudo ./agentsight top`.
-`top` loads eBPF probes, discovers local agents, and connects system activity to
-agent behavior in real time. See the [Usage](#usage) section for more examples
-and details.
 
 ## 🚀 Why AgentSight?
 
@@ -91,27 +86,61 @@ Build requirements and source build commands live in [docs/build.md](https://git
 
 ### Querying Past Sessions
 
-Every `stat -- <command>` or `record` session is automatically saved to SQLite. Start with the perf-style commands, then use `agentsight db` for structured queries:
+Every `record` session is automatically saved to an `agentsight-*.db` SQLite
+file in the current directory. Start with the live and record commands, then
+use `agentsight report` for structured queries:
 
 ```bash
-agentsight stat                       # counters for the latest saved session
-sudo agentsight top                   # live ranked view of current agent sessions
-agentsight top --db run.db --once     # ranked view of a saved session
-sudo agentsight record -- claude      # record a command
-agentsight report                     # high-level run summary
-agentsight list                       # all recorded sessions
-agentsight prompts --json             # full LLM request/response JSON
-agentsight db token                   # token usage (auto-finds latest session)
-agentsight db audit --json            # process spawns, file opens, API calls
-agentsight db export -o snapshot.json # export for web dashboard
+sudo agentsight top                          # live ranked view of current agent sessions
+agentsight monitor install-service           # install/start the background monitor service
+agentsight top --db run.db --once            # ranked view of a saved session
+sudo agentsight record -- claude             # record a command
+agentsight report                            # high-level run summary (default)
+agentsight report list                       # recorded sessions in this directory
+agentsight report prompts --json             # full LLM request/response JSON
+agentsight report token                      # token usage from latest session in this directory
+agentsight report audit --json               # process spawns, file opens, API calls
+agentsight report serve                      # open the web UI for the latest session in this directory
+agentsight report export -o snapshot.json    # export for web dashboard
+agentsight report --local                    # summarize native Claude/Codex/Gemini sessions
 ```
+
+### Offline Agent pprof Profiles
+
+Use `agentpprof` when you want a no-sudo pprof/folded-stack/SVG summary of
+local Codex or Claude session history:
+
+```bash
+cargo run --manifest-path agentpprof/Cargo.toml -- \
+  --project-root . \
+  --view tasks \
+  -o agent.pb.gz
+
+go tool pprof -top agent.pb.gz
+```
+
+The `tasks` view is the best first flamegraph: it aggregates real local
+Codex/Claude AgentSight development sessions by project, agent, session tag,
+prompt tag, and tool/LLM activity.
+
+<div align="center">
+  <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph/examples/tasks.svg" alt="agentpprof task flamegraph from real AgentSight development sessions" width="1000">
+  <p><em>Offline task profile generated from real local AgentSight coding-agent sessions</em></p>
+</div>
+
+See [agentpprof/README.md](agentpprof/README.md) for CLI details and
+[docs/flamegraph](docs/flamegraph/README.md) for flamegraph examples, view
+selection, and deterministic tagging rules.
 
 ### Web Interface
 
 During a session, visit [http://127.0.0.1:7395](http://127.0.0.1:7395) for live traffic, process trees, and metrics:
 - **Timeline View**: http://127.0.0.1:7395/timeline
 - **Process Tree**: http://127.0.0.1:7395/tree
-- **Raw Logs**: http://127.0.0.1:7395/logs
+- **Event Log**: http://127.0.0.1:7395/logs
+- **Metrics View**: http://127.0.0.1:7395/metrics
+
+For a saved SQLite session, run `agentsight report serve --db run.db` and open the same routes.
 
 <div align="center">
   <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/demo-tree.png" alt="AgentSight Demo - Process Tree Visualization" width="800">
@@ -146,8 +175,6 @@ During a session, visit [http://127.0.0.1:7395](http://127.0.0.1:7395) for live 
 | Docker containers (OpenClaw, …) | `sudo ./agentsight record -c node --binary-path docker://openclaw` |
 | Any command | `sudo ./agentsight record -- <command>` |
 
-Discover what's installed locally with `./agentsight discover`.
-
 See [docs/agents.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/agents.md) for agent-specific setup, SSL quirks, browser capture, MCP stdio, and advanced flags.
 
 ### OpenTelemetry Export
@@ -166,13 +193,13 @@ collector setup and backend integration.
 ## ❓ Frequently Asked Questions
 
 **Q: What permissions does AgentSight need?**
-A: eBPF probes need root privileges, so AgentSight may prompt for `sudo`. With `record -- <command>` or `stat -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
+A: eBPF probes need root privileges, so AgentSight may prompt for `sudo`. With `record -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
 
 **Q: What's the performance impact?**
 A: Our evaluation reports less than 3% CPU overhead for typical traced agent workloads.
 
 **Q: Where does captured data go?**
-A: `record` and `stat -- <command>` store sessions locally in SQLite by default. Use `agentsight stat`, `agentsight top`, `agentsight report`, `agentsight list`, `agentsight db audit --json`, and `agentsight db token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
+A: `record` stores sessions as `agentsight-*.db` files in the current directory by default, and `report` reads the latest matching file from that directory unless you pass `--db`. `monitor` stores its weekly background DBs under `~/.agentsight/monitor`, and `top` is read-only unless you explicitly pass `--db` to inspect a saved session. Use `agentsight report`, `agentsight report list`, `agentsight report audit --json`, and `agentsight report token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
 
 **Q: Why doesn't AgentSight capture traffic from Claude Code, Node.js, or Gemini CLI?**
 A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for **all** Node.js — both NVM and system installs) into their own binary instead of using system `libssl.so`, so there's nothing for sslsniff to hook by default. AgentSight handles this for you: `record -- <command>` always discovers the binary, and `record -c node` now auto-discovers the Node binary too. For Claude attach mode, pass `--binary-path`. See the "Zero-Config: record" and "Monitoring Node.js AI Tools" sections.

--- a/docs/agentsight/index.zh.md
+++ b/docs/agentsight/index.zh.md
@@ -27,6 +27,19 @@ AgentSight 在你忘记 sudo 时可以自动请求提权，但推荐命令仍然
 `sudo`。`top` 会加载 eBPF probes，也会优先读取 Claude、Codex、Gemini、OpenCode
 和 OpenClaw 的本地 session 日志。
 
+如果希望长期后台观察本机智能体，而不是一直开着终端，可以安装 systemd user
+service：
+
+```bash
+agentsight monitor install-service
+```
+
+当 monitor service 正在运行时，`agentsight top` 会直接读取后台 monitor 已保存的窗口数据，
+不会再启动另一套 live probes。
+后台 monitor 是轻量模式：记录匹配到的本地 agent session，以及 `/proc` 中的 CPU、内存、
+I/O 和文件目标数量。它不会捕获 SSL/API payload 或其它 eBPF 事件；如果需要完整 live
+eBPF capture，仍然使用 `sudo agentsight top` 或 `sudo agentsight record -- <command>`。
+
 ## 为什么选择 AgentSight？
 
 ### 传统可观测性 vs. 系统级监控
@@ -64,7 +77,10 @@ AgentSight 能捕获应用级工具遗漏的关键交互：
 
 #### Cargo 或 Release Binary
 
-本地使用优先安装 CLI，然后运行 `sudo agentsight top`。需要记录某个具体命令或查看历史 session 时，再参考下面的使用示例。
+本地使用优先安装 CLI，然后运行 `sudo agentsight top`。需要记录某个具体命令时运行
+`sudo agentsight record -- <command>`；默认会在当前目录生成 `agentsight-*.db`，
+随后 `agentsight report` 和 `agentsight report list` 也默认查看当前目录里的记录。
+如果要查看 Claude/Codex/Gemini 的原生日志总览，显式运行 `agentsight report --local`。
 
 #### Docker
 
@@ -76,7 +92,7 @@ docker run --privileged --pid=host --network=host \
   -v /sys:/sys:ro -v /usr:/usr:ro -v /lib:/lib:ro \
   -v $(pwd)/logs:/logs \
   ghcr.io/eunomia-bpf/agentsight:latest \
-  record --comm python --log-file /logs/record.log
+  record --comm python
 
 # 监控 Claude Code（挂载 home 目录以访问二进制文件）
 docker run --privileged --pid=host --network=host \
@@ -84,7 +100,7 @@ docker run --privileged --pid=host --network=host \
   -v $HOME/.local/share/claude:/claude:ro \
   -v $(pwd)/logs:/logs \
   ghcr.io/eunomia-bpf/agentsight:latest \
-  record --comm claude --binary-path /claude/versions/2.1.39 --log-file /logs/record.log
+  record --comm claude --binary-path /claude/versions/2.1.39
 ```
 
 #### 从源码构建
@@ -108,10 +124,12 @@ make build
 
 ### Web 界面
 
-`stat -- <command>` 和 `record` 默认启动 Web UI。低层 `debug trace` 需要传入 `--server`：
+`record -- <command>` 默认启动 Web UI。低层 `debug trace` 需要传入 `--server`：
 - **时间线视图**：http://127.0.0.1:7395/timeline
 - **进程树**：http://127.0.0.1:7395/tree
 - **原始日志**：http://127.0.0.1:7395/logs
+
+查看已保存的 SQLite 会话可以运行 `agentsight report serve --db run.db`，然后打开同样的 Web 路由。
 
 <div align="center">
   <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/demo-tree.png" alt="AgentSight 演示 - 进程树可视化" width="800">
@@ -141,8 +159,6 @@ make build
 | Python（aider、open-interpreter 等） | `sudo ./agentsight record -c python` |
 | Docker 容器（OpenClaw 等） | `sudo ./agentsight record -c node --binary-path docker://openclaw` |
 | 任意命令 | `sudo ./agentsight record -- <command>` |
-
-使用 `./agentsight discover` 发现本地已安装的智能体。
 
 详见 [docs/agents.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/agents.md)，了解各智能体的详细设置、SSL 注意事项、浏览器捕获、MCP stdio 和高级选项。
 

--- a/docs/agentsight/otel.md
+++ b/docs/agentsight/otel.md
@@ -92,6 +92,7 @@ Per the GenAI agent/model span conventions:
 |-----------|--------|
 | `gen_ai.operation.name` | `chat` |
 | `gen_ai.provider.name` | derived from the API host (`openai`, `anthropic`, `gcp.gen_ai`, `azure.ai.openai`, …) |
+| `gen_ai.conversation.id` | real conversation/thread/session id from the provider request body when available; never synthesized |
 | `gen_ai.request.model` | request body `model` |
 | `gen_ai.request.max_tokens` / `temperature` / `top_p` | request body |
 | `gen_ai.response.model` / `gen_ai.response.id` | response body |
@@ -122,7 +123,8 @@ JSON still emit a span with the request attributes and HTTP status.
 
 - OTLP/**HTTP** only (the standard collector receiver). For a remote collector
   behind TLS, run a local collector and let it forward upstream.
-- One span per request/response pair (`chat`); multi-agent workflow spans
-  (`invoke_agent`, `execute_tool`) are not yet emitted — see issue #47.
+- Tool/workflow spans (`execute_tool`, `invoke_agent`, `invoke_workflow`,
+  `plan`) are not emitted yet; native transcript tools may be only aggregated
+  requests, and AgentSight-specific provenance stays in AgentSight rows.
 - The GenAI conventions are still experimental; attribute names track the
   current spec.

--- a/docs/agentsight/quickstart.md
+++ b/docs/agentsight/quickstart.md
@@ -55,6 +55,9 @@ sudo ./collector/target/release/agentsight top
 # Launch and record a command
 sudo ./collector/target/release/agentsight record -- claude
 
+# Inspect the latest saved run
+./collector/target/release/agentsight report
+
 # Attach to an already-running process family
 sudo ./collector/target/release/agentsight record -c claude
 
@@ -64,3 +67,12 @@ sudo ./collector/target/release/agentsight debug trace --server -c claude
 # Raw SSL debug capture with HTTP parsing
 sudo ./collector/target/release/agentsight debug ssl --http-parser
 ```
+
+Use `top` for the normal live view. Use `record` when you want a durable
+agent-run artifact; it starts SSL, process, system, and web-view collection with
+AgentSight's default filters, and saves a local SQLite session for `report`,
+`top --db`, `report prompts`, and other report queries.
+
+Use `debug trace` only when you need low-level control over capture sources or
+filters. It is the advanced replacement for a raw trace command, not the normal
+record/report workflow.

--- a/docs/agentsight/quickstart.zh.md
+++ b/docs/agentsight/quickstart.zh.md
@@ -55,6 +55,9 @@ sudo ./collector/target/release/agentsight top
 # 启动并记录一个命令
 sudo ./collector/target/release/agentsight record -- claude
 
+# 查看最近保存的运行
+./collector/target/release/agentsight report
+
 # 附加到已经运行的进程族
 sudo ./collector/target/release/agentsight record -c claude
 
@@ -65,24 +68,36 @@ sudo ./collector/target/release/agentsight debug trace --server -c claude
 sudo ./collector/target/release/agentsight debug ssl --http-parser
 ```
 
-## record 与 debug trace 子命令对比
+## top、record 与 debug trace
 
-agentsight 提供 `record` 和 `debug trace` 两个主要追踪入口，它们共用底层执行逻辑，但面向不同的使用场景。
+日常使用先从 `top` 开始；需要保存一次运行用于复盘时使用 `record`；只有在需要
+精细控制采集源和过滤规则时才使用 `debug trace`。
+
+### top — 默认实时视图
+
+`top` 是最直接的入口，用于实时查看本机正在活动的智能体 session。它会发现本地
+智能体进程和 agent-native session 日志，并把系统活动关联到 session。
+
+典型用法：
+
+```sh
+sudo ./agentsight top
+```
 
 ### record — 开箱即用的智能体录制
 
-适用于快速录制 AI 智能体（Claude Code、Python AI 工具等）的行为，无需关心细节配置。
+适用于录制 AI 智能体（Claude Code、Python AI 工具等）的一次运行，生成可复盘的本地 session。
 
 - `record -- <command>` 用于启动并记录一个命令；`record -c/-p` 用于附加到已运行进程
 - **自动开启**：SSL 监控 + 进程监控 + 系统监控 + Web 服务器（端口 7395）
 - **内置过滤规则**：自动过滤掉注册请求（`/v1/rgstr`）、HEAD 请求、空响应体、202 状态码、二进制数据等噪音
-- 默认**静默模式**（不输出到控制台），数据写入 `record.log`
-- 默认开启**日志轮转**
+- 默认**静默模式**（不输出到底层事件流），数据写入实时 view 和本地 SQLite session
 
 典型用法：
 
 ```sh
 sudo ./agentsight record -- claude
+./agentsight report
 ```
 
 ### debug trace — 完全可控的灵活监控
@@ -98,7 +113,7 @@ sudo ./agentsight record -- claude
 典型用法：
 
 ```sh
-sudo ./agentsight debug trace --ssl true --process false --server true --http-filter "request.method=POST"
+sudo ./agentsight debug trace --ssl true --process false --server --http-filter "request.method=POST"
 ```
 
 ### 对比总结
@@ -107,10 +122,10 @@ sudo ./agentsight debug trace --ssl true --process false --server true --http-fi
 |------|--------|-------|
 | 定位 | 一键录制，预设优化 | 灵活定制，精细控制 |
 | 必填参数 | 无；可用 `-- <command>`、`-c <comm>` 或 `-p <pid>` | 无 |
-| Web 服务器 | 始终开启 | 需 `--server true` |
-| 系统监控 | 始终开启 | 需 `--system true` |
+| Web 服务器 | 默认开启，可用 `--no-server` 关闭 | 需 `--server` |
+| 系统监控 | 默认开启 | 需 `--system` |
 | 控制台输出 | 默认关闭 | 默认开启 |
 | 过滤规则 | 内置预设 | 用户自定义 |
-| 日志轮转 | 默认开启 | 需 `--rotate-logs` |
+| 持久化 | 默认 SQLite | 传 `--db` 时写 SQLite |
 
-简单来说：**日常录制用 `record`，深度调试用 `debug trace`**。
+简单来说：**实时查看用 `top`，保存复盘用 `record`，深度调试用 `debug trace`**。

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -451,6 +451,9 @@ extra:
           - label: OpenTelemetry
             label_zh: OpenTelemetry 集成
             href: /agentsight/otel/
+          - label: agentpprof
+            label_zh: agentpprof
+            href: /agentsight/agentpprof/
           - label: Development
             label_zh: 开发指南
             href: /agentsight/development/

--- a/rename.sh
+++ b/rename.sh
@@ -28,6 +28,7 @@ cp agentsight/docs/usage.md docs/agentsight/quickstart.md && \
 cp agentsight/docs/usage.zh-CN.md docs/agentsight/quickstart.zh.md && \
 cp agentsight/docs/build.md docs/agentsight/build.md && \
 cp agentsight/docs/docker.md docs/agentsight/docker.md && \
+cp agentsight/docs/agentpprof.md docs/agentsight/agentpprof.md && \
 cp agentsight/docs/agents.md docs/agentsight/agents.md && \
 cp agentsight/docs/otel.md docs/agentsight/otel.md && \
 cp agentsight/docs/development.md docs/agentsight/development.md && \


### PR DESCRIPTION
## Summary

This updates the external documentation sync path for eunomia.dev.

1. Add a repository_dispatch job that runs full external docs sync for document and tutorial sync events.
2. Add make sync-external-docs as the single full sync entrypoint.
3. Keep AgentSight copying inline in rename.sh and include the agentpprof page.
4. Refresh docs/agentsight from the current AgentSight source docs.

## Validation

1. make -n sync-external-docs
2. npm run generate:content-artifacts from app
3. git diff --check

## Notes

AgentSight repo should trigger trigger-document-sync through repository_dispatch. The eunomia.dev side now always performs a full external docs sync when that event arrives.