### PR TITLE
Fix technical SEO: raster og:image, syndication canonical_url, sitemap consistency

### DIFF
--- a/.github/publisher/publish.py
+++ b/.github/publisher/publish.py
@@ -8,12 +8,14 @@ import json
 import os
 import sys
 import re
+import unicodedata
 import requests
 
 
 API_ENDPOINT = "https://media-publisher.vercel.app/api/publish-multi"
 QUEUE_FILE = ".github/publisher/posts_queue.txt"
 DEFAULT_PUBLISH_COUNT = 2
+SITE_URL = "https://eunomia.dev"
 
 
 def has_yaml_frontmatter(content):
@@ -98,6 +100,103 @@ def remove_title_from_content(content):
     return content
 
 
+def slugify_title(value):
+    """
+    Slugify a title using the same rules as the site content pipeline
+    (app/lib/content/source.ts slugifyTitle): lowercase, NFKD-normalize, drop
+    combining marks, collapse runs of non-alphanumeric characters into a single
+    hyphen, and trim leading/trailing hyphens.
+    """
+    text = unicodedata.normalize("NFKD", value.lower())
+    text = "".join(ch for ch in text if not unicodedata.category(ch).startswith("M"))
+    chars = []
+    prev_hyphen = False
+    for ch in text:
+        if ch.isalnum():
+            chars.append(ch)
+            prev_hyphen = False
+        elif not prev_hyphen:
+            chars.append("-")
+            prev_hyphen = True
+    slug = "".join(chars).strip("-")
+    if slug:
+        return slug
+    return re.sub(r"\s+", "-", value.strip())
+
+
+def parse_frontmatter(content):
+    """Parse top-level scalar fields from YAML frontmatter (no external deps)."""
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return {}
+
+    fields = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if match:
+            key = match.group(1)
+            raw = match.group(2).strip()
+            if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+                raw = raw[1:-1]
+            fields[key] = raw
+    return fields
+
+
+def derive_canonical_url(post_path, content, title):
+    """
+    Derive the canonical eunomia.dev URL for a source markdown path so
+    syndicated copies (dev.to, Medium) point back to the original.
+
+    Blog posts under docs/blog/posts/<name>.md map to
+    https://eunomia.dev/blog/YYYY/MM/DD/<slug>/ where YYYY-MM-DD comes from the
+    frontmatter `date` and <slug> is the frontmatter `slug` if present, otherwise
+    the slugified title (matching the site's content pipeline). Other docs paths
+    map to https://eunomia.dev/<path-without-docs-prefix-and-README.md>/.
+    Returns None when no canonical URL can be derived.
+    """
+    normalized = post_path.replace("\\", "/")
+    match = re.search(r"(?:^|/)docs/(.+)$", normalized)
+    if not match:
+        return None
+    rel = match.group(1)
+
+    blog_match = re.match(r"^blog/posts/(?:.+?)(\.zh)?\.md$", rel)
+    if blog_match:
+        is_zh = bool(blog_match.group(1))
+        # The site derives blog date/slug from the English source for both locales
+        # (app/lib/content/discovery.ts prefers sourceByLocale.en), so resolve the
+        # English sibling when the queued file is the Chinese translation.
+        source_content, source_title = content, title
+        if is_zh:
+            en_sibling = re.sub(r"\.zh\.md$", ".md", post_path)
+            if os.path.isfile(en_sibling):
+                with open(en_sibling, "r", encoding="utf-8") as sibling:
+                    source_content = sibling.read()
+                try:
+                    source_title, _ = extract_title_from_markdown(source_content)
+                except ValueError:
+                    source_title = title
+        frontmatter = parse_frontmatter(source_content)
+        date_match = re.match(r"(\d{4})-(\d{2})-(\d{2})", frontmatter.get("date", ""))
+        if not date_match:
+            return None
+        year, month, day = date_match.groups()
+        slug = frontmatter.get("slug") or slugify_title(frontmatter.get("title") or source_title)
+        locale_prefix = "/zh" if is_zh else ""
+        return f"{SITE_URL}{locale_prefix}/blog/{year}/{month}/{day}/{slug}/"
+
+    is_zh = rel.endswith(".zh.md")
+    rel = re.sub(r"(?:\.zh)?\.md$", "", rel)
+    rel = re.sub(r"/README$", "", rel)
+    rel = rel.strip("/")
+    if not rel:
+        return None
+    locale_prefix = "/zh" if is_zh else ""
+    return f"{SITE_URL}{locale_prefix}/{rel}/"
+
+
 def read_queue():
     """Read the posts queue file and return list of posts."""
     if not os.path.exists(QUEUE_FILE):
@@ -172,12 +271,14 @@ def prepare_post(post, index):
 
     title, _title_line = extract_title_from_markdown(original_content)
     cleaned_content = remove_title_from_content(original_content)
+    canonical_url = derive_canonical_url(validated_post_path, original_content, title)
 
     return {
         "title": title,
         "content": cleaned_content,
         "path": validated_post_path,
-        "tags": tags
+        "tags": tags,
+        "canonical_url": canonical_url
     }
 
 
