### PR TITLE
Update site operator to Eunomia Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 eunomia-bpf
+Copyright (c) 2023 Eunomia Labs, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/components/Credibility.tsx
+++ b/app/components/Credibility.tsx
@@ -172,17 +172,17 @@ export function ContactCard({
     locale === "zh"
       ? {
           eyebrow: "联系",
-          title: "和维护团队直接对话",
+          title: "联系 Eunomia Labs",
           body:
-            "由 eunomia-bpf 开源团队维护，聚焦 eBPF、runtime extension 和 AI agent infrastructure 的系统工程。企业评估、POC 和生产集成可直接邮件联系，我们通常在两个工作日内回复。",
+            "Eunomia Labs, Inc. 负责运营和维护，聚焦 eBPF、runtime extension 和 AI agent infrastructure 的系统工程。企业评估、POC 和生产集成可直接邮件联系，我们通常在两个工作日内回复。",
           cta: "邮件联系",
           response: "通常 2 个工作日内回复"
         }
       : {
           eyebrow: "Contact",
-          title: "Talk to the people who maintain it",
+          title: "Talk to Eunomia Labs",
           body:
-            "Maintained by the eunomia-bpf open-source team, focused on systems engineering for eBPF, runtime extension, and AI agent infrastructure. Reach out directly for enterprise evaluation, POCs, and production integration.",
+            "Operated and maintained by Eunomia Labs, Inc., with a focus on systems engineering for eBPF, runtime extension, and AI agent infrastructure. Reach out directly for enterprise evaluation, POCs, and production integration.",
           cta: "Email us",
           response: "Typically replies within 2 business days"
         };

--- a/app/components/SiteFooter.tsx
+++ b/app/components/SiteFooter.tsx
@@ -33,7 +33,7 @@ export function SiteFooter({ locale }: SiteFooterProps) {
           <p className="text-lg font-semibold tracking-tight text-ink">eunomia</p>
           <p className="mt-3 max-w-md leading-7">{copy.copyright}</p>
           <p className="mt-3 text-xs text-slate-500">
-            © {new Date().getFullYear()} eunomia-bpf · MIT License
+            {siteConfig.copyright} · MIT License
           </p>
         </div>
         <FooterColumn title={copy.explore} links={exploreLinks} />

--- a/app/lib/site-config.generated.ts
+++ b/app/lib/site-config.generated.ts
@@ -3,7 +3,7 @@ export const generatedSiteConfig = {
   description: "Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.",
   siteUrl: "https://eunomia.dev",
   repoUrl: "https://github.com/eunomia-bpf/eunomia.dev",
-  copyright: "Copyright (c) 2025 Eunomia Labs, Inc.",
+  copyright: "Copyright (c) 2026 Eunomia Labs, Inc.",
   remoteBranch: "docs",
   editUri: "https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs"
 } as const;

--- a/app/lib/site-config.generated.ts
+++ b/app/lib/site-config.generated.ts
@@ -3,7 +3,7 @@ export const generatedSiteConfig = {
   description: "Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.",
   siteUrl: "https://eunomia.dev",
   repoUrl: "https://github.com/eunomia-bpf/eunomia.dev",
-  copyright: "Copyright (c) 2025 eunomia-bpf org.",
+  copyright: "Copyright (c) 2025 Eunomia Labs, Inc.",
   remoteBranch: "docs",
   editUri: "https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs"
 } as const;

--- a/app/lib/ui-copy.ts
+++ b/app/lib/ui-copy.ts
@@ -106,7 +106,7 @@ export const siteFooterCopyByLocale = {
     explore: "Explore",
     projects: "Projects",
     community: "Community",
-    copyright: "Open-source systems research, eBPF tooling, and runnable documentation from the eunomia-bpf community.",
+    copyright: "Eunomia Labs, Inc. operates the site and supports the open-source systems research, eBPF tooling, and runnable documentation published here.",
     legacyBlog: "Legacy blog",
     sourceCode: "Site Source"
   },
@@ -114,7 +114,7 @@ export const siteFooterCopyByLocale = {
     explore: "浏览",
     projects: "项目",
     community: "社区",
-    copyright: "来自 eunomia-bpf 社区的开源系统研究、eBPF 工具和可运行文档。",
+    copyright: "本网站由 Eunomia Labs, Inc. 运营，并支持这里发布的开源系统研究、eBPF 工具和可运行文档。",
     legacyBlog: "旧博客",
     sourceCode: "网站源码"
   }

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,7 +1,7 @@
 site_name: eunomia
 repo_url: https://github.com/eunomia-bpf/eunomia.dev
 site_url: https://eunomia.dev
-copyright: Copyright (c) 2025 Eunomia Labs, Inc.
+copyright: Copyright (c) 2026 Eunomia Labs, Inc.
 site_description: 'Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.'
 remote_branch: docs
 edit_uri: https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,7 +1,7 @@
 site_name: eunomia
 repo_url: https://github.com/eunomia-bpf/eunomia.dev
 site_url: https://eunomia.dev
-copyright: Copyright (c) 2025 eunomia-bpf org.
+copyright: Copyright (c) 2025 Eunomia Labs, Inc.
 site_description: 'Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.'
 remote_branch: docs
 edit_uri: https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs


### PR DESCRIPTION
Summary:
- update the repository MIT copyright holder to Eunomia Labs, Inc.
- identify Eunomia Labs, Inc. as the site operator and maintainer in English and Chinese
- render the footer copyright from mkdocs.yaml while preserving the MIT license label

Validation:
- npm run verify
- npm run typecheck
- npm run test:content (79 tests passed within verify)
- NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run build
- inspected generated English and Chinese footer/contact HTML