### PR TITLE
ci: pin tutorial sync to dispatched commit

### DIFF
--- a/.github/workflows/app-static-pages.yml
+++ b/.github/workflows/app-static-pages.yml
@@ -30,26 +30,52 @@ jobs:
           fetch-depth: 0
 
       - name: Sync external documentation
+        id: sync
         env:
           DISPATCH_TYPE: ${{ github.event.action }}
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           SOURCE_SHA: ${{ github.event.client_payload.source_sha }}
         run: |
           set -euo pipefail
+          echo "synced=false" >> "$GITHUB_OUTPUT"
           case "${DISPATCH_TYPE}" in
             trigger-document-sync)
               make sync-external-docs
               ;;
             trigger-tutorial-sync)
-              make sync-external-docs
+              if [ "${SOURCE_REPO}" != "eunomia-bpf/bpf-developer-tutorial" ]; then
+                echo "Invalid tutorial source repository: ${SOURCE_REPO}" >&2
+                exit 1
+              fi
+              if [[ ! "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "Invalid tutorial source commit: ${SOURCE_SHA}" >&2
+                exit 1
+              fi
+
+              source_url="https://github.com/${SOURCE_REPO}.git"
+              git init --quiet tutorial-source
+              git -C tutorial-source remote add origin "${source_url}"
+              git -C tutorial-source fetch --quiet --depth=1 origin refs/heads/main
+              fetched_sha="$(git -C tutorial-source rev-parse FETCH_HEAD)"
+              if [ "${SOURCE_SHA}" != "${fetched_sha}" ]; then
+                echo "Skipping stale tutorial sync ${SOURCE_SHA}; main is ${fetched_sha}."
+                exit 0
+              fi
+
+              git -C tutorial-source checkout --quiet --detach FETCH_HEAD
+              make clean
+              mv tutorial-source tutorial
+              make docs/CNAME
               ;;
             *)
               echo "Unsupported repository_dispatch type: ${DISPATCH_TYPE}" >&2
               exit 1
               ;;
           esac
+          echo "synced=true" >> "$GITHUB_OUTPUT"
 
       - name: Commit synced documentation
+        if: steps.sync.outputs.synced == 'true'
         env:
           SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
           SOURCE_SHA: ${{ github.event.client_payload.source_sha }}


### PR DESCRIPTION
## Summary

- validate tutorial dispatch provenance before syncing
- fetch the current tutorial `main` commit and require it to match the dispatched SHA
- skip stale dispatches without creating a misleading sync commit
- keep the generic documentation sync path unchanged

This is the downstream companion for eunomia-bpf/bpf-developer-tutorial#214.

## Validation

- parsed `.github/workflows/app-static-pages.yml` as YAML
- exercised current and stale tutorial SHA paths against the remote repository
- `git diff --check`