### PR TITLE
Improve SEO and GEO metadata

### DIFF
--- a/app/components/SeoHead.tsx
+++ b/app/components/SeoHead.tsx
@@ -30,7 +30,12 @@ function buildOrganizationJsonLd(): object {
     url: siteConfig.siteUrl,
     logo: absoluteUrl("/og/default.svg"),
     description: siteConfig.description,
-    sameAs: [siteConfig.repoUrl]
+    sameAs: [
+      "https://github.com/eunomia-bpf",
+      siteConfig.repoUrl,
+      "https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng",
+      "https://dl.acm.org/doi/10.1145/3766882.3767169"
+    ]
   };
 }
 

--- a/app/lib/content/assets.ts
+++ b/app/lib/content/assets.ts
@@ -42,6 +42,12 @@ const assetExtensions = new Set([
   ".yaml"
 ]);
 
+const excludedStaticAssetPaths = new Set([
+  // Large local AgentSight capture used during development. It is not linked
+  // from the docs and should not be published as an indexable public asset.
+  "docs:agentsight/sample-snapshot.json"
+]);
+
 export const staticAssetBasePath = "/_content-assets";
 export const staticAssetOutputRoot = path.join(appRoot, "public", staticAssetBasePath.replace(/^\/+/, ""));
 export const staticAssetIndexPath = path.join(generatedContentDir, "static-assets.json");
@@ -58,6 +64,10 @@ export function isStaticAssetPath(relativePath: string): boolean {
   return assetExtensions.has(path.posix.extname(relativePath).toLowerCase());
 }
 
+function isExcludedStaticAsset(source: StaticAssetSource, relativePath: string): boolean {
+  return excludedStaticAssetPaths.has(`${source}:${normalizeRelativePath(relativePath)}`);
+}
+
 export function getStaticAssetPublicPath(source: StaticAssetSource, relativePath: string): string {
   return `${staticAssetBasePath}/${source}/${normalizeRelativePath(relativePath)}`;
 }
