### PR TITLE
[codex] Retire tutorial summary sitemap paths

### DIFF
--- a/test/scripts/sitemap-parity.mjs
+++ b/test/scripts/sitemap-parity.mjs
@@ -7,7 +7,12 @@ import {
 
 const failures = [];
 const datedBlogRoutePattern = /^\/(?:zh\/)?blog\/\d{4}\/\d{2}\/\d{2}\/[^/]+\/$/;
-const retiredLegacySitemapPaths = new Set(["/GPTtrace/agentsight/", "/zh/GPTtrace/agentsight/"]);
+const retiredLegacySitemapPaths = new Set([
+  "/GPTtrace/agentsight/",
+  "/zh/GPTtrace/agentsight/",
+  "/tutorials/SUMMARY/",
+  "/zh/tutorials/SUMMARY/"
+]);
 const expectedAppOnlyPaths = new Set([
   "/about/",
   "/products/",


### PR DESCRIPTION
## Summary

- Mark `/tutorials/SUMMARY/` and `/zh/tutorials/SUMMARY/` as retired legacy sitemap paths after removing `docs/tutorials/SUMMARY*.md`.
- This fixes the main deployment failure in `audit:parity` after PR #102 intentionally removed those generated tutorial summary pages.

## Validation

- `npm run verify`

## Review

- Claude Code read-only review: no blocking issues.