@@ -187,10 +288,11 @@ def print_post_preview(prepared_post, index, total):
     print(f"Title: {prepared_post['title']}")
     print(f"Path: {prepared_post['path']}")
     print(f"Tags: {', '.join(prepared_post['tags'])}")
+    print(f"Canonical URL: {prepared_post.get('canonical_url') or '(none)'}")
     print(f"Content preview: {prepared_post['content'][:200]}...")
 
 
-def publish_post(title, content, tags, password, is_draft=True):
+def publish_post(title, content, tags, password, is_draft=True, canonical_url=None):
     """
     Publish a post to Medium and Dev.to via the API.
     """
@@ -201,6 +303,11 @@ def publish_post(title, content, tags, password, is_draft=True):
         "is_draft": is_draft,
         "platforms": ["devto", "medium"]
     }
+    # Canonical URL points syndicated copies back to the original on eunomia.dev.
+    # The media-publisher Vercel service is responsible for forwarding this to
+    # dev.to (canonical_url) and Medium (canonicalUrl).
+    if canonical_url:
+        payload["canonical_url"] = canonical_url
 
     headers = {
         "Content-Type": "application/json",
@@ -276,7 +383,8 @@ def main():
                 prepared_post["content"],
                 prepared_post["tags"],
                 password,
-                is_draft
+                is_draft,
+                prepared_post.get("canonical_url")
             )
             print(f"\n✅ Publish {index}/{len(prepared_posts)} successful!")
             print(json.dumps(result, indent=2))

--- a/.github/publisher/publish.py
+++ b/.github/publisher/publish.py
@@ -183,7 +183,13 @@ def derive_canonical_url(post_path, content, title):
         if not date_match:
             return None
         year, month, day = date_match.groups()
-        slug = frontmatter.get("slug") or slugify_title(frontmatter.get("title") or source_title)
+        # Mirror the site pipeline (app/lib/content/markdown.ts parseSlug), which
+        # slugifies the frontmatter slug too and falls back to the title when it
+        # normalizes to empty.
+        raw_slug = frontmatter.get("slug")
+        slug = (slugify_title(raw_slug) if raw_slug else "") or slugify_title(
+            frontmatter.get("title") or source_title
+        )
         locale_prefix = "/zh" if is_zh else ""
         return f"{SITE_URL}{locale_prefix}/blog/{year}/{month}/{day}/{slug}/"
 

--- a/.github/publisher/publish.py
+++ b/.github/publisher/publish.py
@@ -8,16 +8,12 @@ import json
 import os
 import sys
 import re
-import unicodedata
-from collections import namedtuple
-
 import requests
 
 
 API_ENDPOINT = "https://media-publisher.vercel.app/api/publish-multi"
 QUEUE_FILE = ".github/publisher/posts_queue.txt"
 DEFAULT_PUBLISH_COUNT = 2
-SITE_URL = "https://eunomia.dev"
 
 
 def has_yaml_frontmatter(content):
@@ -102,160 +98,6 @@ def remove_title_from_content(content):
     return content
 
 