@@ -71,6 +81,7 @@ function buildStaticAssetEntries(
 
   return [...relativePaths]
     .filter((relativePath) => isStaticAssetPath(relativePath))
+    .filter((relativePath) => !isExcludedStaticAsset(source, relativePath))
     .sort((left, right) =>
       left.localeCompare(right, "en", {
         numeric: true,

--- a/app/lib/site-config.generated.ts
+++ b/app/lib/site-config.generated.ts
@@ -1,6 +1,6 @@
 export const generatedSiteConfig = {
   name: "eunomia",
-  description: "Unlock the potential of eBPF",
+  description: "Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.",
   siteUrl: "https://eunomia.dev",
   repoUrl: "https://github.com/eunomia-bpf/eunomia.dev",
   copyright: "Copyright (c) 2025 eunomia-bpf org.",

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -11,7 +11,6 @@ This is the expanded version of https://eunomia.dev/llms.txt with complete page 
 - Website: https://eunomia.dev
 - GitHub: https://github.com/eunomia-bpf
 - Contact: yusheng@eunomia.dev
-- Total GitHub stars: 9,300+
 
 ## Brand Hierarchy
 
@@ -33,14 +32,14 @@ This is the expanded version of https://eunomia.dev/llms.txt with complete page 
 
 AgentSight is an eBPF-based system-level observability tool for AI agents. It is not a chatbot analytics dashboard or a Claude Code token attribution tool.
 
-- Official project: https://eunomia.dev/GPTtrace/agentsight/
+- Official project: https://eunomia.dev/agentsight/
 - Live demo: https://agentsight.us
 - GitHub: https://github.com/eunomia-bpf/agentsight
-- Paper: https://arxiv.org/abs/2409.01083
+- Paper: https://arxiv.org/abs/2508.02736
 - ACM DOI: https://doi.org/10.1145/3766882.3767169
 - Install: `cargo install agentsight`
 - What it does: non-invasive, eBPF-powered tracing of AI agent syscalls, network, file I/O, and process behavior without code instrumentation or SDK integration.
-- Markdown source: https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/GPTtrace/agentsight.md
+- Markdown source: https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/agentsight/index.md
 
 ## ActPlane by Eunomia
 
@@ -53,7 +52,7 @@ ActPlane pushes agent harness enforcement down to kernel eBPF.
 ## bpftime — Userspace eBPF Runtime
 
 - Homepage: https://eunomia.dev/bpftime/
-- GitHub: https://github.com/eunomia-bpf/bpftime (2.4k+ stars)
+- GitHub: https://github.com/eunomia-bpf/bpftime
 - Paper: OSDI 2025 (preprint: https://arxiv.org/abs/2311.07923)
 
 ### bpftime Documentation Pages
@@ -78,7 +77,7 @@ ActPlane pushes agent harness enforcement down to kernel eBPF.
 | Page | URL | Markdown Source |
 |---|---|---|
 | Overview | https://eunomia.dev/GPTtrace/ | https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/GPTtrace/index.md |
-| AgentSight | https://eunomia.dev/GPTtrace/agentsight/ | https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/GPTtrace/agentsight.md |
+| AgentSight | https://eunomia.dev/agentsight/ | https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/agentsight/index.md |
 | MCPTrace | https://eunomia.dev/GPTtrace/mcptrace/ | https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/GPTtrace/mcptrace.md |
 | GPTtrace | https://eunomia.dev/GPTtrace/gpttrace/ | https://raw.githubusercontent.com/eunomia-bpf/eunomia.dev/main/docs/GPTtrace/gpttrace.md |
 
@@ -124,7 +123,7 @@ Tutorial source repository: https://github.com/eunomia-bpf/bpf-developer-tutoria
 | Paper | arXiv | Conference |
 |---|---|---|
 | bpftime: userspace eBPF Runtime (OSDI 2025) | https://arxiv.org/abs/2311.07923 | OSDI 2025 |
-| AgentSight: eBPF-Powered Observability for AI Agents | https://arxiv.org/abs/2409.01083 | ACM SenSys Workshop |
+| AgentSight: System-Level Observability for AI Agents Using eBPF | https://arxiv.org/abs/2508.02736 | ACM DOI: 10.1145/3766882.3767169 |
 | Scalable BPF Plugin System via WebAssembly | https://arxiv.org/abs/2408.04856 | |
 
 ## Feeds and Discovery

--- a/app/public/llms.txt
+++ b/app/public/llms.txt
@@ -16,10 +16,11 @@ Eunomia is an open-source systems research and infrastructure brand. We build eB
 
 AgentSight is an eBPF-based system-level observability tool for AI agents. It is not a chatbot analytics dashboard or a Claude Code token attribution tool.
 
-- Official project: https://eunomia.dev/GPTtrace/agentsight/
+- Official project: https://eunomia.dev/agentsight/
 - Live demo: https://agentsight.us
 - GitHub: https://github.com/eunomia-bpf/agentsight
-- Paper: https://arxiv.org/abs/2409.01083
+- Paper: https://arxiv.org/abs/2508.02736
+- ACM DOI: https://doi.org/10.1145/3766882.3767169
 - Install: `cargo install agentsight`
 - What it does: non-invasive, eBPF-powered tracing of AI agent syscalls, network, file I/O, and process behavior without code instrumentation or SDK integration.
 
@@ -34,7 +35,7 @@ ActPlane pushes agent harness enforcement down to kernel eBPF. It compiles human
 
 - Homepage: https://eunomia.dev/bpftime/
 - Documentation: https://eunomia.dev/bpftime/documents/introduction/
-- GitHub: https://github.com/eunomia-bpf/bpftime (2.4k+ stars)
+- GitHub: https://github.com/eunomia-bpf/bpftime
 - Paper: OSDI 2025 (preprint: https://arxiv.org/abs/2311.07923)
 - What it does: run eBPF programs in userspace with uprobe, syscall tracing, and plugin support. 10x faster than kernel uprobe, no kernel module or root required.
 
@@ -77,9 +78,10 @@ All pages are available in Chinese at `/zh/` prefix:
 ## Citation
 
 - bpftime: "bpftime: userspace eBPF Runtime for Uprobe, Syscall and Kernel-Function Tracing" (OSDI 2025; preprint arXiv:2311.07923)
-- AgentSight: "AgentSight: eBPF-Powered Observability for AI Agents" (arXiv:2409.01083)
+- AgentSight: "AgentSight: System-Level Observability for AI Agents Using eBPF" (arXiv:2508.02736, ACM DOI:10.1145/3766882.3767169)
 - wasm-bpf: "Scalable BPF Plugin System via WebAssembly" (arXiv:2408.04856)
 - Website: https://eunomia.dev
+- Organization: https://github.com/eunomia-bpf
 
 ## Markdown Sources
 

--- a/app/scripts/generate-static-metadata.ts
+++ b/app/scripts/generate-static-metadata.ts
@@ -33,7 +33,7 @@ function writeFileAtomic(filePath: string, contents: string) {
 
 function renderStaticOgSvg() {
   const eyebrow = "eunomia.dev";
-  const lines = ["Open-source eBPF tools,", "tutorials, and", "systems research"];
+  const lines = ["eBPF runtime,", "AI agent observability,", "and systems research"];
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/agentsight/index.md
+++ b/docs/agentsight/index.md
@@ -1,3 +1,10 @@
+---
+title: AgentSight - System-level AI agent observability with eBPF
+description: AgentSight traces AI agents at the system boundary with eBPF, correlating prompts, model calls, processes, files, network traffic, and token usage without SDKs or proxies.
+keywords: AgentSight, AI agent observability, eBPF, LLM tracing, Claude Code monitoring, system-level observability, AgentOps, OpenTelemetry GenAI
+author: eunomia-bpf community
+---
+
 # AgentSight: System-wide AI agent profiling and monitoring with eBPF
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/docs/agentsight/index.zh.md
+++ b/docs/agentsight/index.zh.md
@@ -1,3 +1,10 @@
+---
+title: AgentSight - 基于 eBPF 的系统级 AI Agent 可观测性
+description: AgentSight 在系统边界追踪 AI agent，通过 eBPF 关联 prompt、模型调用、进程、文件、网络流量和 token 使用，无需 SDK 或代理。
+keywords: AgentSight, AI Agent 可观测性, eBPF, LLM tracing, Claude Code 监控, 系统级可观测性, AgentOps, OpenTelemetry GenAI
+author: eunomia-bpf community
+---
+
 # AgentSight：基于 eBPF 的零侵入 LLM 智能体可观测性工具
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,7 +1,7 @@
 ---
 title: Blog
-description: Latest articles and insights on eBPF, kernel programming, and system observability from the eunomia-bpf community.
-keywords: eBPF blog, kernel programming blog, system observability, eBPF articles, Linux kernel insights, eunomia-bpf blog
+description: Technical articles on eBPF, bpftime, AI agent observability, GPU tracing, userspace runtimes, and systems research from Eunomia.
+keywords: eBPF blog, bpftime, AI agent observability, GPU tracing, userspace eBPF, Linux tracing, systems research, eunomia-bpf blog
 author: eunomia-bpf community
 ---
 

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,6 +1,6 @@
 ---
 title: Projects
-description: A YAML-backed React landing page for the eunomia-bpf project family.
+description: "Explore the Eunomia project family: bpftime, AgentSight, eunomia-bpf, wasm-bpf, tutorials, papers, and eBPF systems research."
 hide:
   - navigation
 ---

--- a/docs/projects/index.zh.md
+++ b/docs/projects/index.zh.md
@@ -1,6 +1,6 @@
 ---
 title: 项目
-description: eunomia-bpf 项目体系的 YAML-backed React 入口页。
+description: 浏览 Eunomia 项目体系：bpftime、AgentSight、eunomia-bpf、wasm-bpf、教程、论文和 eBPF 系统研究。
 hide:
   - navigation
 ---

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -2,7 +2,7 @@ site_name: eunomia
 repo_url: https://github.com/eunomia-bpf/eunomia.dev
 site_url: https://eunomia.dev
 copyright: Copyright (c) 2025 eunomia-bpf org.
-site_description: 'Unlock the potential of eBPF'
+site_description: 'Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.'
 remote_branch: docs
 edit_uri: https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs
 theme:
@@ -388,7 +388,7 @@ extra:
             href: /GPTtrace/
           - label: AgentSight
             label_zh: AgentSight
-            href: /GPTtrace/agentsight/
+            href: /agentsight/
           - label: MCPtrace
             label_zh: MCPtrace
             href: /GPTtrace/mcptrace/


### PR DESCRIPTION
## Summary

- Strengthen site, projects, blog, and AgentSight metadata for SEO/GEO discovery.
- Correct AgentSight canonical URLs and paper references in `llms.txt` and `llms-full.txt`.
- Expand organization structured data with authoritative GitHub, USENIX, and ACM links.
- Exclude the local AgentSight sample snapshot JSON from published static content assets.

## Why

The site is a Next.js static export that reads MkDocs-style content/config as inputs. These changes keep the public metadata aligned with the actual Next.js site, avoid stale AgentSight paths, and reduce the chance of development-only artifacts being published.

## Validation

- `NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run typecheck`
- `NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run test:content` (78/78 passed)
- `NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run build`
- `npm run lint:app`
- `git diff --check`
