### PR TITLE
Remove ActPlane docs from Products

### DIFF
--- a/app/components/ProductPages.tsx
+++ b/app/components/ProductPages.tsx
@@ -453,7 +453,7 @@ export function ProductsLandingPage({ locale, links, projects }: ProductPageProp
             title="AI Agent Observability & Enforcement"
             description={copy.agent}
             href={linkByKey.get("agent-infra")}
-            links={[linkByKey.get("agent-infra"), linkByKey.get("actplane-docs")]}
+            links={[linkByKey.get("agent-infra")]}
             visualLabel="agent observe + enforce"
             visualLines={["observe.agent()", "enforce.policy()", "audit.runtime()"]}
           />
@@ -846,7 +846,7 @@ export function AgentRuntimeInfrastructurePage({ locale, links, projects }: Prod
               ? "OS-level harness，在 syscall、exec、file 和 network 边界用系统级策略约束 agent 行为，并提供应用层日志之外的执行证据。"
               : "An OS-level harness that shapes agent behavior with system-boundary policy across syscall, exec, file, and network — plus execution evidence beyond application logs."}
           </p>
-          <ActionRow links={[linkByKey.get("actplane-docs"), linkByKey.get("actplane-github")]} />
+          <ActionRow links={[linkByKey.get("actplane-github")]} />
         </article>
       </div>
 

--- a/app/tests/content.test.ts
+++ b/app/tests/content.test.ts
@@ -182,7 +182,7 @@ test("primary nav children and section sidebars are sourced from mkdocs config",
 
   assert.deepEqual(
     navChildren.get("products")?.map((item) => item.href),
-    ["/bpftime/", "/products/agent-runtime-infrastructure/", "/actplane/", "/products/services/"]
+    ["/bpftime/", "/products/agent-runtime-infrastructure/", "/products/services/"]
   );
   assert.deepEqual(
     navChildren.get("tutorials")?.map((item) => item.href),
@@ -277,7 +277,6 @@ test("configured section landing copy is sourced from mkdocs config", async () =
       "mailto:yusheng@eunomia.dev",
       "https://github.com/eunomia-bpf/bpftime",
       "/products/agent-runtime-infrastructure/",
-      "/actplane/",
       "/products/services/"
     ]
   );
@@ -287,7 +286,7 @@ test("configured section landing copy is sourced from mkdocs config", async () =
   assert.equal(bpftime?.reactPage, "bpftime-product");
   assert.equal(bpftime?.reactLinks?.find((link) => link.key === "bpftime-docs")?.href, "/bpftime/documents/introduction/");
   assert.equal(agentInfra?.reactPage, "agent-runtime-infrastructure");
-  assert.equal(agentInfra?.reactLinks?.find((link) => link.key === "actplane-docs")?.href, "/actplane/");
+  assert.equal(agentInfra?.reactLinks?.find((link) => link.key === "actplane-docs"), undefined);
   assert.equal(services?.reactPage, "services");
   assert.equal(about?.reactPage, "about");
   assert.equal(about?.reactLinks?.find((link) => link.key === "cuda-tutorial")?.href, "/others/cuda-tutorial/");
@@ -511,7 +510,7 @@ test("primary nav follows the configured external site order", () => {
   );
   assert.deepEqual(
     getPrimaryNav("en").find((item) => item.href === "/products/")?.children?.map((item) => item.href),
-    ["/bpftime/", "/products/agent-runtime-infrastructure/", "/actplane/", "/products/services/"]
+    ["/bpftime/", "/products/agent-runtime-infrastructure/", "/products/services/"]
   );
   assert.deepEqual(
     getPrimaryNav("en").find((item) => item.href === "/tutorials/")?.children?.map((item) => item.href),

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -347,9 +347,6 @@ extra:
       - label: AI Agent Observability & Enforcement
         label_zh: AI Agent 可观测与执行控制
         href: /products/agent-runtime-infrastructure/
-      - label: ActPlane
-        label_zh: ActPlane
-        href: /actplane/
       - label: Services / Enterprise Support
         label_zh: 服务 / 企业支持
         href: /products/services/
@@ -917,10 +914,6 @@ extra:
           label_zh: 了解 AI Agent 可观测与执行控制
           href: /products/agent-runtime-infrastructure/
           variant: primary
-        - key: actplane-docs
-          label: ActPlane docs
-          label_zh: ActPlane 文档
-          href: /actplane/
         - key: services
           label: View services
           label_zh: 查看服务
@@ -951,10 +944,6 @@ extra:
           label: GitHub
           label_zh: GitHub
           href: https://github.com/eunomia-bpf/agentsight
-        - key: actplane-docs
-          label: ActPlane docs
-          label_zh: ActPlane 文档
-          href: /actplane/
         - key: actplane-github
           label: GitHub
           label_zh: GitHub


### PR DESCRIPTION
## Summary
- remove the ActPlane docs entry from the Products dropdown configuration
- remove ActPlane docs CTAs from the Products landing page and Agent Runtime Infrastructure page
- keep ActPlane documentation and Projects entries unchanged

## Validation
- `cd app && npm run test:content` passed (79/79)
- `cd app && npm run verify` passed, including production static export, HTTP audit, sitemap parity, browser smoke, link crawl, and runtime audit

## Independent review
- Claude CLI review: no blocking findings
- Codex subagent review: no blocking findings