-def slugify_title(value):
-    """
-    Slugify a title using the same rules as the site content pipeline
-    (app/lib/content/source.ts slugifyTitle): lowercase, NFKD-normalize, drop
-    combining marks, collapse runs of non-alphanumeric characters into a single
-    hyphen, and trim leading/trailing hyphens.
-    """
-    text = unicodedata.normalize("NFKD", value.lower())
-    text = "".join(ch for ch in text if not unicodedata.category(ch).startswith("M"))
-    chars = []
-    prev_hyphen = False
-    for ch in text:
-        if ch.isalnum():
-            chars.append(ch)
-            prev_hyphen = False
-        elif not prev_hyphen:
-            chars.append("-")
-            prev_hyphen = True
-    slug = "".join(chars).strip("-")
-    if slug:
-        return slug
-    return re.sub(r"\s+", "-", value.strip())
-
-
-# Parsed frontmatter scalar: `text` is the value with quotes/comments removed,
-# `is_string` reflects whether js-yaml (used by gray-matter on the site) would
-# treat the value as a string. The site's parseSlug ignores non-string slugs.
-FrontmatterScalar = namedtuple("FrontmatterScalar", ["text", "is_string"])
-
-# YAML 1.1 (js-yaml) parses these unquoted scalars as non-strings (numbers,
-# booleans, null), which the site's parseSlug rejects.
-_YAML_NONSTRING_SCALAR = re.compile(
-    r"^(?:"
-    r"[+-]?\d+"                              # integer
-    r"|[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?"  # float / scientific
-    r"|0x[0-9a-fA-F]+|0o[0-7]+"              # hex / octal
-    r"|true|false|null|~"                    # bool / null
-    r"|yes|no|on|off"                        # YAML 1.1 booleans
-    r")$",
-    re.IGNORECASE,
-)
-
-
-def _parse_frontmatter_scalar(raw):
-    """Interpret one unparsed frontmatter scalar the way js-yaml would for the
-    fields we consume: a quoted value is a string; an unquoted value has any
-    inline `# comment` stripped and is flagged as a string only when YAML would
-    not parse it as a number, boolean, or null."""
-    raw = raw.strip()
-    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
-        return FrontmatterScalar(raw[1:-1], True)
-    raw = re.sub(r"\s+#.*$", "", raw).strip()
-    is_string = bool(raw) and not _YAML_NONSTRING_SCALAR.match(raw)
-    return FrontmatterScalar(raw, is_string)
-
-
-def parse_frontmatter(content):
-    """Parse top-level scalar fields from YAML frontmatter (no external deps).
-
-    Returns a mapping of field name to FrontmatterScalar. Only simple inline
-    scalars are recognized; block/flow values are out of scope for the canonical
-    URL derivation below.
-    """
-    lines = content.split("\n")
-    if not lines or lines[0].strip() != "---":
-        return {}
-
-    fields = {}
-    for line in lines[1:]:
-        if line.strip() == "---":
-            break
-        match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
-        if match:
-            fields[match.group(1)] = _parse_frontmatter_scalar(match.group(2))
-    return fields
-
-
-def derive_canonical_url(post_path, content, title):
-    """
-    Derive the canonical eunomia.dev URL for a source markdown path so
-    syndicated copies (dev.to, Medium) point back to the original.
-
-    Blog posts under docs/blog/posts/<name>.md map to
-    https://eunomia.dev/blog/YYYY/MM/DD/<slug>/ where YYYY-MM-DD comes from the
-    frontmatter `date` and <slug> is the frontmatter `slug` if present, otherwise
-    the slugified title (matching the site's content pipeline). Other docs paths
-    map to https://eunomia.dev/<path-without-docs-prefix-and-README.md>/.
-    Returns None when no canonical URL can be derived.
-    """
-    normalized = post_path.replace("\\", "/")
-    match = re.search(r"(?:^|/)docs/(.+)$", normalized)
-    if not match:
-        return None
-    rel = match.group(1)
-
-    blog_match = re.match(r"^blog/posts/(?:.+?)(\.zh)?\.md$", rel)
-    if blog_match:
-        is_zh = bool(blog_match.group(1))
-        # The site derives blog date/slug from the English source for both locales
-        # (app/lib/content/discovery.ts prefers sourceByLocale.en), so resolve the
-        # English sibling when the queued file is the Chinese translation.
-        source_content, source_title = content, title
-        if is_zh:
-            en_sibling = re.sub(r"\.zh\.md$", ".md", post_path)
-            if os.path.isfile(en_sibling):
-                with open(en_sibling, "r", encoding="utf-8") as sibling:
-                    source_content = sibling.read()
-                try:
-                    source_title, _ = extract_title_from_markdown(source_content)
-                except ValueError:
-                    source_title = title
-        frontmatter = parse_frontmatter(source_content)
-        # The site parses `date` with new Date(...).toISOString() (UTC). A bare,
-        # zero-padded YYYY-MM-DD maps unambiguously to that UTC day; a value with a
-        # time/zone component (or a non-padded one) can shift the UTC day, so omit
-        # the canonical rather than emit a wrong one.
-        date_field = frontmatter.get("date")
-        date_match = re.match(r"^(\d{4})-(\d{2})-(\d{2})$", date_field.text) if date_field else None
-        if not date_match:
-            return None
-        year, month, day = date_match.groups()
-        # Mirror app/lib/content/markdown.ts: a string frontmatter `title` wins,
-        # otherwise fall back to the H1 heading.
-        title_field = frontmatter.get("title")
-        fallback_title = title_field.text if title_field and title_field.is_string else source_title
-        # Mirror parseSlug: only a string frontmatter `slug` is used (slugified);
-        # non-string YAML scalars and empty slugs fall back to the slugified title.
-        slug_field = frontmatter.get("slug")
-        slug = slugify_title(slug_field.text) if slug_field and slug_field.is_string else ""
-        if not slug:
-            slug = slugify_title(fallback_title)
-        locale_prefix = "/zh" if is_zh else ""
-        return f"{SITE_URL}{locale_prefix}/blog/{year}/{month}/{day}/{slug}/"
-
-    # Non-blog docs: strip the locale suffix (.zh.md/.zh-CN.md map to the /zh
-    # tree; .en.md/.md map to the default tree), then collapse a trailing README
-    # or index segment since the site serves those at the section root.
-    locale_match = re.search(r"\.(zh-CN|zh|en)\.md$", rel)
-    if locale_match:
-        is_zh = locale_match.group(1) in ("zh", "zh-CN")
-        rel = rel[: locale_match.start()]
-    elif rel.endswith(".md"):
-        is_zh = False
-        rel = rel[: -len(".md")]
-    else:
-        return None
-    rel = re.sub(r"(?:^|/)(README|index)$", "", rel)
-    rel = rel.strip("/")
-    if not rel:
-        return None
-    locale_prefix = "/zh" if is_zh else ""
-    return f"{SITE_URL}{locale_prefix}/{rel}/"
-
-
 def read_queue():
     """Read the posts queue file and return list of posts."""
     if not os.path.exists(QUEUE_FILE):
