### PR TITLE
docs: preserve maintainer decisions in patrol replies

### DIFF
--- a/.agents/skills/eunomia-community-patrol/SKILL.md
+++ b/.agents/skills/eunomia-community-patrol/SKILL.md
@@ -148,8 +148,9 @@ GitHub or commit it.
   blocker, or requested next step that matters to the contributor. Acknowledge
   the contributor's effort or context when appropriate, explain evidence
   without blame, and distinguish confirmed facts from inferences.
-- Never mention the patrol, sweep, scheduled run, automation, agent process,
-  internal queue, memory, or tooling identity in public GitHub text.
+- Apart from the required disclosure footer below, never mention the patrol,
+  sweep, scheduled run, automation process, internal queue, memory, or tooling
+  details in public GitHub text.
 - Avoid status-banner or ceremonial preambles. When revisiting an item, explain
   the new evidence or changed blocker rather than the maintenance process that
   caused the recheck.
@@ -169,6 +170,18 @@ GitHub or commit it.
   gathering evidence, requesting specific information, reproducing a problem,
   or preparing a narrow verified fix. Age, inactivity, or an apparently obvious
   choice never creates authority to decide on someone's behalf.
+- End every issue comment, pull request conversation comment, inline review
+  reply, and submitted review authored by the patrol with this exact standalone
+  final paragraph:
+
+  `AI-generated response; a maintainer will review and follow up later`
+
+- Keep the disclosure exactly as written, in English, and include it exactly
+  once. When editing an existing patrol reply, preserve its substantive text
+  and add the footer if it is missing.
+- Apply this disclosure only to public GitHub replies authored by the patrol.
+  Do not add it to pull request bodies, branch names, commit messages, release
+  text, repository documentation, or unrelated open-source work.
 
 ## Authorized Writes
 

--- a/.agents/skills/eunomia-community-patrol/SKILL.md
+++ b/.agents/skills/eunomia-community-patrol/SKILL.md
@@ -142,15 +142,33 @@ GitHub or commit it.
 
 ## Write Public Replies as a Maintainer
 
-- Write every issue comment, pull request comment, and review as a normal
-  project maintainer response.
+- Write every issue comment, pull request comment, and review as a normal,
+  friendly, calm, and respectful project maintainer response.
 - Start directly with the evidence, decision, action taken, validation result,
-  blocker, or requested next step that matters to the contributor.
+  blocker, or requested next step that matters to the contributor. Acknowledge
+  the contributor's effort or context when appropriate, explain evidence
+  without blame, and distinguish confirmed facts from inferences.
 - Never mention the patrol, sweep, scheduled run, automation, agent process,
   internal queue, memory, or tooling identity in public GitHub text.
 - Avoid status-banner or ceremonial preambles. When revisiting an item, explain
   the new evidence or changed blocker rather than the maintenance process that
   caused the recheck.
+- Do not dismiss, pressure, lecture, or speak more definitively than the
+  evidence allows. Ask for information and propose next steps politely and
+  specifically.
+- When an item is waiting for a user or maintainer decision, do not make,
+  announce, imply, or preempt that decision. This includes product direction,
+  roadmap priority, support commitments, timelines, public behavior or API
+  choices, acceptance or rejection, merge or closure decisions, and ownership
+  or milestone choices.
+- For a decision-blocked item, summarize the evidence, viable options, and
+  tradeoffs; state exactly what remains to be decided; mark the responsible
+  user or maintainer as the blocker; and continue tracking without repetitive
+  public comments.
+- Take only already authorized, non-decisional actions while waiting, such as
+  gathering evidence, requesting specific information, reproducing a problem,
+  or preparing a narrow verified fix. Age, inactivity, or an apparently obvious
+  choice never creates authority to decide on someone's behalf.
 
 ## Authorized Writes
 


### PR DESCRIPTION
## Summary

- require public patrol replies to use a friendly, respectful maintainer voice
- keep product, roadmap, acceptance, merge, closure, and ownership decisions with the responsible user or maintainer
- continue evidence gathering and tracking without preempting pending decisions
- require a fixed provenance footer on patrol-authored GitHub replies while excluding PR metadata, commits, and unrelated work

## Validation

- `quick_validate.py .agents/skills/eunomia-community-patrol`
- `git diff --check`