@@ -330,14 +172,12 @@ def prepare_post(post, index):
 
     title, _title_line = extract_title_from_markdown(original_content)
     cleaned_content = remove_title_from_content(original_content)
-    canonical_url = derive_canonical_url(validated_post_path, original_content, title)
 
     return {
         "title": title,
         "content": cleaned_content,
         "path": validated_post_path,
-        "tags": tags,
-        "canonical_url": canonical_url
+        "tags": tags
     }
 
 
@@ -347,11 +187,10 @@ def print_post_preview(prepared_post, index, total):
     print(f"Title: {prepared_post['title']}")
     print(f"Path: {prepared_post['path']}")
     print(f"Tags: {', '.join(prepared_post['tags'])}")
-    print(f"Canonical URL: {prepared_post.get('canonical_url') or '(none)'}")
     print(f"Content preview: {prepared_post['content'][:200]}...")
 
 
-def publish_post(title, content, tags, password, is_draft=True, canonical_url=None):
+def publish_post(title, content, tags, password, is_draft=True):
     """
     Publish a post to Medium and Dev.to via the API.
     """
@@ -362,11 +201,6 @@ def publish_post(title, content, tags, password, is_draft=True, canonical_url=No
         "is_draft": is_draft,
         "platforms": ["devto", "medium"]
     }
-    # Canonical URL points syndicated copies back to the original on eunomia.dev.
-    # The media-publisher Vercel service is responsible for forwarding this to
-    # dev.to (canonical_url) and Medium (canonicalUrl).
-    if canonical_url:
-        payload["canonical_url"] = canonical_url
 
     headers = {
         "Content-Type": "application/json",
@@ -442,8 +276,7 @@ def main():
                 prepared_post["content"],
                 prepared_post["tags"],
                 password,
-                is_draft,
-                prepared_post.get("canonical_url")
+                is_draft
             )
             print(f"\n✅ Publish {index}/{len(prepared_posts)} successful!")
             print(json.dumps(result, indent=2))

--- a/.github/publisher/publish.py
+++ b/.github/publisher/publish.py
@@ -9,6 +9,8 @@ import os
 import sys
 import re
 import unicodedata
+from collections import namedtuple
+
 import requests
 
 
@@ -124,8 +126,45 @@ def slugify_title(value):
     return re.sub(r"\s+", "-", value.strip())
 
 
+# Parsed frontmatter scalar: `text` is the value with quotes/comments removed,
+# `is_string` reflects whether js-yaml (used by gray-matter on the site) would
+# treat the value as a string. The site's parseSlug ignores non-string slugs.
+FrontmatterScalar = namedtuple("FrontmatterScalar", ["text", "is_string"])
+
+# YAML 1.1 (js-yaml) parses these unquoted scalars as non-strings (numbers,
+# booleans, null), which the site's parseSlug rejects.
+_YAML_NONSTRING_SCALAR = re.compile(
+    r"^(?:"
+    r"[+-]?\d+"                              # integer
+    r"|[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?"  # float / scientific
+    r"|0x[0-9a-fA-F]+|0o[0-7]+"              # hex / octal
+    r"|true|false|null|~"                    # bool / null
+    r"|yes|no|on|off"                        # YAML 1.1 booleans
+    r")$",
+    re.IGNORECASE,
+)
+
+
+def _parse_frontmatter_scalar(raw):
+    """Interpret one unparsed frontmatter scalar the way js-yaml would for the
+    fields we consume: a quoted value is a string; an unquoted value has any
+    inline `# comment` stripped and is flagged as a string only when YAML would
+    not parse it as a number, boolean, or null."""
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+        return FrontmatterScalar(raw[1:-1], True)
+    raw = re.sub(r"\s+#.*$", "", raw).strip()
+    is_string = bool(raw) and not _YAML_NONSTRING_SCALAR.match(raw)
+    return FrontmatterScalar(raw, is_string)
+
+
 def parse_frontmatter(content):
-    """Parse top-level scalar fields from YAML frontmatter (no external deps)."""
+    """Parse top-level scalar fields from YAML frontmatter (no external deps).
+
+    Returns a mapping of field name to FrontmatterScalar. Only simple inline
+    scalars are recognized; block/flow values are out of scope for the canonical
+    URL derivation below.
+    """
     lines = content.split("\n")
     if not lines or lines[0].strip() != "---":
         return {}
@@ -136,11 +175,7 @@ def parse_frontmatter(content):
             break
         match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
         if match:
-            key = match.group(1)
-            raw = match.group(2).strip()
-            if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
-                raw = raw[1:-1]
-            fields[key] = raw
+            fields[match.group(1)] = _parse_frontmatter_scalar(match.group(2))
     return fields
 
 
@@ -179,23 +214,41 @@ def derive_canonical_url(post_path, content, title):
                 except ValueError:
                     source_title = title
         frontmatter = parse_frontmatter(source_content)
-        date_match = re.match(r"(\d{4})-(\d{2})-(\d{2})", frontmatter.get("date", ""))
+        # The site parses `date` with new Date(...).toISOString() (UTC). A bare,
+        # zero-padded YYYY-MM-DD maps unambiguously to that UTC day; a value with a
+        # time/zone component (or a non-padded one) can shift the UTC day, so omit
+        # the canonical rather than emit a wrong one.
+        date_field = frontmatter.get("date")
+        date_match = re.match(r"^(\d{4})-(\d{2})-(\d{2})$", date_field.text) if date_field else None
         if not date_match:
             return None
         year, month, day = date_match.groups()
-        # Mirror the site pipeline (app/lib/content/markdown.ts parseSlug), which
-        # slugifies the frontmatter slug too and falls back to the title when it
-        # normalizes to empty.
-        raw_slug = frontmatter.get("slug")
-        slug = (slugify_title(raw_slug) if raw_slug else "") or slugify_title(
-            frontmatter.get("title") or source_title
-        )
+        # Mirror app/lib/content/markdown.ts: a string frontmatter `title` wins,
+        # otherwise fall back to the H1 heading.
+        title_field = frontmatter.get("title")
+        fallback_title = title_field.text if title_field and title_field.is_string else source_title
+        # Mirror parseSlug: only a string frontmatter `slug` is used (slugified);
+        # non-string YAML scalars and empty slugs fall back to the slugified title.
+        slug_field = frontmatter.get("slug")
+        slug = slugify_title(slug_field.text) if slug_field and slug_field.is_string else ""
+        if not slug:
+            slug = slugify_title(fallback_title)
         locale_prefix = "/zh" if is_zh else ""
         return f"{SITE_URL}{locale_prefix}/blog/{year}/{month}/{day}/{slug}/"
 
-    is_zh = rel.endswith(".zh.md")
-    rel = re.sub(r"(?:\.zh)?\.md$", "", rel)
-    rel = re.sub(r"/README$", "", rel)
+    # Non-blog docs: strip the locale suffix (.zh.md/.zh-CN.md map to the /zh
+    # tree; .en.md/.md map to the default tree), then collapse a trailing README
+    # or index segment since the site serves those at the section root.
+    locale_match = re.search(r"\.(zh-CN|zh|en)\.md$", rel)
+    if locale_match:
+        is_zh = locale_match.group(1) in ("zh", "zh-CN")
+        rel = rel[: locale_match.start()]
+    elif rel.endswith(".md"):
+        is_zh = False
+        rel = rel[: -len(".md")]
+    else:
+        return None
+    rel = re.sub(r"(?:^|/)(README|index)$", "", rel)
     rel = rel.strip("/")
     if not rel:
         return None

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__
 /app/public/robots.txt
 /app/public/zh/feed.xml
 /app/public/og/default.svg
+/app/public/og/default.png
 /app/*.tsbuildinfo
 /app/node_modules
 /test/node_modules

--- a/app/components/SeoHead.tsx
+++ b/app/components/SeoHead.tsx
@@ -212,7 +212,7 @@ export function SeoHead({
       <meta property="og:image" content={ogImage} />
       <meta property="og:image:width" content={String(OG_IMAGE_WIDTH)} />
       <meta property="og:image:height" content={String(OG_IMAGE_HEIGHT)} />
-      <meta property="og:image:type" content="image/svg+xml" />
+      <meta property="og:image:type" content="image/png" />
       <meta property="og:locale" content={locale} />
       <meta property="og:locale:alternate" content={altLocale} />
       {articlePublishedAt ? <meta property="article:published_time" content={articlePublishedAt} /> : null}

--- a/app/lib/content/manifest.ts
+++ b/app/lib/content/manifest.ts
@@ -38,8 +38,13 @@ const routeAliasesByCanonicalPath: Record<string, string[]> = {
 
 const sitemapExcludedRoutes = new Set(["/GPTtrace/agentsight/", "/zh/GPTtrace/agentsight/"]);
 
+// Legacy /blogs/** (and /zh/blogs/**) pages are served with robots: noindex,follow
+// (see page-factories.tsx), so they must not appear in the sitemap. This pattern
+// mirrors the noindex regex used there to keep the two in sync.
+const noindexBlogRoutePattern = /\/(blogs|zh\/blogs)\//;
+
 export function isSitemapExcludedRoute(routePath: string): boolean {
-  return sitemapExcludedRoutes.has(routePath);
+  return sitemapExcludedRoutes.has(routePath) || noindexBlogRoutePattern.test(routePath);
 }
 
 function allowManifestFallback(): boolean {

--- a/app/lib/seo.ts
+++ b/app/lib/seo.ts
@@ -1,7 +1,8 @@
 import type { LocaleAlternates } from "./content/types";
 import { siteConfig } from "./site-data";
 
-export const STATIC_OG_IMAGE_PATH = "/og/default.svg";
+// Emitted as a rasterized PNG (not SVG) so social platforms can render the card.
+export const STATIC_OG_IMAGE_PATH = "/og/default.png";
 
 export type AlternateLink = {
   hrefLang: string;

--- a/app/scripts/assert-content-artifacts.mjs
+++ b/app/scripts/assert-content-artifacts.mjs
@@ -21,6 +21,7 @@ const requiredFiles = [
   path.join(appDir, "public", "sitemap.xml"),
   path.join(appDir, "public", "robots.txt"),
   path.join(appDir, "public", "og", "default.svg"),
+  path.join(appDir, "public", "og", "default.png"),
   path.join(staticBuildRoot, "index.html"),
   path.join(staticBuildRoot, "feed.xml"),
   path.join(staticBuildRoot, "robots.txt"),

--- a/app/scripts/clean-generated-output.mjs
+++ b/app/scripts/clean-generated-output.mjs
@@ -14,7 +14,8 @@ const generatedPaths = [
   path.join("public", "sitemap.xml"),
   path.join("public", "robots.txt"),
   path.join("public", "zh", "feed.xml"),
-  path.join("public", "og", "default.svg")
+  path.join("public", "og", "default.svg"),
+  path.join("public", "og", "default.png")
 ];
 
 function removeIfPresent(relativePath) {

--- a/app/scripts/generate-static-metadata.ts
+++ b/app/scripts/generate-static-metadata.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { Resvg } from "@resvg/resvg-js";
+
 import { renderFeed } from "../lib/content/feed";
 import { getGitMetadata } from "../lib/content/git";
 import { getContentManifest, isSitemapExcludedRoute } from "../lib/content/manifest";
@@ -21,13 +23,13 @@ type StaticMetadataPaths = {
 
 type StaticMetadataFile = {
   relativePath: string;
-  contents: string;
+  contents: string | Buffer;
 };
 
-function writeFileAtomic(filePath: string, contents: string) {
+function writeFileAtomic(filePath: string, contents: string | Buffer) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.tmp`;
-  fs.writeFileSync(tempPath, contents, "utf8");
+  fs.writeFileSync(tempPath, contents);
   fs.renameSync(tempPath, filePath);
 }
 
@@ -71,6 +73,15 @@ function renderStaticOgSvg() {
   <text x="88" y="520" fill="#C7D2FE" font-size="28" font-family="ui-sans-serif, system-ui, sans-serif">eunomia.dev</text>
   <text x="88" y="560" fill="#E2E8F0" font-size="24" font-family="ui-sans-serif, system-ui, sans-serif">Static OG image shared by all pages for static export compatibility</text>
 </svg>`;
+}
+
+// Social platforms (Slack, Twitter/X, Facebook, LinkedIn, Discord) do not render
+// SVG og:image cards, so rasterize the shared SVG to a 1200x630 PNG at build time.
+function renderStaticOgPng(svg: string): Buffer {
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: "width", value: 1200 }
+  });
+  return resvg.render().asPng();
 }
 
 export function buildSitemapXml() {
@@ -146,6 +157,7 @@ Sitemap: ${absoluteUrl("/sitemap.xml")}
 export function writeStaticMetadata(paths: StaticMetadataPaths = {}) {
   const publicDir = paths.publicDir ?? defaultPublicDir;
   const indexPath = paths.indexPath ?? defaultGeneratedIndexPath;
+  const ogSvg = renderStaticOgSvg();
   const files: StaticMetadataFile[] = [
     {
       relativePath: "feed.xml",
@@ -165,7 +177,11 @@ export function writeStaticMetadata(paths: StaticMetadataPaths = {}) {
     },
     {
       relativePath: path.join("og", "default.svg"),
-      contents: renderStaticOgSvg()
+      contents: ogSvg
+    },
+    {
+      relativePath: path.join("og", "default.png"),
+      contents: renderStaticOgPng(ogSvg)
     }
   ];
 

--- a/app/tests/content.test.ts
+++ b/app/tests/content.test.ts
@@ -637,10 +637,13 @@ test("docPathToRoute keeps legacy blog routes stable across locales", () => {
   assert.equal(docPathToRoute("blogs/bpftime.zh.md", "zh"), "/zh/blogs/bpftime/");
 });
 
-test("listSitemapRoutes keeps key legacy and section routes", () => {
+test("listSitemapRoutes keeps section routes but excludes noindex'd legacy blog routes", () => {
   const rawRoutes = listSitemapRoutes();
   const routes = new Set(rawRoutes);
-  assert.ok(routes.has("/zh/blogs/bpftime/"));
+  // Legacy /blogs/** pages are served with robots: noindex, so they must not
+  // appear in the sitemap (see isSitemapExcludedRoute).
+  assert.ok(!routes.has("/blogs/bpftime/"));
+  assert.ok(!routes.has("/zh/blogs/bpftime/"));
   assert.ok(routes.has("/eunomia-bpf/setup/build/"));
   assert.ok(routes.has("/eunomia-bpf/setup/"));
   assert.ok(routes.has("/tutorials/38-btf-uprobe/test-verify/"));
@@ -925,7 +928,7 @@ test("static metadata generation emits feed, sitemap, robots, and shared OG asse
       indexPath
     });
 
-    assert.deepEqual(result.files, ["feed.xml", path.join("zh", "feed.xml"), "sitemap.xml", "robots.txt", path.join("og", "default.svg")]);
+    assert.deepEqual(result.files, ["feed.xml", path.join("zh", "feed.xml"), "sitemap.xml", "robots.txt", path.join("og", "default.svg"), path.join("og", "default.png")]);
     assert.ok(fs.existsSync(indexPath));
     assert.match(fs.readFileSync(path.join(publicDir, "feed.xml"), "utf8"), /<rss version="2.0"/);
     assert.match(fs.readFileSync(path.join(publicDir, "zh", "feed.xml"), "utf8"), /<language>zh-CN<\/language>/);
@@ -933,8 +936,13 @@ test("static metadata generation emits feed, sitemap, robots, and shared OG asse
     assert.match(sitemap, /<loc>https:\/\/eunomia\.dev\//);
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/GPTtrace\/agentsight\//);
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/zh\/GPTtrace\/agentsight\//);
+    // Legacy noindex'd /blogs/** URLs must be excluded from the sitemap.
+    assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/blogs\//);
+    assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/zh\/blogs\//);
     assert.match(fs.readFileSync(path.join(publicDir, "robots.txt"), "utf8"), /Sitemap: https:\/\/eunomia\.dev\/sitemap\.xml/);
     assert.match(fs.readFileSync(path.join(publicDir, "og", "default.svg"), "utf8"), /Static OG image shared by all pages/);
+    const ogPng = fs.readFileSync(path.join(publicDir, "og", "default.png"));
+    assert.equal(ogPng.subarray(0, 8).toString("hex"), "89504e470d0a1a0a");
   } finally {
     fs.rmSync(publicDir, { recursive: true, force: true });
     fs.rmSync(indexPath, { force: true });

--- a/test/scripts/http-audit.mjs
+++ b/test/scripts/http-audit.mjs
@@ -42,14 +42,20 @@ async function auditFeed(pathname) {
 }
 
 async function auditStaticOg() {
-  const url = pageUrl("/og/default.svg");
-  const { response, text } = await fetchText(url);
-  check(response.ok, "static OG image is reachable");
+  // The og:image is a rasterized PNG so social platforms can render the card.
+  const pngUrl = pageUrl("/og/default.png");
+  const { response: pngResponse } = await fetchText(pngUrl);
+  check(pngResponse.ok, "static OG image (PNG) is reachable");
   check(
-    (response.headers.get("content-type") ?? "").includes("image/svg+xml"),
-    "static OG image is served as SVG"
+    (pngResponse.headers.get("content-type") ?? "").includes("image/png"),
+    "static OG image is served as PNG"
   );
-  check(text.includes("<svg"), "static OG image contains SVG markup");
+
+  // The SVG source is still emitted (used as the PNG source and JSON-LD logo).
+  const svgUrl = pageUrl("/og/default.svg");
+  const { response: svgResponse, text: svgText } = await fetchText(svgUrl);
+  check(svgResponse.ok, "static OG SVG source is reachable");
+  check(svgText.includes("<svg"), "static OG SVG source contains SVG markup");
 }
 
 async function auditSitemap() {
@@ -92,7 +98,7 @@ function validateSeoDocument(url, text, sitemapPathSet) {
     `${pathname}: og:description exists`
   );
   check(Boolean(ogImage), `${pathname}: og:image exists`);
-  check(ogImage === pageUrl("/og/default.svg"), `${pathname}: og:image uses the shared static asset`);
+  check(ogImage === pageUrl("/og/default.png"), `${pathname}: og:image uses the shared static asset`);
   check(!ogImage.includes("/api/og"), `${pathname}: og:image does not use a runtime API`);
   check(rssFeed === expectedFeed, `${pathname}: rss alternate matches locale feed`);
   check(

--- a/test/scripts/sitemap-parity.mjs
+++ b/test/scripts/sitemap-parity.mjs
@@ -13,6 +13,9 @@ const retiredLegacySitemapPaths = new Set([
   "/tutorials/SUMMARY/",
   "/zh/tutorials/SUMMARY/"
 ]);
+// Legacy /blogs/** (and /zh/blogs/**) pages are served with robots: noindex, so
+// they are intentionally excluded from the app sitemap (see isSitemapExcludedRoute).
+const retiredLegacyBlogPattern = /^\/(?:zh\/)?blogs(?:\/|$)/;
 const expectedAppOnlyPaths = new Set([
   "/about/",
   "/products/",
@@ -38,10 +41,15 @@ function check(condition, message) {
 async function main() {
   console.log(`Comparing sitemap parity for ${baseUrl.toString()}`);
 
+  const legacySitemapPathnames = readLocalSitemapPaths(legacySitemapPath).map(
+    (url) => new URL(url).pathname
+  );
+  const retiredPaths = new Set([
+    ...retiredLegacySitemapPaths,
+    ...legacySitemapPathnames.filter((pathname) => retiredLegacyBlogPattern.test(pathname))
+  ]);
   const legacyPaths = new Set(
-    readLocalSitemapPaths(legacySitemapPath)
-      .map((url) => new URL(url).pathname)
-      .filter((pathname) => !retiredLegacySitemapPaths.has(pathname))
+    legacySitemapPathnames.filter((pathname) => !retiredPaths.has(pathname))
   );
   const { response, paths } = await fetchSitemapPaths();
   check(response.ok, "target sitemap is reachable");
@@ -53,7 +61,7 @@ async function main() {
   const compatibleGrowth = extra.filter((pathname) => datedBlogRoutePattern.test(pathname));
   const expectedGrowth = extra.filter((pathname) => expectedAppOnlyPaths.has(pathname));
   const missingExpectedGrowth = [...expectedAppOnlyPaths].filter((pathname) => !appPaths.has(pathname)).sort();
-  const retiredStillPublic = [...retiredLegacySitemapPaths].filter((pathname) => appPaths.has(pathname)).sort();
+  const retiredStillPublic = [...retiredPaths].filter((pathname) => appPaths.has(pathname)).sort();
 
   check(missing.length === 0, `all legacy sitemap paths exist in app sitemap (${missing.length} missing)`);
   check(
@@ -67,7 +75,7 @@ async function main() {
   console.log(`App-only sitemap paths: ${extra.length}`);
   console.log(`Compatible dated blog paths: ${compatibleGrowth.length}`);
   console.log(`Expected app-only paths: ${expectedGrowth.length}`);
-  console.log(`Retired legacy sitemap paths: ${retiredLegacySitemapPaths.size}`);
+  console.log(`Retired legacy sitemap paths: ${retiredPaths.size}`);
 
   if (missing.length) {
     for (const pathname of missing.slice(0, 50)) {


### PR DESCRIPTION
## Summary

Fixes two technical-SEO problems, validated against a production static export (`NEXT_PUBLIC_SITE_URL=https://eunomia.dev`).

> Note: this PR originally also added a `canonical_url` to the dev.to/Medium syndication payload in `.github/publisher/publish.py`. That change was reverted (see commit "Revert publisher canonical_url change") because the receiving service (`yunwei37/media-publisher`, `pages/api/publish-multi.ts`) only accepts `{title, content, tags, is_draft, platforms}` and silently ignores `canonical_url`, making the client-side field dead code. It will be redone as a minimal change once a media-publisher PR adds support for the field.

### 1. og:image is now a rasterized PNG (was SVG)
Social platforms (Slack, Twitter/X, Facebook, LinkedIn, Discord) do not render SVG Open Graph cards, so shared links showed no preview image. The shared OG SVG is now rasterized to a 1200x630 PNG at build time via `@resvg/resvg-js` (already a dependency on `main`), and `og:image` / `og:image:type` point at the PNG.
- `app/lib/seo.ts`: `STATIC_OG_IMAGE_PATH` -> `/og/default.png`
- `app/components/SeoHead.tsx`: `og:image:type` -> `image/png`
- `app/scripts/generate-static-metadata.ts`: renders `og/default.png` from the SVG source (SVG still emitted for the PNG source and JSON-LD logo)
- The generated PNG is build output, so it is gitignored alongside `default.svg` rather than committed (`.gitignore`, `assert-content-artifacts.mjs`, `clean-generated-output.mjs`)

### 2. Sitemap consistency with the noindex policy
Legacy `/blogs/**` and `/zh/blogs/**` pages are served `robots: noindex,follow`, yet still appeared in `sitemap.xml`. `isSitemapExcludedRoute` now excludes them (`app/lib/content/manifest.ts`), and the `http-audit`/`sitemap-parity` scripts plus `content.test.ts` assert the PNG og:image and the noindex blog exclusions.

## Validation

- `npm ci` clean install (Node 22)
- `npm run verify` passes (lint, typecheck, content tests, link crawl, runtime/static-export audit)
- `NEXT_PUBLIC_SITE_URL=https://eunomia.dev npm run build` succeeds
- Exported HTML head: `og:image` = `https://eunomia.dev/og/default.png` on 645 pages, 0 pages still reference the SVG, `og:image:type` = `image/png`
- `out/og/default.png` present with valid PNG magic bytes (`89504e47...`)
- `out/sitemap.xml` contains 0 `/blogs/` entries

## Notes on the recovered diff

- Dropped the `app/package.json` + `app/package-lock.json` edits from the original interrupted work: `main` already added `@resvg/resvg-js@^2.6.2`, so those hunks were redundant.
- The interrupted work left the generated `og/default.png` (and `default.svg`) as untracked binaries; these are build artifacts, so this PR gitignores the PNG instead of committing it (consistent with how `default.svg` was already handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2bjXhUX2DqEm87VK3S2tF