### PR TITLE
Rewrite parallel agent research for human readers

### DIFF
--- a/.agents/skills/blog-writing-style/SKILL.md
+++ b/.agents/skills/blog-writing-style/SKILL.md
@@ -1,36 +1,88 @@
 ---
 name: blog-writing-style
-description: Define the finished prose style for English and Chinese eunomia.dev blog posts. Use when writing or reviewing reader comfort, natural rhythm, technical tone, and recurring sentence-level AI tells. This skill does not define article content or workflow.
+description: Define the finished prose style for English and Chinese eunomia.dev blog posts and Research pages. Use when writing or reviewing reader comfort, natural rhythm, technical tone, research readability, and recurring sentence-level AI tells. This skill does not choose the topic or evidence.
 ---
 
 # Blog Writing Style
 
 Judge the finished prose by one outcome: a technically qualified human reader
-can read it comfortably once, without reconstructing missing premises or
-fighting mechanical language.
+can read it comfortably once, understand the argument, and explain the main
+decision without reconstructing missing premises.
 
-This is a style reference, not a content specification. Do not use it to choose
-the topic, thesis, evidence, structure, length, citations, figures, or workflow.
-Examples identify patterns, not forbidden strings or sentence-shape quotas.
+This is a style reference, not a source or workflow specification. Examples
+identify failure patterns, not banned words or sentence-shape quotas.
+
+## Human Reader First
+
+- Write for a domain-aware engineer, researcher, or maintainer who has not read
+  the source corpus.
+- Establish the concrete situation, actor, state change, and consequence before
+  introducing a taxonomy, formal model, or coined abstraction.
+- Make the title and description understandable without prior knowledge of a
+  paper, project, or invented term.
+- Within the opening screen, tell the reader what problem exists, why it matters,
+  and what the article argues.
+- A report may be deep without sounding like a paper abstract. Academic quality
+  comes from evidence and reasoning, not compressed terminology.
+- Organize sections around questions the reader needs answered, not around the
+  order in which sources were discovered.
+- A long article should remain selective. Include detail that changes the
+  reader's model or decision; remove detail that only proves the author read many
+  sources.
+
+## Progressive Disclosure
+
+Use this order when it fits the subject:
+
+1. a concrete situation or failure;
+2. the incomplete mental model that made it possible;
+3. the mechanism;
+4. the design or decision that changes;
+5. evidence, implementation detail, and alternatives;
+6. limits and falsification.
+
+Do not front-load a dense comparison table, a list of runtime names, equations,
+or a newly named property. Introduce these only after the reader knows what they
+explain.
+
+When a formal definition is useful, first explain the same idea in ordinary
+language and with an example. Define every symbol locally. If removing the
+notation does not reduce precision, remove it.
+
+## Terms And Abstractions
+
+- Use the fewest terms needed to carry the argument.
+- Define a term before relying on it. A coined term should name a pattern the
+  reader has already seen, not create the appearance of novelty.
+- Prefer one stable term to several near-synonyms.
+- Do not make adjacent headings stacks of English nouns or unexplained
+  abstractions.
+- Avoid paragraphs containing several new terms at once. Introduce one idea,
+  show its consequence, then continue.
+- After a dense technical section, give the reader a plain-language implication
+  before moving on.
+- Source names support the argument; they do not substitute for it. Do not write
+  a paper-by-paper parade.
 
 ## Reading Experience
 
 - Write clear, natural, technically serious prose rather than notes, an
   abstract, a benchmark ledger, or promotion copy.
-- Give the intended reader enough local context to follow the next sentence
-  without guessing a necessary term, premise, or change of subject. Do not turn
-  this outcome into a prescribed introduction.
+- Give enough local context for the next sentence without forcing the reader to
+  infer a necessary premise or a change of subject.
 - Let each thought lead naturally to the next. Use transitions that express the
-  real relationship instead of announcing another item.
+  actual causal, conditional, or contrasting relationship.
 - Prefer concrete actors, actions, comparisons, and consequences over abstract
-  labels such as “the result,” “the study,” or “the advantage.”
+  labels such as "the result," "the study," or "the advantage."
 - Keep the tone professional and restrained. Avoid hype, exaggerated urgency,
   empty drama, self-congratulation, and academic ceremony.
+- A strong paragraph usually contains a claim, the mechanism or evidence behind
+  it, and the consequence for the reader.
 
-## Paragraphs and Sentences
+## Paragraphs And Sentences
 
-- Develop one coherent thought in a paragraph. Do not place several unrelated
-  fact cards next to each other.
+- Develop one coherent thought in a paragraph. Do not place unrelated fact cards
+  next to each other.
 - Let paragraph and sentence length follow the thought. A page of equally sized
   paragraphs or uniformly short sentences feels mechanical.
 - Keep a condition, contrast, cause, and consequence connected when they form
@@ -38,56 +90,68 @@ Examples identify patterns, not forbidden strings or sentence-shape quotas.
 - Do not repair choppy prose by joining unrelated facts with semicolons or
   colons.
 - Do not begin several adjacent paragraphs with the same abstract topic-sentence
-  shape. A clear topic sentence may remain when it helps orientation.
+  shape.
 - Do not replace one repeated pattern with another row of rhetorical questions,
   presenter cues, number-led openings, or forced transitions.
-- Avoid repeated openings such as “The study…,” “The result…,” “This shows…,”
-  and “Furthermore…” when a concrete subject can carry the sentence.
+- Avoid repeated openings such as "The study," "The result," "This shows," and
+  "Furthermore" when a concrete subject can carry the sentence.
 - Do not build several adjacent claims from repeated negative constructions such
-  as “is not,” “does not,” “cannot,” `不是`、`没有`、`不意味着`、`并不`、
-  `不能`. When the reader needs the positive condition, capability, relationship,
-  or boundary, state it directly. Keep a negative construction when the contrast
-  or limitation itself carries the meaning.
-- Do not end a section by merely restating it.
-- Do not use em dashes in blog prose.
+  as "is not," "does not," or `不是`、`没有`、`不意味着`、`并不`、`不能`.
+  State the positive requirement or relationship when that is what the reader
+  needs.
+- Do not end a section by merely restating its first sentence.
+- Do not use em dashes in public prose.
+
+## Tables, Lists, And Diagrams
+
+- Use a table only when every row is compared on the same dimensions.
+- Do not use a table to compress explanations that readers need in prose.
+- Introduce what a diagram is meant to show before the diagram appears.
+- A list should make a real set or sequence visible. Do not turn every paragraph
+  into bullets.
+- In a research article, one recurring scenario is often more useful than many
+  disconnected examples.
 
 ## Recurring Failure Patterns
 
 `The kernel sees a write. The harness sees a tool call. Neither can decide.`
 
-This breaks one contrast-and-consequence chain into presentation notes. When it
-is one thought, keep the relationship connected.
+This breaks one contrast-and-consequence chain into presentation notes. Keep the
+relationship connected when it is one thought.
 
 `研究给出了分类。结果很明显。这进一步说明了方案的优势。`
 
 These sentences have no concrete object or progression and could be reordered
 without changing their meaning.
 
-A sequence such as `跨事件策略反复出现为四类关系。`、
-`上下文依赖让强制执行更难落地。`、`两类难点会叠加。` feels mechanical
-because the adjacent paragraphs repeat one abstract opening. Any individual
-sentence may still be useful.
+`并行 Agent 需要 contract-valid effect serializability。它还需要 semantic
+resource discovery、authority revalidation 和 global outcome contract。`
 
-Replacing every such opening with `看看这些跨事件策略长什么样。` or
-`那这套强制执行实际表现如何？` creates a different template. Variety should
-follow the thought, not a rotation rule.
+This asks a Chinese reader to decode several undefined English abstractions
+before seeing the problem. Start with a concrete failure, explain what must be
+checked, and introduce a formal name only if it remains useful.
+
+A sequence such as `跨事件策略反复出现为四类关系。`、`上下文依赖让强制执行更难
+落地。`、`两类难点会叠加。` feels mechanical because adjacent paragraphs repeat
+one abstract opening. Any individual sentence may still be useful.
 
 `代码能编译，并不意味着它选对了目标，也不意味着它不会引入开销。`
 
-This makes the reader recover the real claim through three negatives. When the
-intended point is a requirement, state it directly: `成功的调优还需要明确目标、
-控制开销，并在测试中保持稳定。` The individual words are not banned; the
-failure is using repeated negation as the default argumentative rhythm.
+This makes the reader recover the real claim through repeated negation. When the
+point is a requirement, state it directly: `成功的调优还需要明确目标、控制开销，
+并在测试中保持稳定。`
 
-## Tone and Diction
+## Tone And Diction
 
-- Avoid empty judgments such as “a major breakthrough,” “the advantage is
-  clear,” “further validates the superiority,” and “truly changes everything.”
+- Avoid empty judgments such as "a major breakthrough," "the advantage is
+  clear," "further validates the superiority," and "truly changes everything."
 - Do not manufacture surprise, uncertainty, failure, or personal experience to
   make generated prose sound human.
 - State real limitations plainly, without apology or self-attack.
-- Prefer direct verbs and specific nouns. Cut filler such as “it is important to
-  note that,” “in order to,” “due to the fact that,” and “with respect to.”
+- Prefer direct verbs and specific nouns. Cut filler such as "it is important to
+  note that," "in order to," "due to the fact that," and "with respect to."
+- Do not use the tone of a peer-review response in a public article. The reader
+  needs the argument, not ceremonial claims of novelty.
 
 ## English
 
@@ -95,52 +159,54 @@ failure is using repeated negation as the default argumentative rhythm.
 - Prefer active constructions when the actor matters, without forcing every
   sentence into active voice.
 - Avoid nominalized prose when a direct verb is clearer.
-- Keep modifiers close to the words they qualify. Long sentences are welcome
-  when their clauses form one easy-to-follow thought.
+- Keep modifiers close to the words they qualify.
+- Spell out the practical meaning of a formal property before naming it.
 - Use straight quotation marks for English prose and code literals.
 
 ## Chinese
 
-- Write Chinese as Chinese. The finished article should not read like an English
-  paragraph translated clause by clause or preserve line-level symmetry with an
-  English version. Sentence and paragraph boundaries may differ.
-- Do not place a full stop after every short clause. Join a connected setup,
-  contrast, condition, mechanism, and consequence with natural Chinese.
-- Use Chinese for ordinary prose. English is appropriate for proper nouns and
-  product names; recognized terms of art without a clear Chinese rendering;
-  code, commands, paths, filenames, and identifiers; and metric acronyms.
-- Put code, commands, paths, filenames, and identifiers in backticks. Expand a
-  metric acronym in Chinese on first use when a verified expansion is useful;
-  never guess its meaning from the letters.
-- Translate ordinary concepts consistently. Add the English original on first
-  use only when readers need the source terminology for recognition or search;
-  do not turn prose into a parenthetical glossary.
-- Use `AI Agent` or `AI 智能体` consistently for the general role, whichever
-  reads more naturally in the article. Avoid `AI 编程 agent` and
-  `AI 编程助手` unless that narrower distinction is essential.
-- Do not mix English verbs or ordinary nouns into Chinese clauses, splice an
-  English clause into a Chinese sentence, or begin a Chinese sentence with an
-  English common noun when a natural Chinese subject exists.
-- Render table headers in Chinese except for proper nouns, code identifiers, and
+- Write Chinese as Chinese. Do not preserve English sentence and paragraph
+  boundaries or translate clause by clause.
+- Use Chinese for ordinary prose. English is appropriate for proper nouns,
+  identifiers, code, paths, recognized terms of art without a clear translation,
+  and useful search terms on first mention.
+- When a term has a clear Chinese explanation, give the Chinese explanation
+  first and the English original in parentheses only when useful.
+- Do not write a Chinese sentence whose grammatical load is carried mostly by
+  English nouns.
+- Use `AI Agent` or `AI 智能体` consistently for the general role.
+- Put code, commands, paths, filenames, and identifiers in backticks.
+- Render table headers in Chinese except for proper nouns, identifiers, and
   established acronyms.
-- Render English quotations in natural Chinese. Keep the original only when its
-  exact wording matters.
+- Render English quotations in natural Chinese unless exact wording matters.
 - Use full-width punctuation in Chinese prose and half-width punctuation inside
-  code, paths, commands, and quoted English.
-- Use matching Chinese quotation marks for Chinese quotations and straight
-  quotes for code literals. Do not turn `"git"` into `“git”`.
+  code and identifiers.
 - Keep a half-width space between Chinese characters and Latin letters or
   digits, such as `64 个仓库` and `eBPF 程序`.
-- Avoid calques such as `每系统调用开销` and repeated abstract subjects such as
-  `论文`、`研究`、`这些发现`、`该评测` when the sentence can name the actual
-  mechanism, workload, measurement, or consequence.
+- Avoid calques and repeated abstract subjects such as `论文`、`研究`、`这些发现`
+  when the sentence can name the actual mechanism, workload, measurement, or
+  consequence.
 
 ### Chinese Style Anchor
 
-Use this kind of Chinese technical-blog rhythm as a positive anchor:
+Use this kind of Chinese technical rhythm as a positive anchor:
 
 > 基于 Wasm，我们可以使用多种语言构建 eBPF 应用，并以统一、轻量级的方式管理和发布。以我们构建的示例应用 `bootstrap.wasm` 为例，大小仅为约 90K，很容易通过网络分发，并可以在不到 100ms 的时间内在另一台机器上动态部署、加载和运行，同时保留轻量级容器的隔离特性。运行时不需要内核头文件、LLVM、clang 等依赖，也不需要做任何消耗资源的重量级编译工作。
 
 The example reads naturally because related clauses stay together, sentence
-length changes with the thought, and each full stop lands after a complete
-claim. Treat it as a rhythm reference, not a required content pattern.
+length follows the thought, and each full stop lands after a complete claim.
+Treat it as a rhythm reference, not a required content pattern.
+
+## Final Reader Test
+
+Before publishing, read only the title, description, opening, headings, and
+conclusion. A qualified reader should be able to answer:
+
+- What concrete problem does this article address?
+- Why do existing mechanisms leave a gap?
+- What decision or design does the article recommend?
+- Where does the recommendation stop applying?
+- Which one or two terms are worth remembering?
+
+If those answers require reading the references or decoding several coined
+terms, rewrite the article.

--- a/.agents/skills/eunomia-research-report/SKILL.md
+++ b/.agents/skills/eunomia-research-report/SKILL.md
@@ -1,28 +1,84 @@
 ---
 name: eunomia-research-report
-description: Research and draft source-grounded Eunomia weekly analysis reports. Use when Codex needs to analyze broad AI, Agent, and infrastructure change; synthesize papers, industry and open-source projects, and other primary material; select a topic and thesis only after research; create a substantial deep report; or continue a report invoked by eunomia-content-patrol. This skill prepares and validates local drafts but does not authorize final publishing.
+description: Research and draft source-grounded Eunomia research briefs and weekly analysis reports for technically qualified human readers. Use when Codex needs to analyze broad AI, Agent, and infrastructure change; use platform Deep Research as an input; synthesize primary papers, official documentation, open-source artifacts, and deployment evidence; select a thesis only after research; or revise an existing Research page that is accurate but difficult to read. This skill prepares and validates drafts but does not authorize final publishing.
 ---
 
 # Eunomia Research Report
 
-Research current technical change before choosing a thesis, then write a
-substantial public report whose length is earned by evidence and analysis.
+Research first, choose a defensible thesis, then write a report that a human
+technical reader can understand in one pass.
+
+Academic quality comes from evidence, reasoning, scope, and falsifiability. It
+does not come from paper-like tone, term density, formal notation, or a long
+related-work section.
 
 ## Required Context
 
 Read these before acting:
 
 - `CLAUDE.md`
-- rolling publication queue: `draft/plan/publishing-queue.zh.md`
+- `.agents/skills/blog-writing-style/SKILL.md`
+- rolling publication queue: `draft/plan/publishing-queue.zh.md`, when relevant
 - today's media workspace and run log, if present:
   `draft/media/YYYY-MM-DD/` and `draft/media/YYYY-MM-DD/run-log.md`
+- existing Research pages under `docs/research/`
 - previous reports under `draft/media/` and `docs/reports/` when checking topic
   duplication
 - `references/research-method.md`
+- `docs/papers/registry.yaml` only after a candidate thesis exists
 
 This skill may be invoked directly or by `eunomia-content-patrol`. The patrol
-decides when research work belongs in the daily operating loop; this skill owns
-the research, topic selection, report drafting, and report QA.
+decides when research work belongs in the operating loop; this skill owns
+research, topic selection, drafting, and report QA.
+
+## Output Modes
+
+Choose the output mode before drafting.
+
+### Research brief
+
+Use `docs/research/<topic>.md` and a paired Chinese or English page when the work
+is intended for the public `/research/` section.
+
+A Research brief has a stable question, a durable URL, an explicit evidence
+cutoff, and a claim that can be revised when later evidence changes. It is not a
+daily news post and should not be created merely because a scheduled run needs
+an output.
+
+### Weekly analysis
+
+Use `draft/media/YYYY-MM-DD/<topic-slug>/deep-report.zh.md` for the scheduled
+weekly analysis workflow. The draft is handed back to the publishing workflow
+after validation.
+
+## Reader Contract
+
+The intended reader is a technically qualified engineer, researcher, or
+maintainer who understands the broad domain but has not read the source corpus.
+
+The public report must satisfy all of these conditions:
+
+- The title and description are understandable without knowing a coined term.
+- Within the first 250 English words or 500 Chinese characters, the reader can
+  state the concrete problem, who experiences it, why it matters, and the
+  report's main claim.
+- The article shows a concrete end-to-end scenario before introducing a
+  taxonomy, formal property, or new abstraction.
+- A named abstraction appears only after the reader has seen the failure it
+  explains.
+- Ordinary prose uses the reader's language. English terms appear only when
+  they are established terms of art, identifiers, or useful search terms.
+- The argument is organized by reader questions and engineering decisions, not
+  by the order in which sources were discovered.
+- Formal notation is optional. When used, it follows an intuitive explanation,
+  defines every symbol locally, and adds precision that prose alone cannot.
+- Tables compare one clear dimension. Do not place a dense runtime or
+  related-work matrix in the opening third of the article.
+- A long report remains selective. It explains the evidence that changes the
+  conclusion instead of listing everything reviewed.
+
+A technically correct article that fails this contract is not publication
+ready.
 
 ## Workflow
 
@@ -32,156 +88,215 @@ Begin with a wide editorial direction such as current AI, Agent, or systems
 infrastructure. Do not decide the thesis, preferred conclusion, or relationship
 to Eunomia projects before searching.
 
-### 2. Build The Weekly Research Corpus
+When revising an existing article for readability, preserve its evidence and
+central question only if they remain defensible. Do not protect its title,
+section order, coined terminology, or formal model merely because they already
+exist.
 
-Cover the latest seven days, with the latest 48 hours receiving first attention.
-Use the wider 7-30 day window for mechanisms, contradictions, deployments, and
-context. Follow the source families in `references/research-method.md`.
+### 2. Build The Research Corpus
 
-Before drafting a scheduled weekly analysis, materially review at least:
+Cover the latest seven days when the task is current analysis, with the latest
+48 hours receiving first attention. Use the wider 7-30 day window for
+mechanisms, contradictions, deployments, and context. Use older primary sources
+for standards, prior art, and baselines.
+
+For a scheduled broad weekly analysis, materially review at least:
 
 - 20 distinct papers
 - 20 distinct industry or open-source projects
-- 10 distinct news or current-event sources published within the latest seven
-  days
+- 10 distinct current-event sources from the latest seven days
 
-Count independent sources, not reposts or several pages repeating one
-announcement. If the topic cannot support this corpus without padding, skip the
-report or choose a better-supported question. Older standards, documentation,
-datasets, and background material may strengthen the report but do not satisfy
-the 10-source current-news requirement.
+This numeric gate applies to the broad weekly scan, not automatically to every
+focused Research brief. A focused brief should use the smallest corpus that
+adequately supports its question, alternatives, and boundaries. Do not pad a
+brief to imitate a survey.
 
-Search broad AI, Agent, and infrastructure topics before narrowing. Include
-model serving and inference, training systems, GPU/runtime performance,
-observability, security, evaluation, developer tooling, eBPF, and open-source
-infrastructure when they carry current signal.
+Count independent sources, not reposts or multiple pages repeating one
+announcement.
+
+### 3. Use Platform Deep Research Correctly
+
+When the user asks for platform Deep Research, or when it is available and
+materially useful, use it for discovery and source synthesis.
+
+Treat the returned report as research input, not publishable prose:
+
+- inspect the cited primary sources;
+- verify dates, metrics, scope, and quoted conclusions;
+- remove unsupported extrapolation;
+- compare the result with existing Eunomia content;
+- rebuild the argument for the intended human reader;
+- do not preserve the tool's outline, phrasing, or source-by-source structure by
+  default;
+- never label a page as produced by Deep Research unless a complete report was
+  actually returned and used.
+
+If the platform report is unavailable or incomplete, say so in the work record
+and continue only with sources that can be verified directly.
+
+### 4. Search Efficiently And Verify Selectively
+
+Use web search, feeds, paper indexes, official release pages, repository search,
+and public project pages for discovery. Search snippets, aggregators,
+newsletters, and reposts identify leads but do not support factual claims by
+themselves.
+
+Open and read primary sources for serious candidates. Use official
+documentation for current product behavior and specifications. Use papers,
+code, datasets, issues, and first-person engineering reports for mechanisms and
+measured results.
 
 Distinguish the date of the underlying event from the article, repost, or
 indexing date.
 
-### 3. Search Efficiently And Verify Selectively
+### 5. Build The Signal Map
 
-Use web search, feeds, paper indexes, official release pages, repository search,
-and public project pages for discovery. Do not open an interactive browser for
-every result. Search snippets, aggregators, newsletters, and reposts identify
-leads but do not support factual claims by themselves.
+Capture serious candidates compactly with source type, primary URL,
+publication date, event date, concrete claim, evidence strength, limitation,
+and contradictory signal. Keep this in working context or the dated run log; do
+not create a public source-inventory artifact.
 
-Open and read primary sources for serious candidates. Before citing, quoting,
-or acting on a social post, inspect the public post and its context through the
-normal visible browser UI. Never use hidden platform APIs, background endpoints,
-or scraping datasets.
+Cluster candidates by mechanism, change, or tension rather than shared
+keywords. Generate candidate questions only after clustering.
 
-### 4. Build The Signal Map
+Before selecting a broad thesis, build the evidence lattice in
+`references/research-method.md`. Do not fill a missing role with a weak source
+merely to complete the pattern.
 
-Capture serious candidates compactly with source type, primary URL, publication
-date, event date, concrete claim, evidence strength, limitation, and any
-contradictory signal. Keep this in working context or the dated run log; do not
-create a visible source-inventory artifact.
+### 6. Form And Test The Thesis
 
-Cluster candidates by mechanism, change, or tension rather than shared keywords.
-Generate candidate research questions only after clustering. Compare candidates
-for timeliness, evidence independence, technical consequence, disagreement, and
-reader usefulness.
+Choose a clear, contestable thesis only after the scan. It may support,
+qualify, contradict, or be unrelated to existing Eunomia projects.
 
-Before choosing a thesis, build the compact evidence lattice described in
-`references/research-method.md`. A broad report should normally combine a
-current event, academic or methodological evidence, an implementation or open
-technical artifact, and deployment or community evidence. Do not fill a missing
-role with a weak source merely to complete the pattern.
+Look for the strongest alternative explanation and evidence that could overturn
+the thesis. Narrow or discard a thesis that depends on one marketing claim, one
+repeated announcement, or social posts quoting each other.
 
-### 5. Form And Test The Thesis
+Then compare the candidate with existing Research pages, blog posts, and public
+papers. The central question, argument, or conclusion must be materially
+different. A new headline, product, example, or coined term does not create a
+new thesis.
 
-Choose a clear, contestable thesis only after the scan. It may support, qualify,
-contradict, or be unrelated to existing Eunomia projects and editorial views.
+Repository-owned work is one evidence node, not the destination of the
+argument. Apply the same evidence and caveat standards to it as to outside work.
 
-Before drafting, look for the strongest alternative explanation and evidence
-that could overturn the thesis. Narrow or discard a thesis that depends on one
-marketing claim, one repeated press release, or social posts quoting each other.
+### 7. Design The Reader Path Before Drafting
 
-Only after the thesis is formed, check `docs/papers/registry.yaml`, related
-public papers, projects, and existing Eunomia posts. The selected thesis must be
-materially different from existing articles in its central question, argument,
-or conclusion. A new headline, news hook, product, or example alone does not
-make it a new thesis. Apply the same evidence and caveat standards to
-repository-owned and outside work. Include repository-owned work only when it
-adds a mechanism, measurement, implementation,
-counterexample, or clearly bounded exploration. Make its evidentiary role clear
-enough that the reader can distinguish a measured finding, the report's
-interpretation, a design response, and a project result. Mention provenance
-when omitting it would mislead, but do not add an affiliation detour. Omit the
-connection when it is not useful, and do not add a promotional project roundup,
-call to action, or forced tie-back.
+Before writing paragraphs, be able to answer these questions in plain language:
 
-### 6. Draft The Public Report
+1. What concrete situation makes this problem visible?
+2. What does the reader probably believe today?
+3. Where does that model fail?
+4. What decision should change?
+5. What evidence supports and challenges the change?
+6. Where does the conclusion stop applying?
 
-Create the working report at:
+Use one recurring scenario when possible. Revisit it as the article introduces
+mechanisms and design choices.
 
-`draft/media/YYYY-MM-DD/<topic-slug>/deep-report.zh.md`
+Prefer this progression unless the subject needs another natural order:
 
-Give it a stable `report_id`, research question, research window, source cutoff
-date, status, thesis, and ordinary public `tags`. Reports produced by the weekly
-research workflow use `weekly-analysis`, `research`, and a small number of
-precise topic tags. Prefer established reader-facing names such as `eBPF`, `AI Agent`,
-`Agent Infrastructure`, `Observability`, `Security`, `Linux`, and `Open Source`.
-Use a topic tag only when the article materially covers it. Make the latest
-48-hour developments identifiable in the report while using older sources only
-where they add mechanism, prior art, baseline, or contradiction.
+- concrete situation and stakes;
+- the mistaken or incomplete mental model;
+- two or three failure mechanisms;
+- what existing mechanisms solve and leave open;
+- the proposed design or decision;
+- evidence and implementation details;
+- evaluation, limitations, and falsification.
 
-Use the editorial functions in `references/research-method.md` without turning
-them into a rigid heading checklist. Keep the evidence chain in the article and
-the raw browsing process out of it.
+Do not start with an abstract, a source matrix, a taxonomy, a formula, or the
+name of a new system property.
 
-End a Chinese report with `## 参考资料`. List only primary papers, datasets,
-standards, repositories, official technical documentation, or first-person
-engineering material that the argument actually uses. Product names may appear
-where they identify evidence, but the future-tracking section should normally
-name technical questions and capabilities rather than vendors or products.
+### 8. Draft The Public Report
 
-### 7. Review For Publication Value
+For a Research brief, include frontmatter with:
+
+- date
+- reader-facing title
+- description
+- precise public tags
+- research question
+- source cutoff
+- review status
+
+For a weekly report, include its stable `report_id`, research window, cutoff,
+status, thesis, and tags.
+
+Apply `blog-writing-style` to both modes. In particular:
+
+- write Chinese as Chinese and English as idiomatic technical English;
+- define a technical term in plain language before relying on it;
+- prefer concrete actors, state changes, and consequences;
+- connect evidence to the claim it changes;
+- summarize a dense mechanism in ordinary language before moving on;
+- keep source process and browsing chronology out of public prose;
+- avoid a paragraph that contains several undefined abstractions;
+- do not make readers decode a sentence made mostly of English nouns inside
+  Chinese grammar.
+
+End a Chinese report with `## 参考资料`. List only sources that materially support
+the argument.
+
+### 9. Run The Human Readability Gate
+
+Read the complete article once as a domain-aware reader who has not seen the
+research notes.
+
+The draft fails if any answer below is unclear:
+
+- What is the problem in one sentence?
+- What real user or operator decision does the article change?
+- What is the main claim in ordinary language?
+- What are the two or three strongest pieces of evidence?
+- What would make the claim false?
+- Which terms must the reader remember, and are all of them necessary?
+
+Also check:
+
+- no title or early heading depends on unexplained jargon;
+- the opening contains a concrete situation rather than an abstract field
+  overview;
+- every major abstraction has a nearby example;
+- literature is synthesized by mechanism instead of reviewed source by source;
+- the first half is not dominated by tables, definitions, or formal notation;
+- headings form a readable argument when viewed alone;
+- Chinese prose is not a line-by-line translation of the English article;
+- the article can lose a technical term without losing the underlying idea;
+- the conclusion states the engineering judgment, not merely the article
+  structure.
+
+Rewrite when this gate fails. Do not treat grammar cleanup as sufficient.
+
+### 10. Review Evidence And Publication Value
 
 Check that:
 
-- the thesis emerged from the evidence and is not product advocacy by default
-- the central question, argument, or conclusion is materially different from
-  existing Eunomia articles
-- every central factual claim resolves to a primary or clearly labeled source
-- current events are separated from older context and republished material
-- independent sources are truly independent
-- each central inference is supported or challenged by at least two independent
-  source types when the scope of the claim requires cross-validation
-- a broad technical report includes academic evidence and a non-vendor
-  implementation, standard, dataset, or reproducible artifact
-- contradictions, uncertainty, and source limitations remain visible
-- analysis explains mechanism and second-order effects instead of summarizing
-- developer or operator implications follow from the evidence
-- repository-owned work, if used, follows the same evidence standard as an
-  outside source, has a clear and proportionate role in the argument, and does
-  not blur measured findings, interpretation, design, and project evaluation
-- the tracking section stays problem-led rather than reading like a product
-  watchlist, unless a named product is itself the report's subject
-- a weekly research report has the public `weekly-analysis` and `research` tags,
-  plus only the topic tags materially supported by the article
-- the reviewed corpus contains at least 20 papers, 20 industry or open-source
-  projects, and 10 other useful sources, with repeated coverage of one source
-  counted only once
-- the final Chinese source section is named `参考资料`
-- the report is materially different from previous report questions and theses
-- no private strategy, customer information, pricing plans, or unreleased work
-  entered the public repository
-- no em dash appears in public prose
+- the thesis emerged from evidence and is not product advocacy by default;
+- every central factual claim resolves to a primary or clearly labeled source;
+- independent sources are truly independent;
+- contradictions, uncertainty, and source limitations remain visible;
+- analysis explains mechanisms and second-order effects rather than summarizing;
+- practical implications follow from the evidence;
+- repository-owned work has a clear and proportionate role;
+- the public page does not expose private strategy, customer information,
+  pricing, or unreleased work;
+- the final Chinese source section is named `参考资料`;
+- no em dash appears in public prose;
+- links, frontmatter, Markdown, diagrams, and locale pairs are valid.
 
-Give the report enough room to synthesize the corpus, develop the mechanism,
-compare competing evidence, and explain practical consequences. Do not compress
-it into a news summary, and do not pad it with unused sources.
+Length follows the evidence and reader need. Do not compress a real argument
+into a news summary, and do not pad a report with unused sources, taxonomies, or
+notation.
 
-### 8. Record And Hand Back
+### 11. Record And Hand Back
 
 When a separate run record is useful, update
 `draft/media/YYYY-MM-DD/run-log.md` with the research window, source families
-checked, selected topic or "no defensible thesis", report path, and next
-concrete action. Do not create a monthly daily-log file. When invoked by
-`eunomia-content-patrol`, return control to that skill for platform adaptation,
-publishing authorization, and ledger work.
+checked, selected topic or `no defensible thesis`, report path, reader test
+result, and next concrete action.
+
+When invoked by `eunomia-content-patrol`, return control to that skill for
+platform adaptation, publishing authorization, and ledger work.
 
 This skill does not authorize a final publish, repost, comment, or other social
 action.

--- a/.agents/skills/eunomia-research-report/references/research-method.md
+++ b/.agents/skills/eunomia-research-report/references/research-method.md
@@ -1,183 +1,264 @@
 # Research Method
 
 Use this reference for source coverage, topic selection, evidence grading, and
-public report shape.
+the shape of a public report.
 
 ## Research Windows
 
-Cover the latest seven days to find current news, releases, papers, incidents,
-and discussion, reading the latest 48 hours first. Confirm both the publication
-date and the date of the underlying event. A new repost of an old result is not
-a new event.
+Use the latest seven days to find current releases, papers, incidents, and
+discussion when the assignment is time-sensitive. Read the latest 48 hours
+first, then widen to the previous 7-30 days for mechanisms, contradictions,
+deployments, and engineering context.
 
-Widen to the latest working day and then the previous 7-30 days for slow-moving
-research, engineering writeups, and context that has not yet reached broad
-discussion. Use older primary sources for mechanisms, prior art, baselines, and
-counterevidence.
+Use older primary sources for standards, prior art, baselines, and theory.
+Confirm both the publication date and the date of the underlying event. A recent
+repost of an old result is not a recent event.
 
-The seven-day window sets the reporting cadence, while the latest 48 hours set
-discovery priority. Neither is a freshness requirement for every citation.
+A durable Research brief does not need a news hook. Its source cutoff should
+still be explicit so later readers know which evidence the claim includes.
 
 ## Source Coverage
 
-For a scheduled weekly analysis, materially review at least 20 distinct papers,
-20 distinct industry or open-source projects, and 10 distinct news or
-current-event sources published within the latest seven days. A paper counts in
-the first group; a vendor system, production implementation, or open-source
-repository counts in the second. The third group exists to establish what
-changed during the reporting window. Older standards, datasets, documentation,
-and background material may strengthen the analysis but do not satisfy that
-current-news requirement. Count a source once even when several articles repeat
-it. Do not create a separate inventory artifact.
+For a scheduled broad weekly analysis, materially review at least:
 
-- **Academic research:** conference papers, journals, arXiv, workshop material,
-  datasets, benchmark papers, and author project pages.
-- **Engineering practice:** engineering blogs, architecture notes, postmortems,
-  performance studies, migration reports, and security disclosures.
-- **Commercial products:** official launches, release notes, documentation,
-  system cards, engineering-relevant pricing or limit changes, and concrete case
-  studies. Treat marketing claims as claims until corroborated.
+- 20 distinct papers
+- 20 distinct industry or open-source projects
+- 10 distinct current-event sources published within the latest seven days
+
+This gate exists to prevent a broad landscape report from being built from a
+small or repetitive sample. It does not apply mechanically to every focused
+Research brief. A focused brief should use enough primary evidence to establish
+the mechanism, the strongest alternative, and the boundary of the claim. Do not
+pad a narrow question with unrelated sources.
+
+Count a source only when it changes the analysis by adding a fact, mechanism,
+comparison, contradiction, adoption signal, failure, or useful question.
+Several articles repeating one announcement remain one piece of evidence.
+
+Useful source families include:
+
+- **Academic research:** conference papers, journals, arXiv papers, workshop
+  material, datasets, benchmarks, and author artifacts.
+- **Engineering practice:** architecture notes, postmortems, performance
+  studies, migration reports, and security disclosures.
+- **Official product material:** release notes, specifications, system cards,
+  and detailed documentation. Treat marketing metrics as claims until they are
+  independently supported.
 - **Open source:** repositories, releases, commits, issues, pull requests,
-  discussions, maintainer notes, adoption signals, and reproducible artifacts.
-- **Public institutions:** government agencies, standards bodies, foundations,
-  research laboratories, specifications, consultations, and regulatory notices.
-- **Social and community discussion:** LinkedIn, Xiaohongshu, X, Reddit, Hacker
-  News, Lobsters, Zhihu, Juejin, and public maintainer discussions. Use these to
-  find practitioner experience, disagreement, and emerging questions.
+  discussions, maintainer notes, and reproducible artifacts.
+- **Public institutions:** standards bodies, foundations, agencies, research
+  laboratories, and formal consultations.
+- **Community evidence:** public maintainer discussions and practitioner reports
+  that expose disagreement or operational friction.
 
-Every counted source must materially affect the report by adding a fact,
-mechanism, comparison, contradiction, adoption signal, real failure, or useful
-research question. If a source does not affect the analysis, it does not satisfy
-the corpus gate.
+Discovery sources such as newsletters, aggregators, and social posts are leads,
+not final support for factual claims.
 
 ## Evidence Lattice
 
-Before selecting a broad thesis, try to fill four different evidence roles:
+Before choosing a broad thesis, try to fill several independent evidence roles:
 
-- **Current change:** a recent release, paper, incident, policy change, or
-  measurable adoption event that explains why the question matters now.
-- **Academic or methodological evidence:** a paper, benchmark, dataset, or
-  systematic study that tests a mechanism, defines a construct, or exposes a
-  measurement boundary.
-- **Implementation evidence:** source code, a reproducible artifact, a standard,
-  an engineering report, or detailed technical documentation showing how the
-  mechanism is built or operated.
-- **Deployment evidence:** a postmortem, issue, maintainer discussion, user
-  report, or public community thread showing where the mechanism succeeds,
-  fails, or creates friction in practice.
+- **Current change:** a release, incident, paper, policy change, or adoption
+  event that explains why the question matters now.
+- **Mechanism evidence:** a paper, benchmark, dataset, or systematic study that
+  tests or defines the underlying mechanism.
+- **Implementation evidence:** source code, a standard, detailed documentation,
+  or a reproducible artifact showing how the mechanism is built.
+- **Deployment evidence:** a postmortem, issue, maintainer discussion, or
+  first-person report showing where the mechanism succeeds or fails.
+- **Counterevidence:** a result, workload, or explanation that would narrow or
+  overturn the thesis.
 
-A broad report should normally use at least three roles, including academic or
-methodological evidence and one non-vendor technical artifact. A narrow report
-may use fewer when one primary source directly answers the question. Never add a
-weak citation solely to satisfy a role.
+A broad report should normally use at least three roles, including mechanism
+evidence and one non-vendor technical artifact. A narrow report may use fewer
+when one primary source directly answers the question. Never add a weak citation
+solely to complete the pattern.
 
 ## Candidate Record
 
 For each serious candidate, capture:
 
 - title and primary URL
-- source family and source owner
+- source family and owner
 - publication date and underlying event date
 - concrete new fact or claim
 - available data, code, logs, or implementation detail
-- whether another source independently supports it
+- independent support
 - limitation, conflict of interest, or missing evidence
 - possible mechanism or tension
 - question it could help answer
 
-Keep this compact. The record is a research aid, not a public artifact.
+Keep this compact and private to the research process.
 
 ## Topic Selection
 
 A useful topic commonly has more than one of these properties:
 
-- independent sources point to the same underlying change
-- a new artifact or dataset makes a claim inspectable
-- research results and production experience disagree
-- a release changes what developers can build, operate, secure, or afford
-- a failure, limit, or second-order effect is missing from surface coverage
-- the evidence can change a reader's technical decision
+- independent sources point to the same underlying change;
+- a new artifact or dataset makes a claim inspectable;
+- research results and production experience disagree;
+- a release changes what developers can build, operate, secure, or afford;
+- a failure mode or second-order effect is missing from surface coverage;
+- the evidence can change a reader's technical decision.
 
-Prefer a narrower question with strong evidence over a broad trend supported by
-weak repetition. Do not choose a topic because it promotes a repository project.
+Prefer a narrow question with strong evidence over a broad trend supported by
+repetition.
 
-Compare the candidate with existing Eunomia articles before drafting. Its
-central question, argument, or conclusion must be materially different. A new
-headline, recent news hook, product, or example does not create a new thesis by
-itself.
+Compare the candidate with existing Eunomia Research pages and blog posts before
+drafting. The central question, argument, or conclusion must be materially
+different. A new headline, product, example, or named abstraction does not make
+a thesis new.
 
-## Evidence Roles
+## Evidence Roles And Attribution
 
 Prefer primary data, code, experiments, standards, official documentation, and
-first-person engineering reports for factual claims. Peer-reviewed work and
-method-complete preprints can establish mechanisms and measured results.
-Commercial pages and social posts can establish what an organization announced
-or what a practitioner observed, but not a broader fact without corroboration.
+first-person engineering reports. Peer-reviewed work and method-complete
+preprints can establish mechanisms and measured results. Commercial pages can
+establish what an organization announced, not a general fact without
+corroboration.
 
-Use multiple independent evidence clusters for a broad thesis when available.
-One decisive source can justify a narrow report, but source volume must not be
-mistaken for independence. Ten articles repeating one press release remain one
-piece of evidence.
+Cross-validate a central inference with independent source types when the claim
+extends beyond one source's own system. Look for agreement on mechanism rather
+than identical wording.
 
-Cross-validate each central inference with at least two independent source types
-when the claim extends beyond one source's own product or experiment. Look for
-agreement on mechanism, not identical wording. Record disagreement explicitly:
-a paper can challenge a product metric, an issue can expose an operational limit
-missing from documentation, and a standard can show which data remains portable.
+Place attribution near the claim it supports. A reference list is not a
+substitute for an evidence chain in the article.
 
 ## Repository-Owned Work
 
-After the thesis exists, inspect `docs/papers/registry.yaml`, public paper text,
+After a thesis exists, inspect `docs/papers/registry.yaml`, public paper text,
 project artifacts, and related Eunomia posts for genuinely relevant evidence.
-Use repository-owned work as one evidence node, never as the destination of the
-argument. In reader-facing prose, give it the same editorial distance as any
-third-party paper or project. Lead with the mechanism or result, name the work
-directly, and avoid first-person possessives, "our research," or explanations of
-its relationship to the repository. Usually one or two sentences inside the
-surrounding argument are enough. Link the source nearby, state its scope and
-limitations, and let independent evidence carry the broader claim. Omit the
-connection when it does not improve the reader's model. Expand only when the
-paper or project is itself the report's explicit subject.
 
-Do not create a dedicated promotional section, project roundup, call to action,
-or paragraph whose only purpose is to establish Eunomia's involvement.
+Use repository-owned work as one evidence node. Give it the same editorial
+distance, limitations, and verification standard as outside work. Avoid a
+dedicated promotional section or a forced tie-back to Eunomia products.
+
+Omit the connection when it does not improve the reader's model.
+
+## Human-Readable Synthesis
+
+The public article is not the research notebook and not the output of a search
+tool.
+
+Write for a technically qualified reader who knows the broad domain but has not
+read the source corpus. Build the article around the reader's decisions:
+
+1. show a concrete situation;
+2. explain why the obvious mental model fails;
+3. identify the mechanism;
+4. state the design or decision that changes;
+5. introduce evidence where it changes the argument;
+6. test alternatives and boundaries.
+
+Use one recurring scenario when possible. It gives the reader a stable object
+to revisit as the article moves from failure to mechanism and design.
+
+Do not start with:
+
+- a field overview;
+- a dense table of products or papers;
+- a source-by-source literature survey;
+- a taxonomy with no prior example;
+- a formula;
+- a coined term.
+
+A new abstraction should compress a pattern the reader already understands. If
+the reader must learn the term before seeing the problem, the order is wrong.
+
+### Titles And Openings
+
+A title should name the problem or decision in ordinary language. A subtitle or
+later section can introduce the formal term.
+
+Within the first 250 English words or 500 Chinese characters, establish:
+
+- the affected actor or system;
+- the concrete failure or unmet need;
+- why existing practice is insufficient;
+- the article's main claim.
+
+Do not use the opening to list credentials, sources, or claims of novelty.
+
+### Technical Depth
+
+Depth should appear as:
+
+- a causal mechanism;
+- a meaningful comparison;
+- a non-obvious consequence;
+- an architecture choice;
+- an evaluation that can distinguish alternatives;
+- an explicit condition that would falsify the claim.
+
+Term density, equations, and article length are not evidence of depth.
+
+Formal notation is optional. Use it after an intuitive explanation and only when
+it removes ambiguity. Define every symbol locally and explain what engineering
+decision the formalism changes.
+
+### Literature And Tables
+
+Synthesize literature by mechanism or disagreement. A paragraph should not exist
+merely to mention another paper.
+
+Use a table only when all rows share the same comparison dimensions. Put dense
+runtime or related-work tables after the reader understands the problem, not in
+the opening third.
+
+### Chinese And English
+
+Chinese and English versions share evidence and claims, not sentence boundaries.
+Write each version naturally.
+
+In Chinese prose, use Chinese for ordinary concepts. Include an English term on
+first mention when it is a recognized term of art or useful search key. Do not
+make a sentence's grammar depend on a stack of English nouns.
 
 ## Public Report Shape
 
-A public report should be independently readable and useful to a technical
-reader. It normally needs these editorial functions, but they do not have to be
-separate headings or appear in a rigid order:
+A report normally needs these editorial functions, but they do not have to be
+rigid headings:
 
-- a clear, contestable thesis
-- the most important facts and what changed recently
-- why the timing matters
-- an evidence chain grounded in primary material
-- the mechanism connecting the evidence
-- patterns, contradictions, and alternative explanations
-- original analysis, boundaries, and second-order effects
-- practical implications for developers or operators
-- uncertainty, falsification conditions, and questions to track next
+- a concrete problem and reader stakes;
+- a clear, contestable thesis in ordinary language;
+- the mechanism connecting the evidence;
+- what existing mechanisms solve and leave open;
+- a design, architecture, or decision consequence;
+- competing evidence and alternative explanations;
+- implementation or operational implications;
+- evaluation criteria;
+- uncertainty, applicability limits, and falsification conditions.
 
-Write future-tracking questions in capability or mechanism terms. Avoid a list
-of named products, vendors, or anticipated launches unless the report studies
-that product directly. Product names belong in the evidence chain when needed,
-not in a closing watchlist that reads like promotion.
+Long form is justified when the argument needs room. It is not a requirement to
+include every source reviewed.
 
-End Chinese reports with `## 参考资料`. A scheduled weekly report must account
-for the sources that materially informed it, including at least 20 papers, 20
-industry or open-source projects, and 10 other useful materials. Inline
-attribution still belongs beside the claim it supports. Do not inflate the list
-with unread or unused links.
+End Chinese reports with `## 参考资料`. List only sources materially used in the
+argument.
 
-Write a long-form analysis rather than a compressed news summary. Give the
-argument enough space to synthesize the required corpus, compare evidence,
-explain mechanisms, test alternatives, and derive practical consequences. There
-is no word-count quota; length follows the work the evidence requires. Never pad
-or cut solely to hit a number.
+## One-Pass Reader Test
+
+Before publication, read only the title, description, opening, headings, and
+conclusion. A qualified reader should be able to answer:
+
+- What problem is being solved?
+- Who experiences it?
+- What is the central claim?
+- What design or operational decision changes?
+- What evidence matters most?
+- What would make the claim false?
+
+Then read the full article once. Rewrite if the reader must:
+
+- remember several undefined terms;
+- reconstruct missing premises;
+- infer why a source was mentioned;
+- translate English-heavy Chinese clauses;
+- read a formal definition before seeing an example;
+- confuse a worker's local success with the workflow's final correctness.
 
 ## No-Report Outcome
 
 If the scan produces interesting links but no defensible thesis, do not draft a
-deep report. Record the source families checked, strongest unresolved question,
-and what future evidence would unblock it. A truthful no-report result is better
-than a topical summary disguised as analysis.
+deep report. Record the strongest unresolved question and the evidence that
+would unblock it. A truthful no-report outcome is better than a topical summary
+disguised as analysis.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,19 +1,19 @@
 ---
 title: Research
-description: "Source-grounded systems research briefs with testable claims, competing evidence, architecture consequences, explicit scope, and falsification conditions."
+description: "Source-grounded systems research briefs written for human technical readers, with testable claims, architecture consequences, explicit scope, and falsification conditions."
 ---
 
 # Research
 
-Eunomia Research publishes source-grounded systems briefs that develop a testable claim rather than summarize a news cycle. Each brief starts from a precise technical question, compares independent primary evidence, identifies tensions or alternative explanations, and states which architecture decision the conclusion would change.
+Eunomia Research publishes source-grounded systems briefs for engineers, researchers, and maintainers. Each brief starts from a concrete technical problem, develops a testable claim, compares independent primary evidence, and explains which architecture or engineering decision should change.
 
-These pages are reviewed research briefs, not peer-reviewed papers unless a page says otherwise. Claims remain bounded by their stated evidence, source cutoff, assumptions, and falsification conditions. When later evidence changes the conclusion, the stable page should be revised rather than replaced by a near-duplicate article.
+These pages are reviewed research briefs, not peer-reviewed papers unless a page says otherwise. Claims remain bounded by their evidence, source cutoff, assumptions, and falsification conditions. When later evidence changes a conclusion, the stable page should be revised instead of being replaced by a near-duplicate article.
 
 ## Current research
 
-### [Parallel Agents Need a Commit Protocol: From Effect Serializability to Contract-Valid Execution](https://eunomia.dev/research/parallel-agent-effect-serializability/)
+### [When Several AI Agents Work at Once, Who Makes Sure the Final Result Is Right?](https://eunomia.dev/research/parallel-agent-effect-serializability/)
 
-Parallel calls, worktrees, reducers, and serializable resource updates can still compose into a result that violates the user's task or stale authority. This brief audits current agent runtimes and proposes contract-valid effect serializability across code, APIs, budgets, approvals, and irreversible actions.
+Worktrees, sandboxes, and parallel tool calls can isolate workers while still producing a wrong combined outcome. This brief uses code changes, shared budgets, approvals, and irreversible actions to explain why parallel agents need one validation and commit step before their effects become real.
 
 ### [What Should an AI Agent Trace Keep? Observability Under a Fixed Evidence Budget](https://eunomia.dev/research/agent-trace-evidence-budget/)
 
@@ -24,6 +24,7 @@ AI agent traces can generate hundreds of system events around each model call wh
 A research brief must provide more than a fluent literature survey. It should contain:
 
 - a question that affects a real systems or engineering decision;
+- an opening that a technically qualified reader can understand without reading the source corpus;
 - independent primary evidence, including implementation or measurement evidence where available;
 - a genuine tension, contradiction, or alternative explanation;
 - a new synthesis that cannot be copied from any single source;

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -1,19 +1,19 @@
 ---
 title: 研究
-description: "基于一手来源的系统研究简报，提出可验证论点，比较互相竞争的证据，并明确架构影响、适用范围和可证伪条件。"
+description: "面向人类技术读者、基于一手来源的系统研究简报，提出可验证论点，并明确架构影响、适用范围和可证伪条件。"
 ---
 
 # 研究
 
-Eunomia Research 发布基于一手来源的系统研究简报。目标不是总结一轮新闻，而是从一个精确技术问题出发，比较独立证据，识别冲突与替代解释，并说明结论会改变哪项架构或工程决策。
+Eunomia Research 面向工程师、研究者和维护者发布基于一手来源的系统研究简报。每篇文章从一个具体技术问题出发，提出可验证的判断，比较独立证据，并说明结论会改变哪项架构或工程决策。
 
 这些页面属于经过审查的研究简报，除非页面另有说明，并不等同于同行评审论文。每项判断都受证据范围、来源截止时间、假设和可证伪条件约束。后续证据改变结论时，应更新稳定页面，而不是再创建一篇高度重复的文章。
 
 ## 当前研究
 
-### [并行 Agent 需要 Commit Protocol：从 Effect Serializability 到契约有效执行](https://eunomia.dev/zh/research/parallel-agent-effect-serializability/)
+### [多个 AI Agent 同时工作时，谁来保证最终结果是对的？](https://eunomia.dev/zh/research/parallel-agent-effect-serializability/)
 
-并行调用、worktree、reducer 和可串行化的资源更新，仍然可能组合成违背用户任务或使用过期权限的结果。本文审视当前 Agent runtime，并针对代码、API、预算、审批与不可逆动作提出 contract-valid effect serializability。
+`worktree`、沙箱和并行工具调用可以隔离 worker，却仍可能产生错误的组合结果。本文用代码修改、共享预算、审批和不可逆操作说明：并行 Agent 的结果在真正生效前，需要经过一次统一的验证和提交。
 
 ### [AI Agent 轨迹到底该保留什么：固定证据预算下的可观测性设计](https://eunomia.dev/zh/research/agent-trace-evidence-budget/)
 
@@ -24,6 +24,7 @@ Eunomia Research 发布基于一手来源的系统研究简报。目标不是总
 一篇研究简报必须提供比流畅综述更多的价值：
 
 - 问题会影响真实的系统或工程决策；
+- 开头应让没有读过来源材料的技术读者直接理解；
 - 使用相互独立的一手来源，并在可能时加入实现或测量证据；
 - 存在真实张力、矛盾或替代解释；
 - 综合结论不能从任意单篇来源直接复制；

--- a/docs/research/parallel-agent-effect-serializability.md
+++ b/docs/research/parallel-agent-effect-serializability.md
@@ -1,522 +1,337 @@
 ---
 date: 2026-08-05
-title: "Parallel Agents Need a Commit Protocol: From Effect Serializability to Contract-Valid Execution"
-description: "Parallel tool calls, worktrees, reducers, and clean merges can all coexist with a wrong combined outcome. This research brief audits current agent runtimes, separates four layers of concurrency correctness, and proposes contract-valid effect serializability across code, APIs, authority, and irreversible actions."
+title: "When Several AI Agents Work at Once, Who Makes Sure the Final Result Is Right?"
+description: "Worktrees, sandboxes, and parallel tool calls can isolate workers, but they do not guarantee that the combined result still satisfies one user task. This research brief explains why parallel agents need a shared commit step that rechecks state, authority, cross-task constraints, and irreversible effects."
 tags:
   - Research
   - AI Agent
   - Concurrency
   - Distributed Systems
   - Systems
-research_question: "What correctness contract lets tool-using AI agents execute concurrently against shared mutable state without silently violating user intent?"
+research_question: "When several tool-using AI agents modify the same repository, budget, or external system, where should the runtime validate and commit their combined effects?"
 source_cutoff: 2026-08-05
 status: reviewed-research-brief
 ---
 
-# Parallel Agents Need a Commit Protocol: From Effect Serializability to Contract-Valid Execution
+# When Several AI Agents Work at Once, Who Makes Sure the Final Result Is Right?
 
-Parallelism is becoming the default behavior of agent runtimes. A model can emit several tool calls in one turn. An orchestrator can launch multiple specialists against the same repository. A graph can fan out into concurrent nodes. A coding platform can give every worker a separate worktree and merge their patches later.
+Consider a common parallel coding workflow.
 
-These mechanisms reduce latency when tasks are independent. They also create a familiar systems problem in an unfamiliar place. Two agents can read the same old state, make locally reasonable plans, and commit a globally wrong result. They may edit different files while violating the same API invariant, independently spend the same remaining budget, publish contradictory messages, consume one approval twice, or perform external actions whose order cannot be repaired by a Git merge.
+A user asks an agent system to upgrade a service's authentication scheme. The orchestrator gives one worker the token-validation code and another worker the deployment configuration. They work in separate Git worktrees, never overwrite each other's files, pass their local tests, and produce patches that merge cleanly.
 
-The usual safeguards each cover only part of this problem. A sandbox separates processes. A worktree separates file writes. A reducer combines graph state. A CRDT guarantees convergence. A database transaction protects rows. A policy engine checks whether an action is allowed. None of these, by itself, states what it means for a complete set of concurrent agent effects to be correct.
+The deployed service is still wrong. One worker changed the expected token audience, while the other kept the old value in production configuration. There was no line-level conflict and no traditional data race. Two locally reasonable changes composed into a globally invalid system.
+
+The same pattern appears outside source code. Two purchasing agents can each read that a project has $1,000 left and independently place an $800 order. Two communications agents can publish contradictory announcements. Two subagents can consume the same one-time approval. Two tool calls can send the same email, trigger the same deployment, or make the same payment twice.
+
+Sandboxes, worktrees, reducers, locks, and database transactions each prevent some failures. None of them automatically knows whether several successful local results still satisfy the user's overall task.
 
 <!-- more -->
 
-This brief develops that missing contract. The starting point is classical serializability: a concurrent history is acceptable when its observable effect is equivalent to some serial execution of the same transactions. For tool-using agents, even this is not enough. The selected serial order must also remain valid under the intent, authority, state assumptions, and outcome conditions that justified each agent's work.
+The central argument of this brief is simple:
 
-The proposed property is **contract-valid effect serializability**. A concurrent agent run is acceptable only if there exists a serial order of committed work units such that:
+> **Treat each agent as a worker that prepares a proposal, not as an independent owner that may publish effects whenever it finishes. Let reasoning run in parallel, but put shared and irreversible effects through one validation and commit step.**
 
-1. the order respects explicit causality, delegation, approval, and real-time constraints;
-2. every work unit's relevant reads are still valid, or the work unit has repaired its plan against the state that precedes its commit;
-3. its authority and policy predicates hold at commit time;
-4. its local outcome contract and the workflow's global outcome contract hold after commit; and
-5. externally visible effects are observationally equivalent to that valid serial execution.
+That commit step needs to answer five questions:
 
-This is a stronger target than "the branches merged" or "the tools did not write the same key." It lets independent reasoning proceed in parallel while forcing conflicting effects through an explicit validation and commit boundary.
+1. Are the facts and versions the agent relied on still current?
+2. Do several results violate one hidden constraint even when they touch different files or records?
+3. Are the required permissions and approvals still valid at commit time?
+4. Does the combined result satisfy the workflow's end-to-end acceptance conditions?
+5. Will externally visible actions occur in the right order and exactly the intended number of times?
 
-> **Research question.** What correctness contract lets tool-using AI agents execute concurrently against shared mutable state without silently violating user intent?
->
-> **Central claim.** Parallel agent systems need a commit protocol over semantic effects. Workspace isolation, state convergence, ordinary serializability, and policy checks are useful components, but the full execution is safe only when the committed history is both effect-serializable and valid under task, authority, and outcome contracts at commit time.
+This does not mean that every agent must run sequentially. Search, analysis, read-only inspection, and candidate generation can remain highly parallel. The coordination boundary belongs where work becomes shared state, consumed authority, or an externally visible effect.
 
-## Concurrency arrived before its correctness contract
+## Parallel execution and correct composition are different properties
 
-A manual audit of current official runtime documentation shows that parallel execution is already a normal capability, while the safety semantics of side effects remain largely an application decision.
+Parallel tool use is already a normal feature of agent runtimes. The OpenAI Agents SDK can start multiple local function tools emitted in one model turn and lets applications cap that concurrency. Anthropic's tool-use documentation says that a response may contain several tool calls, while the application decides whether to execute them concurrently, sequentially, or in a mixed strategy based on side effects, shared state, and ordering requirements. Google ADK runs `ParallelAgent` subagents in isolated branches and points developers to additional coordination for shared state. LangGraph reducers can combine graph-state updates from parallel nodes, but external effects performed inside those nodes need their own semantics.
 
-| Runtime or protocol | Documented concurrent behavior | Protection it explicitly provides | Boundary left to the application |
-| --- | --- | --- | --- |
-| [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/running_agents/) | By default, all local function calls emitted in one turn are started; a concurrency cap is available | Tool input guardrails can be revalidated immediately before execution; sandbox agents provide workspace-scoped execution | No cross-tool atomic commit or isolation contract is implied by the concurrency setting |
-| [Claude tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use) | A response may contain several tool calls; the application chooses concurrent, sequential, or mixed execution | The documentation distinguishes independent read-only calls from calls with side effects or ordering requirements | Execution order, interference control, and rollback are explicitly left to the application |
-| [AutoGen](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html) | Multiple tool calls execute in parallel by default | Parallelism can be disabled | The documentation warns that side effects may interfere and requires parallel calls to be disabled for stateful agent and team tools |
-| [Google ADK ParallelAgent](https://adk.dev/agents/workflow-agents/parallel-agents/) | Subagents run concurrently in independent branches | Conversation history and branch state are not automatically shared | Shared context requires locks; other shared state needs an external coordination mechanism |
-| [LangGraph](https://docs.langchain.com/oss/python/langgraph/use-graph-api) | Nodes in a fan-out run concurrently in the same superstep | Reducers define how graph-state updates combine; a failing superstep does not apply its graph-state updates | The transactional statement concerns graph state. Side effects already performed inside a node need their own semantics |
-| [MCP sampling with tools](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling) | A model may return an array of tool requests for parallel use | A common representation for tool calls and results | The protocol representation does not itself define a multi-tool transaction, isolation level, commit point, or compensation rule |
+These mechanisms answer scheduling questions: can work overlap, and how should intermediate state be combined? They do not, by themselves, define correctness for the final outcome.
 
-This is not a defect in any one SDK. These interfaces expose execution mechanisms. A Python function, shell command, MCP server, database operation, browser action, and cloud API have different effect models, so a general runtime cannot infer a safe transaction boundary from a tool name alone.
+For read-only work, the distinction may be minor. Two agents can search different documents at the same time, and the main risk is duplicated compute. Once tools create side effects, the distinction becomes fundamental:
 
-The gap becomes dangerous when a developer interprets "parallel tool use is supported" as "parallel effects are correct." Support means that calls can overlap. Correctness needs a separate contract.
+- "Both tools returned successfully" does not imply that the combined outcome is correct.
+- "Both branches merge cleanly" does not imply that they used compatible assumptions.
+- "Both database transactions can commit" does not imply that a shared budget, approval, or business rule still holds.
+- "Each action is individually allowed" does not imply that the set of actions is allowed.
 
-## Four layers that are often confused
+The most dangerous failure in a parallel agent system is often not a crash or merge conflict. It is a run in which every component reports success while the final artifact quietly violates the user's intent.
 
-Agent concurrency discussions commonly collapse four different properties into one word: isolation. Separating them explains why apparently safe systems still produce wrong outcomes.
+## Three failure modes that ordinary isolation misses
 
-### 1. Execution parallelism
+### Different files can share one invariant
 
-Execution parallelism answers a scheduling question: can several model calls, tools, nodes, or subagents run at the same time?
+Many repository conflicts are semantic rather than textual.
 
-A concurrency limit, task group, worker pool, or graph fan-out belongs here. This layer determines throughput and latency. It says nothing about whether two operations interfere.
+One agent changes an API input contract while another adds a caller in a different package. One agent renames a configuration field while another updates a deployment template using the old name. One agent changes retry semantics while another writes error handling against the previous behavior. The agents can edit disjoint files and pass local tests.
 
-### 2. State separation or convergence
+A worktree is useful because it gives each worker a stable filesystem view. It does not prove that the workers' assumptions are compatible. Git detects overlapping lines, not a shared API invariant. The integration step must rebuild the combined tree, run cross-module tests, and determine whether important premises changed while the workers were running.
 
-State separation answers whether workers overwrite each other's intermediate representation.
+### Different records can consume one budget or approval
 
-Worktrees, containers, copy-on-write filesystems, separate graph branches, reducers, and CRDTs belong here. They can prevent physical write corruption or guarantee that replicas converge to one representation.
+Many constraints apply across objects rather than to one file or database row.
 
-Convergence is weaker than semantic correctness. Two patches can merge without a textual conflict and still disagree about a function contract. Two document edits can converge while retaining contradictory claims. Two append-only logs can preserve every update and still violate a budget or uniqueness invariant.
+Two purchasing agents may create different order records while drawing from one budget. Two cloud agents may create different instances while exceeding one quota. Two data agents may query different tables while relying on one approval that permits a single export.
 
-### 3. Effect serializability
+Locks and transactions work well once the system knows the protected resource. Agent tools often expose only a shell command, HTTP request, browser action, or generic MCP call. The logical resource may instead be "the remaining launch budget," "a one-time approval," "the release window," or "the API contract that several files must preserve."
 
-Effect serializability asks whether the combined, externally visible history is equivalent to some serial order of the same work units.
+A conflict detector that watches only paths and keys will miss these aggregate constraints.
 
-This layer detects anomalies such as lost updates, stale-read decisions, write skew, duplicate consumption, and order-dependent external actions. It spans more than files. The relevant resources may include database rows, API objects, deployment state, messages, quotas, approvals, and user-visible artifacts.
+### External actions cannot be repaired by a merge
 
-### 4. Contract validity
+Source changes can usually remain private in a branch until validation succeeds. Email, payments, tickets, releases, and production deployments behave differently.
 
-Contract validity asks whether the serial explanation is one the user would accept.
+A sent email can be followed by a correction, but it cannot be unsent. A payment can be refunded, but the original transaction, fees, and audit history remain. A deployment can be rolled back after it has already served requests. A public release can be withdrawn without erasing copies or notifications.
 
-Classical serializability assumes each transaction is correct when run serially. Agent work weakens that assumption. A work unit's plan is synthesized from a snapshot, a task interpretation, a set of permissions, and intermediate observations. Even if the runtime can place its effects in a serial order, the work may no longer be justified in the state at which it commits.
+A runtime therefore needs to classify effects before speculative execution:
 
-Consider two procurement agents. Both read that $1,000 remains. Each plans an $800 purchase. A serializable system can order the purchases, but the second transaction must recheck the budget and abort. Now add a policy that permits one purchase only after a manager approves a particular vendor. A database-serializable history is still insufficient if the approval is stale, vendor-scoped, consumed, or revoked. Finally, the two purchases may individually satisfy policy but jointly fail the user's task, for example because the user asked for one redundant supplier, not two copies of the same component.
+- **Bufferable:** can remain private until commit, such as a patch in an isolated workspace.
+- **Reversible:** has a reliable inverse that restores the relevant invariant.
+- **Compensatable:** can be amended, but its history remains externally visible.
+- **Irreversible:** cannot be safely undone, or repetition creates a new consequence.
 
-The upper layers therefore constrain the lower ones:
+The closer an action is to the irreversible end, the less freedom an individual parallel worker should have to execute it immediately.
 
-```text
-contract-valid execution
-    requires effect serializability
-        requires meaningful effect and dependency tracking
-            while allowing execution parallelism where safe
-```
+## What current mechanisms do and do not guarantee
 
-## Why familiar mechanisms stop short
-
-The missing contract is easier to see by examining mechanisms that are often presented as complete solutions.
-
-### Worktrees isolate bytes, then defer the hard question
-
-A worktree gives each coding agent a stable filesystem view. It prevents one worker from observing half-written files from another and lets each branch produce a coherent patch. That is valuable.
-
-The hard part moves to merge time. A clean Git merge only proves that line-oriented merge rules found no textual collision. It does not prove that both agents used compatible assumptions. One agent may rename an internal concept while another adds a caller using the old behavior. They can edit different files, pass their local tests, and produce a combined build that fails or, worse, passes incomplete tests with a latent invariant violation.
-
-Recent systems make this gap measurable. [STORM](https://arxiv.org/abs/2605.20563) argues that per-agent worktrees defer conflicts until recovery is expensive and reports better benchmark results from write-time state mediation. [AgenticFlict](https://arxiv.org/abs/2604.03551) finds textual conflicts in 27.67% of more than 107,000 merge-simulated agent pull requests, although its sample and textual-conflict method do not measure higher-level semantic conflicts. The evidence does not imply that worktrees are bad. It shows that isolation and integration are separate stages.
-
-### Reducers and CRDTs define combination, not intent
-
-LangGraph requires reducers for graph keys updated by parallel nodes. This prevents an ambiguous last writer from silently winning. A CRDT goes further by guaranteeing deterministic convergence without locking.
-
-A reducer answers "how should these values combine?" It does not answer "should both values be accepted?" Appending two proposed deployment targets is deterministic even when only one target is valid. Unioning two permission sets converges even when privilege should not expand. Merging two lists of factual claims preserves both sides, including contradictions.
-
-[CodeCRDT](https://arxiv.org/abs/2510.18893) demonstrates both sides of this trade-off. It reports deterministic convergence and zero merge failures, but still observes semantic conflicts and finds that parallel execution ranges from speedup to substantial slowdown depending on task structure. [S-Bus](https://arxiv.org/abs/2605.17076) reconstructs agent read sets and prevents structural races in shared shards, yet its own evaluation reports that the same preservation behavior is harmful in single-shard collaborative writing because concurrent contradictions propagate. Stronger structural consistency can faithfully preserve a semantically invalid combination.
-
-### Locks and optimistic validation inherit agent-specific costs
-
-Classical concurrency control offers two broad strategies.
-
-Pessimistic control acquires locks before conflicting access. This avoids wasted work but is poorly matched to agents that spend minutes reasoning between reads and writes. Locking a repository, budget, or cloud resource across model inference and human approval can remove most useful parallelism and create deadlocks across heterogeneous tools.
-
-Optimistic control lets work proceed, then validates before commit. The foundational [optimistic concurrency-control work](https://db.cs.cmu.edu/publications/) assumes conflicts are uncommon enough that abort and retry are cheaper than blocking. Agent aborts are expensive in a new currency: model tokens, tool calls, external rate limits, and human review. [ATCC](https://arxiv.org/abs/2603.13906) studies this problem for long, irregular SQL transactions generated by data agents and adaptively switches between optimistic and pessimistic strategies while accounting for abort cost.
-
-Neither strategy solves resource identification automatically. A database knows the rows or predicates a transaction touches. An agent runtime sees a shell command, an HTTP request, or a browser action. The logical resource may be "the public API contract," "the remaining project budget," or "the right to send the launch announcement," none of which maps cleanly to one path or key.
-
-### Compensation cannot make every effect disappear
-
-Long-running transactions often use [Sagas](https://www.cs.princeton.edu/research/techreps/598): commit smaller steps and run compensating actions when later work fails. Compensation is practical, but it is not equivalent to rollback.
-
-A deleted cloud instance can sometimes be recreated, but its identity and attached state may differ. A sent email can be followed by a correction, not unsent. A payment can be refunded, but the original transfer, fees, and audit events remain. A public release can be withdrawn, but copies and notifications may persist.
-
-Agent systems therefore need to classify effects before speculative execution:
-
-- **bufferable:** can remain private until commit, such as a file patch in an isolated workspace;
-- **reversible:** has a reliable inverse that restores the relevant contract;
-- **compensatable:** can be amended but leaves observable history;
-- **irreversible:** cannot be safely undone or repeated.
-
-A system that discovers this classification only after an abort is already too late.
-
-## A formal model: from tool calls to work-unit contracts
-
-The unit of concurrency should not be an individual model call. It should be a durable **work unit** whose state includes the task, evidence, authority, effects, and acceptance conditions needed to decide whether its result may commit.
-
-Let work unit \(W_i\) be:
-
-\[
-W_i = \langle I_i, S_i, A_i, R_i, E_i, O_i \rangle
-\]
-
-where:
-
-- \(I_i\) is the task intent and its declared scope;
-- \(S_i\) is the snapshot or authority epoch from which planning began;
-- \(A_i\) is the authority contract, including principal, capability, target, limits, and expiry;
-- \(R_i\) is the observed read set, including versions and semantic dependencies;
-- \(E_i\) is a proposed set of effects over logical resources;
-- \(O_i\) is an outcome predicate that defines acceptable completion.
-
-An effect is more than a write:
-
-\[
-e = \langle resource, operation, value, visibility, reversibility, authority \rangle
-\]
-
-The `resource` field may be physical, such as a file inode or database row, or semantic, such as an API invariant, a shared quota, a release channel, or a one-time approval. `visibility` says whether other actors can observe the effect before commit. `reversibility` determines which abort paths are honest.
-
-For a concurrent history \(H\) of committed work units, ordinary effect serializability requires a serial permutation \(\pi\) such that:
-
-\[
-Obs_Q(H) \equiv Obs_Q(W_{\pi(1)}; W_{\pi(2)}; \ldots; W_{\pi(n)})
-\]
-
-Here, \(Obs_Q\) is an observation contract. For buffered file changes, final-state equivalence may be enough. For messages, payments, or audit events, the visible effect trace and real-time order may matter.
-
-Contract-valid effect serializability adds four requirements. For every \(W_{\pi(k)}\):
-
-\[
-ValidRead(R_{\pi(k)}, state_{k-1}) \lor Repaired(W_{\pi(k)}, state_{k-1})
-\]
-
-\[
-Authorized(A_{\pi(k)}, E_{\pi(k)}, state_{k-1})
-\]
-
-\[
-O_{\pi(k)}(state_{k-1}, state_k, E_{\pi(k)}) = true
-\]
-
-and, for the full workflow:
-
-\[
-G(state_0, state_n, H) = true
-\]
-
-The first condition rejects stale reasoning unless the agent repairs the affected part of its plan. The second revalidates authority immediately before effects become visible. The third checks the work unit's own result. The fourth checks a global task contract that cannot be reduced to independent local successes.
-
-This distinction matters because **serializable does not mean desirable**. A runtime may find a legal serial order for two deployments, two purchases, or two announcements while the user's request permits only one. The global contract selects the acceptable serial histories.
-
-### Conflict classes
-
-A practical implementation needs a conflict graph richer than path overlap.
-
-| Conflict class | Example | Why file or key overlap misses it |
+| Mechanism | What it handles well | What it does not automatically decide |
 | --- | --- | --- |
-| Physical write-write | Two agents edit the same function | Directly detectable |
-| Stale read-write | One agent reads a schema while another changes it | The reader may write a different file |
-| Semantic invariant | Two patches modify different modules but violate one API contract | No shared physical write |
-| Aggregate constraint | Two agents each spend the same remaining budget | Writes may target different purchase records |
-| Authority conflict | Two branches consume or extend one approval | The protected object is a capability, not only data |
-| External-order conflict | Two announcements, deployments, or tickets must occur in order | Both effects can be individually valid |
-| Irreversible duplicate | Two branches send the same payment or email | Deduplication may require semantic identity |
-| Outcome conflict | Two locally successful subtasks make the overall result invalid | The conflict exists only at workflow level |
+| Sandboxes, containers, and worktrees | Process, filesystem, and intermediate-state isolation | Whether several results preserve one API, budget, approval, or business invariant |
+| Reducers and CRDTs | Deterministic combination or convergence of updates | Whether all converged values should have been accepted |
+| Database transactions and locks | Known rows, keys, predicates, and resources | How to identify logical resources behind shell, browser, and cross-service tools |
+| Human approval | Permission for an action at a particular moment | Whether the approval remains applicable after state, target, or delegation changes |
+| Per-agent tests | Local behavior of one branch or candidate | Cross-module and end-to-end behavior after composition |
+| Compensation | Remediation for some partially failed effects | Erasing external history that has already become visible |
 
-The graph may contain false positives. That is acceptable if the system exposes why it believes two work units conflict and allows deterministic validation to discharge the edge. What is unsafe is silently assuming independence because paths differ.
+The conclusion is not that these mechanisms are weak. They operate at different layers. A complete parallel-agent system needs to place them inside one prepare, validate, and commit path.
 
-## What recent systems collectively show
+## A practical model: prepare in parallel, commit together
 
-No single project supplies the full contract above, but recent work makes its components concrete.
-
-Several systems discussed in this section are recent 2026 preprints rather than established production standards. Their reported results are evidence about promising mechanisms, not independent confirmation that the mechanisms generalize. The synthesis below relies more on the boundaries exposed across the papers than on any single headline number.
-
-[Atomix](https://arxiv.org/abs/2602.14849) is the closest tool-effect transaction system. It tags calls with epochs, tracks per-resource frontiers, buffers effects where possible, and compensates externalized effects on abort. Its results show that progress-aware commit can prevent contamination from losing speculative branches and preserve correctness under contention. Atomix establishes that tool calls can be mediated as transactional effects rather than accepted immediately.
-
-[CoAgent](https://arxiv.org/abs/2606.15376) directly targets multi-agent concurrency. It observes that long inference intervals make both locks and full optimistic retry expensive, then uses a predetermined serialization order, order-filtered reads, effect repair, and undoable tools. Its reported results suggest that agent-assisted repair can recover concurrency that classical schemes lose. The important design lesson is that a runtime can ask an agent to repair a dependency without discarding the whole trajectory, but the runtime still needs mechanical effect tracking and undo semantics.
-
-[Provenact](https://arxiv.org/abs/2608.02764) isolates another missing dimension: authorization can become stale while shared budgets, inventory, approvals, or risk state change. It defines policy-state serializability, requiring committed effects to be authorized against the policy state immediately before they occur. This is stronger than passing policy state as ordinary prompt context. It also shows why concurrency control and governance cannot be separate control planes.
-
-[STORM](https://arxiv.org/abs/2605.20563), [S-Bus](https://arxiv.org/abs/2605.17076), and [CodeCRDT](https://arxiv.org/abs/2510.18893) address workspace and shared-state coordination from different directions. Together they show that write-time mediation, observable read sets, and deterministic convergence are all useful, but their value depends on workload topology and semantic invariants.
-
-[Semisolates and `try`](https://www.usenix.org/conference/osdi26/presentation/lamprou) and [`hS`](https://www.usenix.org/conference/osdi26/presentation/liargkovas) demonstrate that a runtime can capture, inspect, defer, and selectively apply effects from opaque processes without rewriting every component. These mechanisms matter for agents because many tools are shell commands or third-party binaries that cannot be instrumented with an agent SDK. System-level effect capture is feasible; attaching task semantics and authority remains the next layer.
-
-Two empirical studies explain why a commit protocol matters even when agents communicate. [CooperBench](https://arxiv.org/abs/2601.13295) reports an average 30% success reduction when two coding agents collaborate compared with one agent performing both tasks, attributing failures to poor communication, broken commitments, and incorrect expectations. AgenticFlict reports frequent textual merge conflict at ecosystem scale. Neither study proves that contract-valid serializability is the only solution. They show that coordination cannot be assumed to emerge reliably from more messages or more capable models.
-
-The synthesis is therefore not "put every tool call in one database transaction." The emerging systems divide the problem into effect capture, read-set reconstruction, state coordination, adaptive scheduling, policy validation, repair, and compensation. A general agent runtime needs a contract that tells these mechanisms what successful composition means.
-
-## A commit architecture for parallel agents
-
-The architecture below lets reasoning and read-only exploration remain parallel while making effect visibility an explicit protocol decision.
+A useful execution model has three stages.
 
 ```mermaid
-flowchart TD
-    U[User task and global outcome contract] --> P[Planner creates work units]
-    P --> X[Snapshot and authority epochs]
-    X --> A[Agent A speculative execution]
-    X --> B[Agent B speculative execution]
-    A --> EA[Read set and effect manifest]
-    B --> EB[Read set and effect manifest]
-    EA --> G[Semantic conflict graph]
-    EB --> G
-    G --> V[Read, policy, authority, and outcome validation]
-    V -->|independent or repairable| O[Choose valid commit order]
-    V -->|stale or invalid| R[Rebase, repair, replan, or abort]
-    O --> C[Commit bufferable and reversible effects]
-    C --> I[Linearize irreversible effects]
-    I --> Q[Verify global outcome contract and record provenance]
+flowchart LR
+    U[User task and acceptance conditions] --> P[Agents read, analyze, and prepare proposals in parallel]
+    P --> M[Each agent returns a candidate plus an effect manifest]
+    M --> V[Commit coordinator validates state, conflicts, authority, and global outcome]
+    V -->|valid| C[Commit bufferable changes]
+    V -->|stale or conflicting| R[Repair, serialize, or ask the user]
+    C --> E[Execute irreversible external actions last]
 ```
 
-### 1. Declare the work unit before execution
+### Stage 1: parallel preparation
 
-The orchestrator creates a stable work-unit identity with:
+Each agent works from a stable snapshot and prepares code, a plan, tool arguments, or another candidate artifact. The result should remain private where possible.
 
-- parent task and delegation path;
-- intent and target objects;
-- snapshot epoch;
-- authority epoch and capability scope;
-- expected output and outcome checks;
-- risk class and maximum effect class;
-- estimated reasoning and abort cost.
+Alongside the artifact, the worker returns a small effect manifest:
 
-The declaration can be incomplete. Agents discover dependencies dynamically. Its purpose is to establish what must be updated when the task changes and what the commit coordinator is allowed to accept.
+- important versions and objects it read;
+- resources it proposes to modify or consume;
+- assumptions that justify the plan;
+- authority or approval it expects to use;
+- acceptance conditions it believes define success.
 
-### 2. Run in an effect-aware speculative environment
+For example:
 
-Each work unit receives an isolated or semisolated execution view:
-
-- a worktree, copy-on-write filesystem, container, browser profile, or database snapshot;
-- intercepted tool adapters for known APIs;
-- system-level observation for opaque subprocesses;
-- a local effect buffer where possible;
-- explicit barriers before compensatable or irreversible actions.
-
-Read-only network and search operations can execute immediately. File writes can remain private. Cloud mutation, messaging, payment, publication, and credential use require a stronger gate.
-
-### 3. Reconstruct physical and semantic footprints
-
-Tool schemas should declare resource templates when possible:
-
-```text
-read:  repo:{id}:symbol:{name}
-write: repo:{id}:api-contract:{service}
-use:   budget:{project}
-send:  channel:{launch-announcement}
-consume: approval:{approval-id}
+```yaml
+work_unit: update-authentication
+intent: migrate service authentication to the new audience value
+reads:
+  - resource: api/auth-contract
+    version: git:8f31c2
+  - resource: deployment/config
+    version: git:27a9d0
+proposed_effects:
+  - modify: src/auth/validator.ts
+  - modify: deploy/service.yaml
+shared_constraints:
+  - token audience must match across code and deployment
+authority:
+  scope: repository:eunomia/service-a
+acceptance:
+  - integration test passes
+  - old audience is absent from production config
 ```
 
-Declarations will be incomplete, so the runtime augments them with:
+The manifest will never predict every effect perfectly. Its purpose is to give the commit layer more information than an unstructured answer and a zero exit code.
 
-- file, process, database, and network observations;
-- versioned tool inputs and outputs;
-- repository dependency graphs and test coverage;
-- policy labels and capability identifiers;
-- application invariants;
-- agent-produced dependency explanations with confidence.
+### Stage 2: shared validation
 
-An LLM may help propose semantic edges, but it should not be the sole commit oracle. Deterministic schemas, version checks, tests, policies, and resource keys should discharge most high-consequence decisions. Model judgments are most useful for locating possible conflicts and requesting targeted validation.
+The commit coordinator collects candidate results and checks whether they can safely compose.
 
-### 4. Build a conflict graph, not a global lock
+At minimum, it checks:
 
-The coordinator adds an edge when one work unit may invalidate another. Edges carry a reason and a validation method:
+1. **Stale reads.** Did a relevant file, object, policy, or external resource change after the worker planned its action?
+2. **Direct conflicts.** Do workers write the same resource or depend on incompatible versions?
+3. **Shared constraints.** Do disjoint changes jointly exceed a budget, violate uniqueness, or break an API invariant?
+4. **Authority.** Does the principal, scope, target, budget, approval, and delegation chain still cover the actual effects?
+5. **Local and global acceptance.** Does each candidate work, and does the combined result complete the user's overall task?
+6. **External ordering.** Which actions must happen exactly once, and which must wait until other changes have committed?
 
-```text
-A -> B
-reason: B read API schema v12; A proposes v13
-discharge: rerun B's compatibility test against v13
-```
+A failed validation does not always require restarting the whole task. The coordinator can ask only the affected worker to repair its plan against the latest state, serialize the conflicting portion, or present the user with a concrete decision instead of a generic "merge conflict."
 
-The graph identifies independent components that can commit concurrently. It also lets the system serialize only the effects that actually conflict, instead of locking an entire repository or task for the duration of reasoning.
+### Stage 3: effect commit
 
-### 5. Validate at commit time
+After validation, the system commits bufferable changes first, such as files, database transactions, and staged configuration. It performs email, payment, deletion, release, and production deployment last.
 
-Commit-time validation has four parts.
+This ordering avoids a common failure pattern: an agent performs the irreversible action, then discovers that the code, approval, or another branch cannot commit. Delaying high-consequence effects keeps more failure modes recoverable and makes the resulting history easier to explain.
 
-**Read validation.** Have the state versions or assumptions used by the plan changed? If so, can the affected suffix be repaired without rerunning the whole work unit?
+## The commit layer must protect logical resources
 
-**Policy and authority validation.** Is the principal still authorized for this exact effect, target, amount, environment, and time? Has the capability been consumed, revoked, narrowed, or delegated?
+Path-based conflict detection is straightforward. Logical conflict detection is harder and more important.
 
-**Outcome validation.** Do tests, deployment probes, ledger predicates, document consistency checks, or other task-specific oracles still pass after earlier commits?
+A logical resource can be:
 
-**Global validation.** Does the proposed combined result satisfy the original task? A collection of locally successful outputs is not automatically one successful workflow.
+- an API or data-format compatibility invariant;
+- a shared budget or quota;
+- a one-time approval;
+- a release window;
+- a user decision that permits only one of several alternatives;
+- code and deployment configuration that must stay consistent;
+- an information-flow boundary or sensitive-data policy.
 
-Approval should not freeze these checks. A human may approve a proposal at time \(t\), but state can change before execution at \(t+\Delta\). Approval records intent and authority; the runtime still needs a commit-time state predicate.
+No general runtime can infer all business semantics automatically. A practical design combines several sources:
 
-### 6. Commit effects in risk order
+- tools and applications explicitly declare resources, preconditions, and effects;
+- system observation adds actual file, database, process, and network behavior;
+- schemas, tests, policies, and invariant checkers provide deterministic validation;
+- models help identify possible semantic conflicts where structured rules are incomplete;
+- high-risk and irreversible actions retain an explicit human commit point.
 
-A safe default order is:
+A model can flag that two patches appear to change one interface in incompatible ways. It should not be the only authority deciding that a payment, deletion, or production release is safe. Wherever versions, types, tests, policy, and transaction semantics can prove a property, the system should prefer those deterministic mechanisms.
 
-1. metadata and provenance;
-2. bufferable local state;
-3. reversible external effects;
-4. compensatable effects;
-5. irreversible effects.
+## Which work should remain fully parallel?
 
-Irreversible effects receive an explicit linearization point and semantic idempotency identity. If a later step fails, the record must say that compensation occurred rather than pretending the original effect vanished.
+Coordination should be proportional to effect risk.
 
-### 7. Repair the affected suffix
+| Work type | Recommended strategy | Examples |
+| --- | --- | --- |
+| Independent read-only work | Run directly in parallel | Documentation search, reading separate logs, independent analysis |
+| Bufferable work on clearly disjoint resources | Prepare in parallel, validate versions before commit | Patches in independent modules, candidate reports |
+| Work with possible hidden shared constraints | Prepare in parallel, run shared integration and invariant checks | API changes, schemas, budgets, release plans |
+| Known hot resources | Lock, partition, or serialize | One configuration object, one quota, one approval |
+| Compensatable external effects | Commit centrally and record compensation semantics | Ticket creation, reversible infrastructure changes |
+| Irreversible or high-consequence effects | Execute last with explicit approval where appropriate | Payments, messages, destructive deletion, production release |
 
-Aborting an entire long trajectory wastes reasoning that may remain valid. CoAgent's direction suggests a more agent-native mechanism: notify the work unit of the changed dependency, identify the part of the plan that used it, undo or discard only dependent effects, and ask the agent to repair that suffix.
+This leads to an important performance rule: a commit protocol should not force every task through its heaviest path. Read-only and genuinely independent work can remain fully parallel. Extra coordination belongs only where workers touch shared state, authority, or externally visible effects.
 
-The runtime, not the model, must decide which effects were visible and whether their inverse succeeded. The model may repair intent-dependent reasoning; it should not be trusted to narrate an effect away.
+## How this relates to database serializability
 
-## Isolation levels for agent runtimes
+Database serializability asks whether a concurrent history is equivalent to running the same transactions one at a time in some order.
 
-A single strongest mode will be too expensive for every task. Runtimes should expose named levels with explicit anomalies, much as databases do.
+That is a useful starting point, but it is not enough for agents. A database typically assumes that each transaction is correct when run serially. An agent's plan may instead depend on an outdated repository, stale permission, incomplete observation, or mistaken interpretation of the task. The runtime may find a serial order that is internally consistent but still unacceptable to the user.
 
-| Level | Guarantee | Appropriate workloads | Remaining risk |
-| --- | --- | --- | --- |
-| Parallel read | Concurrent read-only calls; no shared mutation | Search, retrieval, independent analysis | External sources can still change between reads |
-| Workspace snapshot | Each worker sees an isolated file or environment snapshot | Independent code generation and artifact production | Clean merge can hide semantic and global conflicts |
-| Effect snapshot isolation | Track effect sets and validate write-write conflicts at commit | Low-contention code and data tasks | Write skew, stale semantic reads, authority drift |
-| Effect serializable | Committed effects equal some serial work-unit order | Shared repositories, databases, cloud resources | The selected serial history may violate task or authority contracts |
-| Contract-valid effect serializable | Serial order plus read repair, commit-time authority, local and global outcome predicates | Consequential multi-agent workflows | Depends on the completeness of contracts and effect mapping |
-| Strict contract-valid | Also preserves real-time constraints for completed approvals and visible effects | Payments, deployment control, security, publication | Highest coordination cost |
+An agent commit therefore needs stronger conditions. For every work unit:
 
-The important product decision is not "parallel on or off." It is which anomalies the workload can tolerate.
+- important reads remain valid, or the plan is repaired against current state;
+- authority still covers the effects at commit time;
+- the work unit's own acceptance conditions pass;
+- the combined workflow satisfies a global outcome condition;
+- the externally visible history matches this valid serial explanation.
 
-## Scheduling should be adaptive and effect-aware
+A precise research name for this property is **contract-valid effect serializability**. The name is less important than the distinction: the system needs not only a possible serial order, but a serial order that remains justified by current state, authority, and user intent.
 
-The best concurrency policy depends on conflict probability, abort cost, effect reversibility, and consequence.
+## An implementable architecture
 
-A practical scheduler can classify each work unit along four dimensions:
+A general system can start with a small set of components rather than a complete "agent database":
 
-\[
-score(W) = f(P_{conflict}, C_{abort}, C_{block}, R_{effect})
-\]
+1. **Stable work-unit identity.** Bind the model calls, tool calls, subprocesses, and delegated agents that belong to one piece of work.
+2. **Effect adapters.** Record reads, writes, consumption, and externally visible actions at file, Git, database, cloud API, browser, and MCP boundaries.
+3. **Versions and preconditions.** Track hashes, ETags, policy versions, object revisions, and other comparable state.
+4. **Conflict detection.** Handle physical conflicts first, then use schemas, tests, policies, and semantic analysis for higher-level conflicts.
+5. **Authority revalidation.** Recheck principal, scope, target, budget, approval, and delegation immediately before effects become visible.
+6. **Global validation.** Run cross-branch tests, budget checks, release rules, and user-defined outcome checks.
+7. **Commit log.** Record which candidates were accepted, rejected, repaired, or serialized, and when irreversible actions occurred.
 
-- \(P_{conflict}\): estimated probability of conflict from historical traces, declared resources, and current activity;
-- \(C_{abort}\): tokens, tool time, human review, and external work lost on repair;
-- \(C_{block}\): latency and resource cost of waiting;
-- \(R_{effect}\): consequence and reversibility of proposed effects.
+System-level observation is useful because an agent may create undeclared effects through a shell script, Python subprocess, or third-party tool. File, process, and network observation can reveal that a supposedly read-only tool wrote data or contacted an external destination. Those events show what happened; they do not, on their own, determine whether the result satisfies the task. The commit layer still needs resource, authority, and outcome semantics.
 
-Low-conflict read-heavy work should run optimistically. High-contention, short mutations can use locks. Long reasoning with repairable outputs should run speculatively with suffix repair. Irreversible effects should be serialized at a narrow commit gate even if their preparation is parallel.
+## How to evaluate the design
 
-This produces a useful principle:
+A convincing evaluation must measure both correctness and coordination cost.
 
-> Parallelize evidence gathering and proposal construction aggressively. Serialize only the smallest effect boundary needed to preserve the contract.
+Useful workload families include:
 
-That boundary may be one API call, a set of related repository changes, a budget allocation, or the publication of a final artifact.
+- **Collaborative coding:** agents edit different files while sharing API, schema, configuration, or test invariants.
+- **Data and budget tasks:** agents write separate records while sharing quotas, uniqueness rules, or approval.
+- **Cloud operations:** agents prepare deployments, scaling, rollback, and release steps in parallel.
+- **External communication:** agents create tickets, messages, announcements, or other visible effects.
 
-## How to evaluate the proposal
+Baselines should include:
 
-A convincing evaluation must compare strategies at equal task quality and include conflicts that textual merges cannot detect.
+- parallel execution without coordination;
+- independent worktrees followed by ordinary merge;
+- fully serial execution;
+- locking on known resources;
+- optimistic version validation only;
+- shared commit with state, constraint, authority, and global-outcome checks.
 
-### Workload corpus
+Important metrics include:
 
-The corpus should include:
+- end-to-end task correctness rather than tool success rate;
+- recall for direct and semantic conflicts;
+- latency lost to unnecessary serialization;
+- abort, repair, and model-token cost;
+- duplicate or incorrect external effects;
+- commits that succeed after authority has become stale;
+- user interruptions and reapproval frequency;
+- explanation quality when a commit is rejected.
 
-1. independent read-only research;
-2. disjoint file edits with no shared invariant;
-3. same-file write conflicts;
-4. cross-file API or schema conflicts;
-5. stale-read configuration changes;
-6. aggregate budget, quota, and inventory write skew;
-7. one-time approval and delegated-authority conflicts;
-8. ordered external actions such as deploy-then-announce;
-9. duplicate irreversible effects;
-10. document tasks where facts and conclusions can contradict without textual overlap.
+Ablation should remove state validation, shared constraints, authority checks, and global acceptance one at a time. A layer that does not prevent real failures should not become a permanent default cost.
 
-The ground truth should specify allowed serial orders, global outcome predicates, and which effects are reversible.
+## Scope, limitations, and falsification
 
-### Baselines
+This design targets tool-using agents that modify shared state, use delegated authority, or create external effects. Chat, independent retrieval, and fully isolated candidate generation usually do not need such a protocol.
 
-Compare:
+The design also has real limits:
 
-- sequential single-agent execution;
-- naive parallel tool execution;
-- isolated worktrees or sandboxes with post-hoc merge;
-- reducer or CRDT-based state convergence;
-- pessimistic resource locking;
-- optimistic effect validation with full retry;
-- effect serializability without task or authority contracts;
-- contract-valid effect serializability with targeted repair.
+- logical resources and global invariants cannot all be discovered automatically;
+- semantic conflict detection may produce false positives and serialize safe work;
+- aborting a long-running agent can waste substantial model and tool cost;
+- external services without idempotency, conditional updates, or a prepare phase limit the guarantees a coordinator can provide;
+- user intent may be too vague to express as a reliable acceptance condition;
+- model judgment cannot replace deterministic authorization and transaction boundaries.
 
-### Metrics
+The central claim would be weakened by any of the following findings:
 
-Measure:
+- at equal resource and review cost, ordinary worktrees, merge, and comprehensive tests reach the same final correctness;
+- cross-file, cross-service, and aggregate-constraint conflicts are rare enough that coordination costs more than the failures it prevents;
+- most high-risk tools already provide complete transaction semantics below the agent runtime;
+- global validation does not find failures earlier or more accurately than per-agent checks;
+- maintaining semantic resource declarations and conflict rules is impractical in production.
 
-- final task success;
-- serializability violations;
-- contract violations despite serializable state;
-- semantic conflict recall and false-positive rate;
-- irreversible-effect leakage;
-- wall-clock speedup;
-- model and tool cost;
-- full aborts versus suffix repairs;
-- blocked time and deadlocks;
-- human review time;
-- commit-protocol overhead;
-- percentage of effects with unknown or incorrect reversibility.
+These are measurable conditions. A more complex commit protocol is justified only when it prevents real errors at an acceptable cost.
 
-Ablations should remove semantic resource mapping, authority revalidation, global outcome predicates, and random post-commit audits separately. If these components do not change correctness or diagnosis, the stronger contract is unnecessary.
+## A practical starting point
 
-## Scope and alternative explanations
+Developers can adopt several useful rules without waiting for a full system:
 
-This proposal targets tool-using agents that mutate shared or externally visible state. Read-only fan-out, independent simulation, and embarrassingly parallel retrieval do not need a heavy commit protocol.
+1. Run independent read-only tools in parallel by default. Require side-effecting tools to declare whether parallel execution is safe.
+2. Let coding agents prepare patches in isolated workspaces, but treat merge, integration testing, and release as a separate commit stage.
+3. Protect budgets, quotas, approvals, and versions with compare-and-set, ETags, one-time tokens, or server-side consumption records.
+4. Place messages, payments, deletion, and production release after all bufferable changes have validated.
+5. Define at least one global acceptance condition for the user's whole task instead of trusting each subagent's "success" status.
+6. Record which work unit caused each external effect, which authority it used, and which resource versions justified it.
 
-Several alternative explanations could weaken the case.
-
-First, better task decomposition may eliminate most conflicts. If a planner can reliably assign disjoint resources and invariants, workspace isolation plus tests may be enough. Current evidence from coding benchmarks suggests decomposition is imperfect, but the result may improve with better models and project metadata.
-
-Second, service APIs may absorb the problem. A database can provide serializable transactions, a payment API can enforce idempotency, and a deployment service can expose compare-and-swap. This reduces runtime responsibility. It does not remove cross-service contracts, such as coordinating a repository change, a feature flag, a message, and an approval.
-
-Third, stronger automatic tests may make semantic dependency tracking redundant for code. Tests are excellent outcome predicates. They are usually incomplete, run after expensive work, and cannot undo effects already exposed outside the test environment.
-
-Fourth, model-based repair may be less reliable than rerunning. A repair request can preserve an invalid hidden assumption or introduce new changes. The runtime should therefore compare targeted repair with full replay and fall back when the dependency slice is uncertain.
-
-Fifth, the contract-authoring burden may exceed the benefit. Hand-writing every resource and invariant would not scale. The architecture depends on progressive adoption: strong defaults for common effects, automatic physical footprints, reusable policy schemas, and explicit contracts only at high-consequence boundaries.
-
-## Falsification conditions
-
-The central claim should be rejected or narrowed if evidence shows any of the following:
-
-- At equal cost, worktree isolation plus ordinary tests matches contract-valid effect serializability on semantic conflicts, external effects, and authority changes.
-- Real production workloads have conflict rates low enough that naive parallelism plus human review yields lower total cost without materially worse outcomes.
-- Dynamic effect and dependency reconstruction cannot reach useful recall without so many false positives that the system serializes most work.
-- Commit-time authority and global outcome predicates add no violations beyond resource-level serializability.
-- Targeted repair is less reliable or more expensive than full retry across long-running agent tasks.
-- Service-level transactions and idempotency cover nearly all cross-tool workflows in practice.
-- The coordination overhead and latency of the commit protocol exceed the operational loss from the anomalies it prevents.
-
-These conditions are measurable. A research program should report where the weaker mechanism wins, not assume the strongest level everywhere.
-
-## What builders can do now
-
-A complete runtime is not required to improve current systems.
-
-1. **Classify tools.** Mark each tool read-only, bufferable, reversible, compensatable, or irreversible. Disable parallel execution for unknown high-consequence tools.
-2. **Give work units stable identities.** Carry task, branch, snapshot, policy, and authority epochs across model calls and subprocesses.
-3. **Record read versions as well as writes.** A patch can be stale even when it writes a unique file.
-4. **Make effects private before commit.** Use worktrees, semisolates, staging APIs, dry runs, and preview modes.
-5. **Revalidate approvals.** Bind approval to target, amount, state predicate, and expiry; check it immediately before the effect.
-6. **Define one global outcome predicate.** Tests for each branch are not enough when the combined result has a higher-level goal.
-7. **Linearize irreversible actions.** Prepare in parallel, then execute once through a narrow coordinator with semantic idempotency.
-8. **Expose the isolation level.** A user should know whether "parallel" means only concurrent execution, isolated workspaces, or a serializable commit contract.
-9. **Keep provenance.** Record why a work unit was committed, repaired, reordered, or aborted, including the conflict edges and validation results.
-10. **Measure wasted reasoning.** Abort cost is part of concurrency control for agents, not a separate model-serving metric.
+These practices do not solve every semantic conflict. They replace the most dangerous pattern, several agents independently succeeding and immediately publishing effects, with a clearer model: several agents prepare in parallel, and one explicit boundary decides what becomes real.
 
 ## Conclusion
 
-Parallel agents are not simply a faster version of sequential agents. Once they read and mutate shared state, they become a distributed transaction system with unusual transactions: plans are generated online, read sets are opaque, execution lasts minutes, authority changes, effects cross unrelated services, and some actions cannot be undone.
+The hard part of parallel agents is not running several models or tools at once. It is proving that their combined result still satisfies one user task.
 
-The industry already has mechanisms for each layer. Agent SDKs schedule parallel calls. Worktrees and sandboxes isolate intermediate state. Reducers and CRDTs converge updates. Databases serialize rows. Atomix mediates transactional tool effects. CoAgent repairs concurrent trajectories. Provenact revalidates policy state. Semisolates capture opaque process effects.
+Worktrees and sandboxes isolate execution. Reducers and CRDTs combine state. Database transactions protect known resources. Policy engines check individual actions. None of them alone can decide whether several local successes jointly violate an API, budget, approval, release order, or user objective.
 
-The missing piece is the composition contract. A correct run needs more than one converged state and more than some serial explanation. It needs a serial explanation that remains valid under the task, authority, and outcome conditions that justified the work.
+A more reliable design lets agents prepare candidate results in parallel, then validates them before real effects occur. The commit step rechecks important reads, detects physical and semantic conflicts, confirms authority, runs local and global acceptance checks, and leaves irreversible actions until the end.
 
-Contract-valid effect serializability provides that target. It does not require serial reasoning. It lets agents search, plan, generate, and test in parallel, then forces only the conflicting and consequential effects through a commit protocol. The resulting system can explain not only that its branches merged, but why the combined result was still authorized, current, and correct.
+This does not remove uncertainty, and it should not serialize every task. It creates a clear responsibility boundary: parallel workers propose results; the commit layer decides which results may become part of the external world together.
 
 ## References
 
-1. OpenAI, [Running agents: function-tool concurrency](https://openai.github.io/openai-agents-python/running_agents/).
+1. OpenAI Agents SDK, [Running agents](https://openai.github.io/openai-agents-python/running_agents/).
 2. Anthropic, [Parallel tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use).
-3. Microsoft, [AutoGen agents and parallel tool calls](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html).
-4. Google, [ADK ParallelAgent](https://adk.dev/agents/workflow-agents/parallel-agents/).
-5. LangChain, [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/use-graph-api) and [concurrent update errors](https://docs.langchain.com/oss/python/langgraph/errors/INVALID_CONCURRENT_GRAPH_UPDATE).
-6. Model Context Protocol, [Sampling with tools and parallel tool use](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling).
-7. Kung and Robinson, [On Optimistic Methods for Concurrency Control](https://db.cs.cmu.edu/papers/1981/kung-tods1981.pdf), ACM TODS 1981.
-8. Garcia-Molina and Salem, [Sagas](https://www.cs.princeton.edu/research/techreps/598), 1987.
-9. Mohammadi et al., [Atomix: Timely, Transactional Tool Use for Reliable Agentic Workflows](https://arxiv.org/abs/2602.14849), 2026.
-10. Lyu et al., [CoAgent: Concurrency Control for Multi-Agent Systems](https://arxiv.org/abs/2606.15376), 2026.
-11. Peng and Wu, [Stateful Governance for Concurrent Agentic Systems](https://arxiv.org/abs/2608.02764), 2026.
-12. Zhou et al., [ATCC: Adaptive Concurrency Control for Unforeseen Agentic Transactions](https://arxiv.org/abs/2603.13906), 2026.
-13. Liu et al., [Multi-agent Collaboration with State Management](https://arxiv.org/abs/2605.20563), 2026.
-14. Khan, [S-Bus: Automatic Read-Set Reconstruction for Multi-Agent LLM State Coordination](https://arxiv.org/abs/2605.17076), 2026.
-15. Pugachev, [CodeCRDT: Observation-Driven Coordination for Multi-Agent LLM Code Generation](https://arxiv.org/abs/2510.18893), 2025.
-16. Khatua et al., [CooperBench: Why Coding Agents Cannot be Your Teammates Yet](https://arxiv.org/abs/2601.13295), 2026.
-17. Ogenrwot and Businge, [AgenticFlict](https://arxiv.org/abs/2604.03551), 2026.
-18. Lamprou et al., [Controlling Opaque-Component Effects with Semisolates and Try](https://www.usenix.org/conference/osdi26/presentation/lamprou), OSDI 2026.
-19. Liargkovas et al., [hS: Speculative Script Reordering at Subprocess Granularity](https://www.usenix.org/conference/osdi26/presentation/liargkovas), OSDI 2026.
+3. Google Agent Development Kit, [Parallel agents](https://adk.dev/agents/workflow-agents/parallel-agents/).
+4. Microsoft AutoGen, [Agents and tool execution](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html).
+5. LangChain, [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/use-graph-api).
+6. Model Context Protocol, [Sampling with tools specification](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling).
+7. Philip A. Bernstein, Vassos Hadzilacos, and Nathan Goodman, [Concurrency Control and Recovery in Database Systems](https://www.microsoft.com/en-us/research/people/philbe/book/), 1987.
+8. Hector Garcia-Molina and Kenneth Salem, [Sagas](https://www.cs.princeton.edu/research/techreps/598), 1987.
+9. Marc Shapiro et al., [Conflict-Free Replicated Data Types](https://inria.hal.science/inria-00609399), 2011.
+10. Eunomia Research, [What Should an AI Agent Trace Keep? Observability Under a Fixed Evidence Budget](https://eunomia.dev/research/agent-trace-evidence-budget/), 2026.

--- a/docs/research/parallel-agent-effect-serializability.zh.md
+++ b/docs/research/parallel-agent-effect-serializability.zh.md
@@ -1,518 +1,335 @@
 ---
 date: 2026-08-05
-title: "并行 Agent 需要 Commit Protocol：从 Effect Serializability 到契约有效执行"
-description: "并行工具调用、worktree、reducer 和无冲突合并，都可能与错误的最终结果同时出现。本文审视当前 Agent runtime 的并发语义，区分四层正确性，并提出跨代码、API、权限和不可逆动作的契约有效 effect serializability。"
+title: "多个 AI Agent 同时工作时，谁来保证最终结果是对的？"
+description: "Worktree、沙箱和并行工具调用可以隔离执行，却不能保证多个 Agent 的结果合在一起仍满足同一项用户任务。本文用代码修改、共享预算和外部操作三个场景说明：并行 Agent 在产生真实副作用前，需要一个统一的提交步骤，重新检查状态、权限、共享约束和最终结果。"
 tags:
   - Research
   - AI Agent
   - Concurrency
   - Distributed Systems
   - Systems
-research_question: "工具型 AI Agent 应该遵守什么正确性契约，才能并发操作共享可变状态而不悄悄违背用户意图？"
+research_question: "当多个工具型 AI Agent 同时修改同一仓库、共享预算或外部系统时，运行时应在什么边界验证并提交它们的结果？"
 source_cutoff: 2026-08-05
 status: reviewed-research-brief
 ---
 
-# 并行 Agent 需要 Commit Protocol：从 Effect Serializability 到契约有效执行
+# 多个 AI Agent 同时工作时，谁来保证最终结果是对的？
 
-并行正在成为 Agent runtime 的默认能力。模型可以在一轮响应里发出多个工具调用，orchestrator 可以让几个 specialist 同时修改同一个仓库，图执行引擎可以把一个节点 fan-out 成多条并发分支，coding agent 平台也可以给每个 worker 创建独立 worktree，最后再合并补丁。
+想象一个很常见的并行 coding agent 工作流。
 
-任务彼此独立时，这些机制可以直接缩短延迟。问题在于，一旦两个 Agent 读取同一份旧状态并产生外部效果，它们就进入了传统并发控制研究了几十年的领域。两个局部合理的计划可以组合成一个全局错误的结果：它们也许修改不同文件，却一起破坏同一条 API invariant；也许分别花掉同一笔剩余预算；也许发布互相矛盾的公告；也许重复消费一份审批；也许执行两个无法通过 Git merge 修复的外部动作。
+用户要求升级一个服务的认证机制。系统把任务拆给两个 Agent：第一个修改 token 校验逻辑，第二个更新部署配置。它们各自在独立 `worktree` 中工作，没有覆盖彼此的文件；各自的局部测试也都通过；Git 最后甚至可以无冲突合并。
 
-常见保护机制都只覆盖其中一部分。Sandbox 隔离进程，worktree 隔离文件写入，reducer 合并 graph state，CRDT 保证副本收敛，数据库事务保护数据行，policy engine 判断动作是否允许。任何一个机制单独拿出来，都没有说明一组并发 Agent 效果在整体上什么时候才算正确。
+结果上线后，服务仍然出错。第一个 Agent 把 token 的 audience 改成了新值，第二个 Agent 却沿用旧配置。它们没有写同一行代码，也没有发生传统意义上的数据竞争，但两个局部正确的修改组合成了一个全局错误的系统。
+
+同样的问题不只出现在代码里。两个采购 Agent 可以分别看到“还剩 1,000 美元预算”，然后各自下单 800 美元；两个运营 Agent 可以同时发布互相矛盾的公告；两个子 Agent 可以分别使用同一份一次性审批；两个工具调用也可能把同一封邮件、付款或部署执行两次。`sandbox`、`worktree`、锁和数据库事务各自能挡住一部分错误，却没有一个机制天然知道“这些结果合在一起是否仍然完成了用户真正交代的任务”。
 
 <!-- more -->
 
-本文讨论的正是这项缺失的契约。起点是数据库中的 serializability：如果一段并发历史与某种串行执行具有等价的可观察效果，那么这段历史可以被接受。对工具型 Agent 来说，仅有这一点仍然不够。被选中的串行顺序还必须符合每个 Agent 开始工作时依赖的任务意图、权限、状态假设和结果条件。
+本文的核心判断很简单：
 
-本文提出的目标是 **contract-valid effect serializability**，即“契约有效的效果可串行化”。一段并发 Agent 运行只有在存在某个 work unit 串行顺序，并同时满足以下条件时才可接受：
+> **把每个 Agent 当成并行准备方案的 worker，而不是可以随时把结果写进真实世界的独立 owner。并行发生在准备阶段，真正的副作用应当经过一次统一的验证和提交。**
 
-1. 顺序遵守明确的因果、委派、审批和实时约束；
-2. 每个 work unit 的关键读取仍然有效，或者它已经针对 commit 前状态修复了受影响的计划；
-3. 权限和策略谓词在 commit 时仍成立；
-4. 局部 outcome contract 与整个 workflow 的 global outcome contract 都成立；
-5. 对外可见的效果与这段有效串行执行在相应观察模型下等价。
+这个提交步骤需要回答五个问题：
 
-这比“分支能够合并”或“两个工具没有写同一个 key”强得多。它允许独立的推理并行进行，只把真正冲突的效果送入显式 validation 和 commit 边界。
+1. Agent 做决定时读取的状态现在还有效吗？
+2. 多个结果是否触碰了同一条隐藏约束，即使它们修改的是不同文件或对象？
+3. 执行所需的权限和审批在提交时仍然有效吗？
+4. 每个局部结果合在一起后，是否满足整项任务的验收条件？
+5. 邮件、付款、部署等不可逆动作，是否以正确的次数和顺序发生？
 
-> **研究问题：**工具型 AI Agent 应该遵守什么正确性契约，才能并发操作共享可变状态而不悄悄违背用户意图？
->
-> **中心论点：**并行 Agent 系统需要针对语义效果的 commit protocol。Workspace isolation、状态收敛、普通 serializability 和 policy check 都是有用组件，但完整执行只有在已 commit 历史同时满足 effect serializability，并且在 commit 时仍符合任务、权限和结果契约时才安全。
+这不是要把所有 Agent 都改成串行运行。真正的目标是把“可以并行思考”和“可以并行产生外部效果”分开：读取、搜索、分析和生成候选方案可以高度并行；修改共享状态、消耗预算、使用审批和触发不可逆操作，则需要明确的提交边界。
 
-## 并发能力已经普及，正确性契约还没有跟上
+## 并行执行和正确结果是两件事
 
-对当前官方 runtime 文档做一次人工审计，可以看到一个一致趋势：并行执行已经是常规能力，side effect 的安全语义仍主要交给应用决定。
+当前 Agent runtime 已经普遍支持并行工具调用。OpenAI Agents SDK 在模型一轮发出多个本地函数工具调用时，可以同时启动这些调用，并允许应用限制并发数；Anthropic 的文档也明确说明，一次响应可以包含多个工具调用，但这些调用究竟并行、串行还是混合执行，由应用根据副作用、共享状态和顺序要求决定。Google ADK 的 `ParallelAgent` 会让子 Agent 在隔离分支中运行，同时提醒共享状态需要额外协调。LangGraph 可以通过 reducer 合并并行节点的 graph state，但节点内部已经执行的外部操作并不会因此自动获得事务语义。
 
-| Runtime 或协议 | 文档中的并发行为 | 明确提供的保护 | 留给应用的边界 |
-| --- | --- | --- | --- |
-| [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/running_agents/) | 默认启动模型在一轮中发出的全部本地 function tool call，也可以限制并发数 | 工具输入 guardrail 可以在真正执行前重新验证；sandbox agent 提供 workspace-scoped execution | 并发设置本身不意味着跨工具 atomic commit 或 isolation contract |
-| [Claude tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use) | 一次响应可以包含多个工具调用，应用自行选择并发、串行或混合执行 | 文档明确区分独立只读工具和具有副作用、共享状态或顺序要求的工具 | 执行顺序、干扰控制和 rollback 明确由应用负责 |
-| [AutoGen](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html) | 多个工具调用默认并行执行 | 可以关闭 parallel tool call | 文档警告 side effect 可能互相干扰，并要求 stateful AgentTool 和 TeamTool 禁用并行 |
-| [Google ADK ParallelAgent](https://adk.dev/agents/workflow-agents/parallel-agents/) | Subagent 在独立分支中并发运行 | Conversation history 与分支状态不会自动共享 | 共享 context 需要锁，其他共享状态需要外部协调机制 |
-| [LangGraph](https://docs.langchain.com/oss/python/langgraph/use-graph-api) | Fan-out 节点在同一 superstep 中并发执行 | Reducer 定义 graph-state update 怎样合并；失败 superstep 不应用其 graph state update | “Transactional”保证针对 graph state，节点内部已经产生的外部效果需要另一套语义 |
-| [MCP sampling with tools](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling) | 模型可以返回一组并行 tool request | 提供跨模型供应商的工具调用与结果表示 | 协议表示本身没有定义 multi-tool transaction、isolation level、commit point 或 compensation rule |
+这些能力解决的是调度问题：多个工作能不能同时进行，以及中间状态怎样组合。它们没有自动回答最终正确性问题。
 
-这不是某个 SDK 的 bug。接口暴露的是执行机制，而 Python 函数、shell 命令、MCP server、数据库操作、浏览器动作和 cloud API 具有完全不同的效果模型。通用 runtime 无法只看 tool name 就推导出安全事务边界。
+对只读任务来说，这个区别通常不重要。两个 Agent 同时搜索不同文档，最坏情况往往只是浪费一些计算。对有副作用的任务来说，区别会迅速放大：
 
-真正危险的是把“支持 parallel tool use”理解成“parallel effect 是正确的”。支持只说明这些调用可以重叠，正确性需要另一份契约。
+- “两个工具都成功返回”不等于“组合结果正确”；
+- “两个分支可以 clean merge”不等于“它们使用了兼容的设计假设”；
+- “两个数据库事务都可提交”不等于“总预算、审批范围或用户目标仍然成立”；
+- “每个动作单独被允许”不等于“这组动作整体被允许”。
 
-## 经常被混为一谈的四层性质
+并行系统最危险的失败，不一定是进程崩溃或 merge conflict，而是所有组件都报告成功，最终产物却悄悄偏离了用户目标。
 
-Agent 并发讨论里经常把四种不同性质都叫作 isolation。把它们分开以后，很多“看起来已经安全”的系统为什么仍会出错就清楚了。
+## 三类常见失败
 
-### 第一层：execution parallelism
+### 不同文件，破坏同一条系统约束
 
-Execution parallelism 回答的是调度问题：多个 model call、tool、node 或 subagent 能不能同时运行？
+代码仓库中的冲突常常不是文本冲突，而是语义冲突。
 
-Concurrency limit、task group、worker pool 和 graph fan-out 都属于这一层。它决定 throughput 与 latency，不说明两个操作会不会互相干扰。
+一个 Agent 修改 API 的输入约定，另一个 Agent 在另一目录里新增调用者；一个 Agent 重命名配置项，另一个 Agent 更新部署模板时仍使用旧名字；一个 Agent 改变错误处理语义，另一个 Agent 根据旧语义编写重试逻辑。它们可以编辑完全不同的文件，也可以各自通过局部测试。
 
-### 第二层：state separation 或 convergence
+`worktree` 很适合隔离写入，但它只把冲突推迟到集成阶段。Git 能发现两段补丁是否修改同一行，却不知道两个补丁是否依赖互相矛盾的接口假设。最终的提交者仍然需要重新构建、运行跨模块测试，并检查两个 Agent 开始工作后是否有关键前提已经变化。
 
-这一层回答 worker 会不会覆盖彼此的中间表示，以及最终表示能不能收敛。
+### 不同记录，共享同一个预算或审批
 
-Worktree、container、copy-on-write filesystem、独立 graph branch、reducer 和 CRDT 都属于这里。它们可以避免物理写入破坏，也可以保证多个副本最终合并成一个确定表示。
+很多业务约束不是某个文件或数据库行的属性，而是多个动作共同消耗的资源。
 
-收敛比语义正确弱得多。两个 patch 可以没有 textual conflict，却违反同一条函数契约；两段文档修改可以稳定合并，却同时保留互相矛盾的结论；两个 append-only log 可以完整保存所有 update，却一起突破预算或唯一性约束。
+两个采购 Agent 可能写入不同订单记录，却共享同一笔预算；两个 cloud Agent 可能创建不同实例，却一起突破项目配额；两个数据处理 Agent 可能读取不同表，却共同使用一份只允许一次导出的审批。
 
-### 第三层：effect serializability
+传统锁可以保护已知对象，但前提是系统已经知道应该锁什么。Agent 工具往往只暴露一个 shell 命令、HTTP 请求或浏览器动作，真正需要保护的逻辑资源却可能是“本周剩余预算”“一次性审批”“发布窗口”或“不能同时变更的 API 契约”。
 
-Effect serializability 询问一段并发、对外可见的历史，是否等价于相同 work unit 的某种串行顺序。
+如果运行时只按物理路径和 key 检测冲突，它会漏掉这类聚合约束。
 
-这一层处理 lost update、stale-read decision、write skew、重复消费和依赖顺序的外部动作。资源也不只是文件，还包括数据库行、API object、deployment state、消息、quota、approval 和用户可见 artifact。
+### 外部动作无法靠 merge 或 rollback 修复
 
-### 第四层：contract validity
+文件修改通常可以暂存在分支里，等验证通过再合并。邮件、付款、工单、发布和部署则不同。
 
-Contract validity 进一步问：这个串行解释是不是用户愿意接受的那个解释？
+一封邮件发出后，后续“补偿”只能再发一封更正邮件；一次付款可以退款，但原交易、手续费和审计记录仍然存在；一个生产部署可以回滚，却已经影响过请求；一个公开发布可以撤回，却无法保证没有人看到或复制。
 
-经典 serializability 假设每个 transaction 单独串行运行时本身是正确的。Agent work unit 削弱了这个前提。它的计划来自某个 snapshot、对任务的解释、一组权限以及中间观察。即使 runtime 能找到一个串行顺序，计划在真正 commit 时也可能已经没有依据。
+因此，Agent runtime 必须在执行前区分四类效果：
 
-考虑两个采购 Agent。它们都读取到项目还剩 1,000 美元，并各自计划采购 800 美元。Serializable system 可以确定先后顺序，但第二个 transaction 必须重新检查预算并 abort。现在再加入一条策略：采购只在经理批准特定 vendor 后允许。即使数据库历史可串行化，如果审批已经过期、只绑定另一个 vendor、已经被消费或已撤销，仍然不能执行。最后，即使两笔采购都符合 policy，它们也可能一起违背用户目标，例如用户要的是两个冗余供应商，而不是同一部件的两份副本。
+- **可缓冲：**可以在提交前保持私有，例如独立工作区里的代码补丁；
+- **可逆：**存在可靠的反向操作，并能恢复关键系统约束；
+- **可补偿：**可以追加修正，但历史效果仍然可见；
+- **不可逆：**无法安全撤销，或者重复执行会产生新的后果。
 
-因此，上层性质会约束下层性质：
+越接近不可逆的一端，越不能让每个并行 Agent 自行决定何时“落地”。
 
-```text
-contract-valid execution
-    需要 effect serializability
-        需要有意义的 effect 与 dependency tracking
-            同时尽量保留安全的 execution parallelism
-```
+## 现有机制分别解决了什么
 
-## 为什么熟悉机制仍然停在半路
-
-### Worktree 隔离字节，却把真正的问题推迟到 merge
-
-Worktree 为每个 coding agent 提供稳定 filesystem view，避免 worker 看见另一个 worker 写到一半的文件，也能让每条分支独立形成 coherent patch。这很有价值。
-
-困难被移到了 merge time。一次 clean Git merge 只证明基于文本行的 merge rule 没找到冲突，不证明两个 Agent 使用了兼容假设。一个 Agent 可能修改内部概念的含义，另一个 Agent 在另一文件里继续依赖旧行为。它们可以编辑不同文件，各自通过局部测试，合并后却 build failure，或者在测试覆盖不足时留下 latent invariant violation。
-
-近期系统把这个差距变成了可测对象。[STORM](https://arxiv.org/abs/2605.20563) 认为 per-agent worktree 会把冲突推迟到恢复成本很高的阶段，并报告 write-time state mediation 在 benchmark 上优于 worktree baseline。[AgenticFlict](https://arxiv.org/abs/2604.03551) 对超过 107,000 个 Agent PR 做确定性 merge simulation，发现 27.67% 存在 textual conflict。这个数据集只覆盖特定样本与文本冲突，不能代表所有并发或 semantic conflict，但足以说明 isolation 和 integration 是两个不同阶段。
-
-### Reducer 和 CRDT 定义怎样合并，不定义是否应该合并
-
-LangGraph 要求并行节点更新同一个 graph key 时提供 reducer，以免某个不明确的 last writer 悄悄获胜。CRDT 更进一步，可以在无锁条件下保证确定性收敛。
-
-Reducer 回答“这些值怎样组合”，不回答“这些值是否都应该被接受”。把两个 deployment target append 到列表里是确定的，即使只有一个 target 合法；把两个 permission set 做 union 会稳定收敛，即使权限本来不应该扩张；合并两组 factual claim 可以保留双方，包括互相冲突的事实。
-
-[CodeCRDT](https://arxiv.org/abs/2510.18893) 同时展示了优势与边界。它实现确定性收敛和零 merge failure，但仍观察到 semantic conflict，而且并行执行会随着 task structure 从 speedup 变成明显 slowdown。[S-Bus](https://arxiv.org/abs/2605.17076) 重建 Agent read set，在 shared shard 中防止 structural race；其评测也报告，同一套 preservation 机制在 single-shard collaborative writing 中反而有害，因为它把并发矛盾一起传播。更强的结构一致性可以非常忠实地保存一个语义错误的组合。
-
-### Lock 和 optimistic validation 会继承 Agent 特有成本
-
-经典 concurrency control 大致有两类策略。
-
-Pessimistic control 在冲突访问前拿锁。它避免浪费工作，却不适合在 read 与 write 之间进行几分钟推理的 Agent。如果在 model inference、tool call 和 human approval 整段期间锁住仓库、预算或 cloud resource，大部分有用并行度都会消失，还可能跨多个异构工具形成 deadlock。
-
-Optimistic control 允许工作先进行，commit 前再验证。经典 [optimistic concurrency control](https://db.cs.cmu.edu/papers/1981/kung-tods1981.pdf) 假设冲突足够少，abort 和 retry 比等待更便宜。Agent abort 出现了一种新的成本单位：model token、tool call、external rate limit 和 human review。[ATCC](https://arxiv.org/abs/2603.13906) 针对 data agent 生成的长时间、不规则 SQL transaction，动态在 optimistic 与 pessimistic strategy 之间切换，并把 abort cost 纳入调度。
-
-两种方法都不能自动解决 resource identification。数据库知道 transaction 触碰哪些 row 或 predicate，Agent runtime 看到的却可能只是 shell command、HTTP request 或 browser action。真实逻辑资源可能是“公开 API contract”“项目剩余预算”或“发布 launch announcement 的权利”，它们都无法直接映射成一个 path 或 key。
-
-### Compensation 不能让所有效果消失
-
-长事务经常使用 [Saga](https://www.cs.princeton.edu/research/techreps/598)：把流程拆成多个可 commit step，后续失败时运行 compensating action。这个方式实用，但 compensation 并不等于 rollback。
-
-被删除的 cloud instance 有时可以重建，但 identity 和 attached state 可能已经不同；发出的邮件只能追加更正，不能“未发送”；支付可以退款，但原交易、手续费和 audit event 仍然存在；公开 release 可以撤回，通知和副本不会一起消失。
-
-因此，Agent system 必须在 speculative execution 以前给 effect 分类：
-
-- **bufferable**：可以在 commit 前保持私有，例如 isolated workspace 中的 file patch；
-- **reversible**：存在可靠 inverse，可以恢复相关契约；
-- **compensatable**：可以补救，但会留下可观察历史；
-- **irreversible**：无法安全撤销或重复。
-
-如果系统直到 abort 后才发现一个效果属于哪一类，已经太迟。
-
-## 从 tool call 到 work-unit contract 的形式模型
-
-并发单位不应是单个 model call，而应是持久的 **work unit**。它需要携带任务、证据、权限、效果和 acceptance condition，才能决定结果是否可以 commit。
-
-定义 work unit \(W_i\)：
-
-\[
-W_i = \langle I_i, S_i, A_i, R_i, E_i, O_i \rangle
-\]
-
-其中：
-
-- \(I_i\) 表示任务意图和声明的 scope；
-- \(S_i\) 表示开始计划时使用的 snapshot 或 authority epoch；
-- \(A_i\) 表示 authority contract，包括 principal、capability、target、limit 和 expiry；
-- \(R_i\) 表示观察到的 read set，包括 version 与 semantic dependency；
-- \(E_i\) 表示针对逻辑资源提出的 effect set；
-- \(O_i\) 表示怎样才算完成的 outcome predicate。
-
-Effect 也不只是 write：
-
-\[
-e = \langle resource, operation, value, visibility, reversibility, authority \rangle
-\]
-
-`resource` 可以是 file inode、database row 这样的 physical resource，也可以是 API invariant、共享 quota、release channel 或 one-time approval 这样的 semantic resource。`visibility` 决定其他 actor 是否会在 commit 前看到效果，`reversibility` 决定 abort path 是否真实可信。
-
-对一段包含若干 committed work unit 的并发历史 \(H\)，普通 effect serializability 要求存在一个串行排列 \(\pi\)，使：
-
-\[
-Obs_Q(H) \equiv Obs_Q(W_{\pi(1)}; W_{\pi(2)}; \ldots; W_{\pi(n)})
-\]
-
-这里的 \(Obs_Q\) 是 observation contract。对 buffered file change，final-state equivalence 可能已经足够；对消息、支付和 audit event，可见 effect trace 与 real-time order 也可能属于正确性的一部分。
-
-Contract-valid effect serializability 再增加四个要求。对每个 \(W_{\pi(k)}\)：
-
-\[
-ValidRead(R_{\pi(k)}, state_{k-1}) \lor Repaired(W_{\pi(k)}, state_{k-1})
-\]
-
-\[
-Authorized(A_{\pi(k)}, E_{\pi(k)}, state_{k-1})
-\]
-
-\[
-O_{\pi(k)}(state_{k-1}, state_k, E_{\pi(k)}) = true
-\]
-
-并且完整 workflow 满足：
-
-\[
-G(state_0, state_n, H) = true
-\]
-
-第一项拒绝 stale reasoning，除非 Agent 已修复受影响计划；第二项在 effect 变得可见以前重新验证 authority；第三项检查 work unit 自己的结果；第四项检查无法拆成独立局部成功的 global task contract。
-
-这个区分很重要，因为 **serializable 不等于 desirable**。Runtime 也许能为两个 deployment、两笔采购或两条公告找到合法串行顺序，但用户只允许其中一个。Global contract 用来筛掉形式上可串行化、实质上不符合任务的历史。
-
-### 冲突类型
-
-实际系统需要的 conflict graph 不能只看 path overlap。
-
-| 冲突类型 | 示例 | 为什么 file/key overlap 看不到 |
+| 机制 | 它擅长解决的问题 | 它没有自动解决的问题 |
 | --- | --- | --- |
-| Physical write-write | 两个 Agent 修改同一函数 | 可以直接检测 |
-| Stale read-write | 一个 Agent 读取 schema，另一个修改 schema | Reader 可能写另一个文件 |
-| Semantic invariant | 两个 patch 修改不同 module，却一起破坏 API contract | 没有共享 physical write |
-| Aggregate constraint | 两个 Agent 分别花掉同一笔剩余预算 | 写入可能落在不同 purchase record |
-| Authority conflict | 两条分支消费或扩张同一份 approval | 被保护对象是 capability，不只是数据 |
-| External-order conflict | Announcement、deployment 或 ticket 必须按顺序发生 | 单个 effect 都可能合法 |
-| Irreversible duplicate | 两条分支重复发送付款或邮件 | Deduplication 需要 semantic identity |
-| Outcome conflict | 两个局部成功 subtask 组成一个无效整体 | 冲突只存在于 workflow level |
+| `sandbox`、容器、独立 `worktree` | 隔离进程、文件和中间状态 | 多个结果是否满足同一条 API、预算或业务约束 |
+| reducer、CRDT | 让并行更新以确定方式合并或收敛 | 合并后的值是否符合用户目标 |
+| 数据库事务和锁 | 保护已知行、key、predicate 或资源 | shell、浏览器和跨服务工具背后的逻辑资源怎样识别 |
+| 人工审批 | 在某个时刻批准一个动作 | 状态、目标或权限变化后，旧审批是否仍适用 |
+| 单 Agent 局部测试 | 验证一个分支在局部环境中的行为 | 多个分支合并后的跨模块和全局结果 |
+| 补偿操作 | 在部分失败后修正可补偿效果 | 让已经发生的外部历史真正消失 |
 
-Conflict graph 可以有 false positive。只要系统说明为什么认为两个 work unit 冲突，并允许 deterministic validation 消除 edge，这种保守性可以接受。真正不安全的是因为 path 不同，就默认任务彼此独立。
+这些机制都值得保留。问题不是它们无效，而是它们位于不同层次。一个完整的并行 Agent 系统需要把它们放进同一条“准备、验证、提交”路径里。
 
-## 近期系统放在一起说明了什么
+## 一个更实用的执行模型：先准备，再提交
 
-没有一个项目直接实现本文全部契约，但近期工作已经让各个组件变得具体。
-
-这一节引用的若干系统是 2026 年刚发布的 preprint，还不是已经稳定下来的 production standard。文中的实验数字应被理解为作者报告的机制证据，而不是独立确认的普适结论。下面的综合主要依赖多篇工作共同暴露出的边界，而不是某一个 headline number。
-
-[Atomix](https://arxiv.org/abs/2602.14849) 是最接近 tool-effect transaction 的系统。它给调用标记 epoch，维护 per-resource frontier，在可能时 buffer effect，并在 abort 时补偿已经 externalized 的效果。其实验说明，progress-aware commit 可以避免 losing speculative branch 污染外部环境，也能在 contention 下保持正确性。它证明 tool call 可以被当作 transaction effect 管理，而不是立即接受。
-
-[CoAgent](https://arxiv.org/abs/2606.15376) 直接研究 multi-agent concurrency。它指出，长 inference interval 让 lock 和完整 optimistic retry 都很昂贵，于是使用预先确定的 serialization order、order-filtered read、effect repair 和 undoable tool。报告结果说明，Agent-assisted repair 有可能恢复经典方案丢掉的并行度。这里最重要的设计启示是：runtime 可以要求 Agent 修复受影响 dependency，而不必丢弃整条 trajectory；但 effect tracking 与 undo semantics 仍必须由机械机制保证。
-
-[Provenact](https://arxiv.org/abs/2608.02764) 揭示另一个缺失维度：共享 budget、inventory、approval 和 risk state 在变化时，authorization 会过期。它定义 policy-state serializability，要求 effect 在真正 commit 以前，针对紧邻 commit 的 policy state 仍然被授权。这比把 policy state 当普通 prompt context 强得多，也说明 concurrency control 与 governance 不能放在两个互不知情的 control plane。
-
-[STORM](https://arxiv.org/abs/2605.20563)、[S-Bus](https://arxiv.org/abs/2605.17076) 和 [CodeCRDT](https://arxiv.org/abs/2510.18893) 分别从 workspace state mediation、observable read set 和 deterministic convergence 处理协作。它们合起来说明，write-time mediation、read-set reconstruction 与收敛都很重要，但价值取决于 workload topology 和 semantic invariant。
-
-[Semisolates 与 `try`](https://www.usenix.org/conference/osdi26/presentation/lamprou) 以及 [`hS`](https://www.usenix.org/conference/osdi26/presentation/liargkovas) 说明，即使组件是 opaque subprocess，runtime 也可以在不重写组件的情况下捕获、检查、延迟并选择性应用 effect。Agent 的许多工具正是 shell command 或第三方 binary，无法依赖 SDK 内插桩。这些系统说明 system-level effect capture 是可行的，下一层工作是把它和 task semantics、authority 连接起来。
-
-两项经验研究说明，即使 Agent 会互相通信，也不能假设正确协调会自然出现。[CooperBench](https://arxiv.org/abs/2601.13295) 报告两个 coding agent 协作时，平均成功率比单个 Agent 完成两个任务低 30%，并把问题归因于模糊或错误通信、违背承诺和对对方计划的错误预期。AgenticFlict 则在生态尺度观察到频繁 textual conflict。它们都不能证明 contract-valid serializability 是唯一解法，但足以反驳“更强模型加更多消息就能自动解决并发”的假设。
-
-因此，综合结论不是“把全部 tool call 塞进一个数据库 transaction”。正在出现的系统已经把问题拆成 effect capture、read-set reconstruction、state coordination、adaptive scheduling、policy validation、repair 和 compensation。通用 Agent runtime 还需要一份契约，告诉这些机制什么叫作成功组合。
-
-## 面向并行 Agent 的 commit architecture
-
-下面这套架构允许 reasoning 和 read-only exploration 保持并行，同时把 effect visibility 变成显式协议决定。
+可以把并行 Agent 的工作分成三个阶段。
 
 ```mermaid
-flowchart TD
-    U[用户任务与 global outcome contract] --> P[Planner 创建 work unit]
-    P --> X[Snapshot epoch 与 authority epoch]
-    X --> A[Agent A speculative execution]
-    X --> B[Agent B speculative execution]
-    A --> EA[Read set 与 effect manifest]
-    B --> EB[Read set 与 effect manifest]
-    EA --> G[Semantic conflict graph]
-    EB --> G
-    G --> V[Read, policy, authority, outcome validation]
-    V -->|独立或可修复| O[选择有效 commit order]
-    V -->|过期或无效| R[Rebase, repair, replan 或 abort]
-    O --> C[Commit bufferable 与 reversible effect]
-    C --> I[Linearize irreversible effect]
-    I --> Q[验证 global outcome contract 并记录 provenance]
+flowchart LR
+    U[用户任务与验收条件] --> P[多个 Agent 并行读取、分析和准备方案]
+    P --> M[每个 Agent 输出候选结果和效果清单]
+    M --> V[统一提交器检查状态、冲突、权限和全局结果]
+    V -->|通过| C[提交可缓冲修改]
+    V -->|状态已变化或存在冲突| R[局部重做、降级为串行或请求用户决定]
+    C --> E[最后执行不可逆外部动作]
 ```
 
-### 1. 执行前声明 work unit
+### 第一阶段：并行准备
 
-Orchestrator 先创建稳定 work-unit identity，至少包含：
+每个 Agent 可以在稳定快照上进行分析、生成代码、构建候选计划或准备工具参数。此时尽量不要让结果对外可见。
 
-- parent task 与 delegation path；
-- intent 和 target object；
-- snapshot epoch；
-- authority epoch 与 capability scope；
-- expected output 与 outcome check；
-- risk class 和允许的最高 effect class；
-- 预计 reasoning cost 与 abort cost。
+除了补丁或工具调用，Agent 还应返回一份简短的“效果清单”，说明：
 
-声明可以不完整，dependency 仍由 Agent 动态发现。它的作用是确定任务变化时哪些字段必须更新，以及 commit coordinator 有权接受什么。
+- 它读取了哪些关键版本和对象；
+- 它计划修改或消费什么；
+- 它依赖哪些假设；
+- 它使用什么权限或审批；
+- 它认为怎样才算完成。
 
-### 2. 在 effect-aware speculative environment 中运行
+例如：
 
-每个 work unit 获得 isolated 或 semisolated execution view：
-
-- worktree、copy-on-write filesystem、container、browser profile 或 database snapshot；
-- 已知 API 的 intercepted tool adapter；
-- opaque subprocess 的 system-level observation；
-- 能够 buffer 的本地 effect；
-- compensatable 或 irreversible action 前的明确 barrier。
-
-Read-only network/search 可以立即执行，file write 可以保持私有。Cloud mutation、message、payment、publication 和 credential use 需要更强 gate。
-
-### 3. 重建 physical 与 semantic footprint
-
-Tool schema 应尽可能声明 resource template：
-
-```text
-read:    repo:{id}:symbol:{name}
-write:   repo:{id}:api-contract:{service}
-use:     budget:{project}
-send:    channel:{launch-announcement}
-consume: approval:{approval-id}
+```yaml
+work_unit: update-authentication
+intent: migrate service authentication to the new audience value
+reads:
+  - resource: api/auth-contract
+    version: git:8f31c2
+  - resource: deployment/config
+    version: git:27a9d0
+proposed_effects:
+  - modify: src/auth/validator.ts
+  - modify: deploy/service.yaml
+shared_constraints:
+  - token audience must match across code and deployment
+authority:
+  scope: repository:eunomia/service-a
+acceptance:
+  - integration test passes
+  - old audience is absent from production config
 ```
 
-声明总会不完整，因此 runtime 还要补充：
+这份清单不需要完美预测所有副作用。它首先让提交器拥有比“Agent 返回了一段文本或一个 exit code”更多的结构化信息。
 
-- file、process、database 和 network observation；
-- versioned tool input/output；
-- repository dependency graph 与 test coverage；
-- policy label 与 capability identifier；
-- application invariant；
-- Agent 产生的 dependency explanation 及 confidence。
+### 第二阶段：统一验证
 
-LLM 可以帮助提出 semantic edge，但不应成为唯一 commit oracle。高后果决策应主要由 deterministic schema、version check、test、policy 和 resource key 决定。模型更适合高召回地定位潜在冲突，再请求针对性验证。
+提交器收集多个候选结果后，检查它们是否可以安全组合。
 
-### 4. 构建 conflict graph，而不是拿一把 global lock
+它至少需要检查：
 
-当一个 work unit 可能使另一个失效时，coordinator 建立 edge，并记录原因和消除方式：
+1. **关键读取是否过期。** Agent 开始工作后，相关文件、数据库对象、策略或外部资源是否已经变化？
+2. **是否存在直接冲突。** 两个工作单元是否写同一对象，或依赖彼此的旧版本？
+3. **是否违反共享约束。** 不同对象上的修改是否共同突破预算、配额、唯一性或 API invariant？
+4. **权限是否仍有效。** 审批、凭据和委派关系在真正提交时是否仍覆盖这些效果？
+5. **局部和全局验收是否通过。** 每个结果单独正确之外，合并后的系统是否完成用户的整项任务？
+6. **外部动作的顺序是否正确。** 哪些动作必须只执行一次，哪些必须在其他修改成功后才能发生？
 
-```text
-A -> B
-reason: B 读取 API schema v12；A 提议 v13
-discharge: 在 v13 上重新运行 B 的 compatibility test
-```
+验证失败不一定意味着整项任务重做。提交器可以只让受影响的 Agent 在新状态上重新规划，也可以把冲突部分降级为串行执行，或者向用户呈现一个具体决策，而不是简单地说“merge conflict”。
 
-Graph 可以找出仍能并行 commit 的独立 component，也可以只 serialize 真正冲突的 effect，而不是在整个 reasoning 期间锁住完整 repository 或 task。
+### 第三阶段：提交真实效果
 
-### 5. Commit-time validation
+验证通过后，系统先提交可缓冲的修改，例如文件、数据库事务或暂存配置；最后再执行邮件、付款、生产部署等不可逆动作。
 
-Commit 前至少做四类验证。
+这个顺序能减少一种常见错误：Agent 先把外部动作做了，随后才发现代码、审批或其他分支无法提交。不可逆动作越晚发生，系统越容易在失败时保持一个诚实、可恢复的状态。
 
-**Read validation：**计划依赖的 state version 或假设有没有变化？如果变化，能否只修复受影响 suffix，而不是重跑整个 work unit？
+## 提交器真正需要保护的是“逻辑资源”
 
-**Policy and authority validation：**当前 principal 是否仍然可以对这个 target、amount、environment 和时间执行精确 effect？Capability 是否已消费、撤销、缩小或重新委派？
+按文件路径检测冲突很容易，按逻辑资源检测冲突更难，但后者决定了系统是否真的可靠。
 
-**Outcome validation：**Earlier commit 发生以后，test、deployment probe、ledger predicate、document consistency check 或其他 oracle 是否仍通过？
+逻辑资源可以是：
 
-**Global validation：**组合结果是否满足原始用户任务？一组 locally successful output 不会自动构成成功 workflow。
+- 一个 API 或数据格式的兼容性约束；
+- 一笔共享预算或一个配额；
+- 一份一次性审批；
+- 一个发布窗口；
+- 一项“只能选择一个方案”的用户决策；
+- 一组必须保持一致的代码与部署配置；
+- 一条信息流策略或敏感数据边界。
 
-Human approval 不能冻结这些检查。用户可以在时间 \(t\) 批准 proposal，但真正执行的 \(t+\Delta\) 时状态可能已经改变。Approval 记录 intent 与 authority，runtime 仍需检查 commit-time state predicate。
+运行时不可能自动理解所有业务语义，因此需要组合几种方法：
 
-### 6. 按风险顺序 commit effect
+- 工具和应用显式声明资源、前置条件和效果；
+- 系统根据文件、数据库、进程和网络行为补充实际读写集合；
+- 测试、schema、policy 和 invariant checker 提供确定性验证；
+- 模型只在结构化规则无法覆盖时辅助识别可能的语义冲突；
+- 高风险或不可逆动作保留明确的人工提交点。
 
-一个安全的默认顺序是：
+模型可以帮助发现“两个补丁似乎修改了同一接口语义”，但最终安全边界不应只依赖模型一句“看起来没问题”。能用版本、类型、测试、策略和事务证明的部分，应尽量使用确定性机制。
 
-1. metadata 与 provenance；
-2. bufferable local state；
-3. reversible external effect；
-4. compensatable effect；
-5. irreversible effect。
+## 哪些任务可以直接并行
 
-Irreversible effect 需要明确 linearization point 和 semantic idempotency identity。后续失败时，记录必须说明发生了 compensation，而不是假装原 effect 从未存在。
+并行不是越多越好。一个实用调度器可以按效果风险选择不同策略。
 
-### 7. 修复受影响 suffix
+| 工作类型 | 推荐策略 | 例子 |
+| --- | --- | --- |
+| 独立只读任务 | 直接并行 | 搜索文档、读取不同日志、运行互不影响的分析 |
+| 可缓冲且资源明确不同 | 并行准备，提交前做版本验证 | 在独立模块生成补丁、准备多个候选报告 |
+| 可能共享隐藏约束 | 并行准备，统一运行集成测试和约束检查 | 修改 API、schema、预算、发布计划 |
+| 已知热点资源 | 锁定、分片或直接串行 | 同一配置对象、同一额度、同一审批 |
+| 可补偿外部动作 | 统一提交并记录补偿语义 | 创建工单、可回滚的基础设施修改 |
+| 不可逆或高后果动作 | 最后执行，并保留明确审批 | 付款、发信、删除数据、生产发布 |
 
-完整 abort 一条长 trajectory 会浪费大量仍然有效的 reasoning。CoAgent 展示了更符合 Agent 特征的方向：通知 work unit 哪个 dependency 已改变，定位 plan 中使用它的部分，只撤销或丢弃 dependent effect，再让 Agent 修复这个 suffix。
+这也给出一个性能上的重要结论：提交协议不应该让所有工作都走最重的路径。大量只读和真正独立的任务可以保持完全并行；只有触碰共享状态、权限或外部效果的部分需要额外协调。
 
-哪些 effect 已经可见、inverse 是否成功，必须由 runtime 判断，而不是让模型自行叙述。模型可以修复依赖 intent 的 reasoning，不能把已经发生的 effect 通过文字“解释掉”。
+## 这和数据库的可串行化有什么关系
 
-## Agent runtime 的 isolation level
+数据库中的可串行化要求：一段并发执行的结果，应当等价于这些事务按照某个顺序一个接一个执行。
 
-对所有任务强制最强模式会很昂贵。Runtime 应像数据库一样暴露有名字、有明确 anomaly 的 level。
+这个思想对 Agent 很有用，但还不够。数据库通常假设每个 transaction 在串行执行时本身就是正确的；Agent 的计划却可能基于已经过时的仓库、旧权限、错误任务理解或不完整观察。即使系统能找到某个串行顺序，那个顺序也可能不是用户允许的结果。
 
-| Level | 保证 | 适合场景 | 剩余风险 |
-| --- | --- | --- | --- |
-| Parallel read | 并发只读调用，不共享 mutation | Search、retrieval、独立分析 | 外部 source 仍可能在两次 read 之间变化 |
-| Workspace snapshot | 每个 worker 使用 isolated file/environment snapshot | 独立 code generation 与 artifact production | Clean merge 仍可能隐藏 semantic/global conflict |
-| Effect snapshot isolation | 记录 effect set，commit 时验证 write-write conflict | 低 contention 的代码与数据任务 | Write skew、stale semantic read、authority drift |
-| Effect serializable | Committed effect 等价于某个串行 work-unit order | 共享 repository、database、cloud resource | 被选中的串行历史仍可能违背 task/authority contract |
-| Contract-valid effect serializable | 串行顺序加 read repair、commit-time authority、local/global outcome predicate | 有后果的 multi-agent workflow | 正确性依赖 contract 和 effect mapping 的完整度 |
-| Strict contract-valid | 还保留已完成 approval 与 visible effect 的 real-time constraint | Payment、deployment control、security、publication | 协调成本最高 |
+因此，Agent 提交还需要更强的条件。对每个准备提交的工作单元，都要保证：
 
-真正的产品决策不是“parallel on/off”，而是 workload 能容忍哪些 anomaly。
+- 它依赖的关键读取仍然有效，或者已经针对新状态修复；
+- 它的权限在提交时仍覆盖实际效果；
+- 它自己的验收条件成立；
+- 所有工作单元合在一起后，整项任务的全局验收条件成立；
+- 外部可见历史与这个合法的串行解释一致。
 
-## 调度需要 adaptive，也需要 effect-aware
+如果需要一个研究术语，可以把这个性质称为“契约有效的效果可串行化”（contract-valid effect serializability）。名字不是重点。重点是串行顺序不仅要存在，还必须在当前状态、权限和用户目标下仍然成立。
 
-最佳策略取决于冲突概率、abort cost、effect reversibility 和后果：
+## 一个可实现的系统架构
 
-\[
-score(W) = f(P_{conflict}, C_{abort}, C_{block}, R_{effect})
-\]
+一个通用实现不需要先发明完整的“Agent 数据库”。可以从几个独立组件开始：
 
-- \(P_{conflict}\)：根据历史 trace、声明 resource 和当前活动估计冲突概率；
-- \(C_{abort}\)：repair 会损失的 token、tool time、human review 与 external work；
-- \(C_{block}\)：等待带来的 latency 和 resource cost；
-- \(R_{effect}\)：effect consequence 与 reversibility。
+1. **工作单元标识。** 把跨多个 model call、tool call 和子进程的同一项工作绑定到稳定 ID。
+2. **效果适配器。** 在文件、Git、数据库、cloud API、浏览器和 MCP 工具边界记录读、写、消费和外部可见动作。
+3. **版本与前置条件。** 为关键资源保存版本、hash、ETag、policy version 或其他可比较状态。
+4. **冲突检测器。** 先处理明确的物理冲突，再使用 schema、测试、policy 和语义分析发现更高层冲突。
+5. **权限重新验证。** 在效果即将提交时，重新检查 principal、scope、目标、预算、审批和委派链。
+6. **全局验收器。** 运行跨分支测试、预算约束、发布规则和用户定义的最终结果检查。
+7. **提交日志。** 记录哪些候选结果被接受、拒绝、重做，以及不可逆动作何时发生。
 
-低冲突 read-heavy work 适合 optimistic execution；高 contention、短 mutation 适合 lock；长 reasoning、输出可修复时适合 speculative execution 加 suffix repair；不可逆 effect 即使准备阶段并行，也应该在狭窄 commit gate 中 serialize。
+系统级观测在这里有一个实际作用：Agent 可能通过 shell script、Python 子进程或第三方工具产生没有在 harness 中声明的效果。文件、进程和网络层的观察可以补全效果清单，并发现“工具声称只读，实际却写了文件或访问了外部网络”的情况。不过，系统事件只能告诉提交器发生了什么，不能单独判断这些效果是否符合用户任务；它仍需要上层的资源和验收语义。
 
-由此可以得到一条实用原则：
+## 怎样评估这个设计
 
-> 尽量并行 evidence gathering 与 proposal construction，只 serialize 为保存契约所需的最小 effect boundary。
+一个可信的评测需要同时测正确性和协调成本，而不是只展示“成功阻止了几个冲突”。
 
-这个 boundary 可能是一条 API call、一组相关 repository change、一次 budget allocation，或者最终 artifact 的 publication。
+可以构建四类工作负载：
 
-## 怎样评估这项提案
+- **代码协作：**多个 Agent 修改不同文件，但共享 API、schema、配置或测试约束；
+- **数据与预算：**多个 Agent 写不同记录，却共享额度、唯一性和审批；
+- **云与运维：**多个 Agent 并行准备部署、扩容、回滚和发布；
+- **外部沟通：**多个 Agent 创建工单、邮件、公告或其他可见效果。
 
-有说服力的实验必须在相同 task quality 下比较，并覆盖 textual merge 检测不到的冲突。
+对比基线包括：
 
-### Workload corpus
+- 无协调的并行执行；
+- 独立 `worktree` 加普通 merge；
+- 全局串行；
+- 已知资源上的锁；
+- 仅做版本验证的 optimistic commit；
+- 加入共享约束、权限和全局验收的统一提交。
 
-至少包含：
+核心指标应包括：
 
-1. 独立 read-only research；
-2. 不共享 invariant 的 disjoint file edit；
-3. same-file write conflict；
-4. cross-file API/schema conflict；
-5. stale-read configuration change；
-6. aggregate budget、quota、inventory write skew；
-7. one-time approval 与 delegated-authority conflict；
-8. deploy-then-announce 这类有顺序的 external action；
-9. duplicate irreversible effect；
-10. 文本没有 overlap、事实和结论却互相矛盾的 document task。
+- 最终任务正确率，而不只是工具成功率；
+- 直接冲突和语义冲突的召回率；
+- 不必要串行化造成的延迟；
+- abort、重做和模型 token 成本；
+- 重复或错误外部效果的数量；
+- 权限过期后仍成功提交的比例；
+- 用户被打断和重新审批的次数；
+- 提交失败后能否解释具体原因。
 
-Ground truth 应声明允许的 serial order、global outcome predicate 和 effect reversibility。
+最重要的消融实验是逐项移除状态验证、共享约束、权限检查和全局验收。假如某一层对真实错误没有贡献，它就不应成为默认成本。
 
-### Baseline
+## 适用范围与可证伪条件
 
-比较：
+这个设计主要面向会修改共享状态、使用权限或产生外部效果的工具型 Agent。聊天、独立检索和完全隔离的候选生成任务，通常不需要这样的提交协议。
 
-- sequential single-agent execution；
-- naive parallel tool execution；
-- isolated worktree/sandbox 加 post-hoc merge；
-- reducer 或 CRDT state convergence；
-- pessimistic resource locking；
-- optimistic effect validation 加完整 retry；
-- 不含 task/authority contract 的 effect serializability；
-- 带 targeted repair 的 contract-valid effect serializability。
+它也有明显局限：
 
-### Metric
+- 逻辑资源和全局约束不可能全部自动发现；
+- 语义冲突检测可能产生误报，使本可并行的任务被串行化；
+- 长时间 Agent 被 abort 后，重做会消耗大量 token 和工具成本；
+- 外部服务如果不提供幂等键、版本条件或准备阶段，提交器很难提供强保证；
+- 用户目标本身可能模糊，无法转成可靠的验收条件；
+- 模型辅助判断不能替代确定性的权限和事务边界。
 
-测量：
+本文的中心判断会在以下结果下被削弱：
 
-- final task success；
-- serializability violation；
-- state 可串行化但 contract 仍被违反的比例；
-- semantic conflict recall 与 false-positive rate；
-- irreversible-effect leakage；
-- wall-clock speedup；
-- model/tool cost；
-- full abort 与 suffix repair 数量；
-- blocked time 与 deadlock；
-- human review time；
-- commit-protocol overhead；
-- reversibility 未知或错误的 effect 比例。
+- 在相同资源和人工成本下，普通 `worktree`、merge 和完整测试已经能达到同样的最终正确率；
+- 真实并行 Agent 工作中，跨文件、跨服务和聚合约束冲突极少，协调成本长期高于避免的损失；
+- 大多数高风险工具都能由底层数据库或 API 自己提供完整事务语义，Agent runtime 不需要跨工具提交；
+- 全局验收无法比单 Agent 局部检查更早或更准确地发现错误；
+- 语义资源声明和冲突检测的维护成本高到无法在生产中使用。
 
-Ablation 应分别移除 semantic resource mapping、authority revalidation、global outcome predicate 和 random post-commit audit。如果这些组件不改变 correctness 或 diagnosis，更强契约就没有必要。
+这些都是可以测量的条件。一个更复杂的提交协议只有在它能以可接受成本减少真实错误时才值得部署。
 
-## 适用范围与替代解释
+## 现在可以先做什么
 
-本文面向会修改共享或外部可见状态的工具型 Agent。Read-only fan-out、独立 simulation 和 embarrassingly parallel retrieval 不需要重型 commit protocol。
+不需要等待完整系统，开发者现在就可以采用几个简单规则：
 
-几种替代解释可能削弱本文判断。
+1. 默认只并行执行独立只读工具；有副作用的工具需要显式声明是否可以并行。
+2. 让 coding agent 在独立工作区生成补丁，但把合并、集成测试和发布视为单独的提交阶段。
+3. 对预算、配额、审批和版本使用 compare-and-set、ETag、一次性 token 或服务端消费记录。
+4. 把邮件、付款、删除和生产发布放在所有可缓冲修改验证成功之后。
+5. 为整项用户任务定义至少一个全局验收条件，不要只依赖每个子 Agent 的“成功”状态。
+6. 记录每个外部动作属于哪个工作单元、使用了什么权限、基于什么资源版本。
 
-第一，更好的 task decomposition 也许能消除绝大多数冲突。如果 planner 能稳定分配 disjoint resource 和 invariant，workspace isolation 加测试可能足够。当前 coding benchmark 说明 decomposition 仍不可靠，但更强模型和更好的项目 metadata 可能改善这一点。
-
-第二，service API 可以吸收一部分问题。数据库提供 serializable transaction，支付 API 提供 idempotency，deployment service 提供 compare-and-swap，这些都会降低 runtime 责任。但跨 service contract 仍存在，例如同时协调 repository change、feature flag、message 与 approval。
-
-第三，更强自动测试可能让 semantic dependency tracking 在代码场景中显得多余。Test 是很好的 outcome predicate，但通常不完整，往往在昂贵工作已经完成后运行，也不能撤销 test environment 以外已经暴露的 effect。
-
-第四，model-based repair 可能不如完整 rerun 可靠。Repair request 也可能保留无效 hidden assumption 或引入新变化。因此 runtime 应比较 targeted repair 与 full replay，在 dependency slice 不确定时回退。
-
-第五，contract authoring burden 可能超过收益。手工标注每个 resource 和 invariant 无法扩展。架构必须渐进采用：为常见 effect 提供强默认值，自动采集 physical footprint，复用 policy schema，只在高后果 boundary 显式声明 contract。
-
-## 可证伪条件
-
-出现下列证据时，本文中心判断应被拒绝或缩小范围：
-
-- 在相同成本下，worktree isolation 加普通测试已经能在 semantic conflict、external effect 和 authority change 上匹配 contract-valid effect serializability。
-- 真实生产 workload 的冲突率足够低，naive parallelism 加 human review 总成本更低，结果也没有实质变差。
-- Dynamic effect/dependency reconstruction 无法在不过度制造 false positive 的情况下达到有用 recall，最终迫使系统 serialize 大多数工作。
-- Commit-time authority 和 global outcome predicate 没有发现 resource-level serializability 以外的新违规。
-- Targeted repair 在长任务中比 full retry 更不可靠或更昂贵。
-- Service-level transaction 与 idempotency 在实践中覆盖了几乎所有 cross-tool workflow。
-- Commit protocol 的协调开销和 latency 超过它避免的 operational loss。
-
-这些条件都可以测量。研究应该报告弱机制在哪些地方更好，而不是默认所有任务使用最强 level。
-
-## 开发者现在可以做什么
-
-不需要先实现完整 runtime，也能立刻改善系统。
-
-1. **给 tool 分类。** 标注 read-only、bufferable、reversible、compensatable 和 irreversible；未知且高后果的 tool 默认关闭并行。
-2. **给 work unit 稳定 identity。** 跨 model call 和 subprocess 携带 task、branch、snapshot、policy 与 authority epoch。
-3. **记录 read version，不只记录 write。** Patch 即使写独立文件，也可能基于过期 schema。
-4. **Commit 前保持 effect 私有。** 使用 worktree、semisolate、staging API、dry run 和 preview mode。
-5. **重新验证 approval。** Approval 绑定 target、amount、state predicate 和 expiry，并在 effect 前立即检查。
-6. **定义一个 global outcome predicate。** 每条 branch 的 test 都通过，不代表组合目标正确。
-7. **Linearize irreversible action。** 准备阶段并行，真正执行只通过一个带 semantic idempotency 的窄 coordinator。
-8. **暴露 isolation level。** 用户应该知道“parallel”只是 concurrent execution、isolated workspace，还是包含 serializable commit contract。
-9. **保存 provenance。** 记录 work unit 为什么 commit、repair、reorder 或 abort，以及对应 conflict edge 和 validation result。
-10. **测量 wasted reasoning。** Abort cost 是 Agent concurrency control 的一部分，不只是独立的 model-serving metric。
+这些做法不能解决所有语义冲突，但能把最危险的模式从“多个 Agent 各自成功后直接落地”，改成“多个 Agent 并行准备，由一个明确边界决定哪些结果真正生效”。
 
 ## 结论
 
-并行 Agent 不是串行 Agent 的简单加速版。一旦它们读取和修改共享状态，就变成一种特殊 distributed transaction system：计划在线生成，read set 不透明，执行持续数分钟，权限会变化，effect 跨越多个互不相关的 service，而且部分动作无法撤销。
+并行 Agent 的难点不是让几个模型或工具同时运行。真正困难的是，当它们都完成以后，系统怎样证明组合结果仍然符合用户任务。
 
-产业已经拥有每一层的机制。Agent SDK 调度并行调用，worktree 与 sandbox 隔离中间状态，reducer 与 CRDT 合并 update，数据库 serialize row，Atomix 管理 transactional tool effect，CoAgent 修复并发 trajectory，Provenact 重新验证 policy state，semisolate 捕获 opaque process effect。
+`worktree` 和 `sandbox` 可以隔离执行，reducer 和 CRDT 可以合并状态，数据库事务可以保护已知资源，policy engine 可以检查单个动作。这些机制都不能单独判断多个局部结果是否共同破坏 API、预算、审批、发布顺序或用户目标。
 
-缺失的是组合契约。正确运行不仅需要一个收敛状态，也不仅需要某种串行解释；它需要一个在任务、权限与结果条件下仍然有效的串行解释。
+更可靠的设计是让 Agent 并行准备候选结果，并在真实副作用出现前经过统一提交：重新验证关键读取，检查物理和语义冲突，确认权限，运行局部与全局验收，并把不可逆动作留到最后。
 
-Contract-valid effect serializability 提供了这样的目标。它不要求 reasoning 串行。Agent 仍然可以并行 search、plan、generate 和 test，只把真正冲突且有后果的 effect 送入 commit protocol。这样，系统最终能回答的不只是“这些分支合并成功了吗”，还包括“组合结果为什么在 commit 时仍被授权、仍基于当前状态，并且仍然满足用户任务”。
+这样做不会消除 Agent 的不确定性，也不应该把所有任务都变成串行。它提供的是一个清楚的责任边界：并行 worker 负责提出方案，提交器负责决定哪些方案可以一起成为真实世界的一部分。
 
 ## 参考资料
 
-1. OpenAI, [Running agents: function-tool concurrency](https://openai.github.io/openai-agents-python/running_agents/).
+1. OpenAI Agents SDK, [Running agents](https://openai.github.io/openai-agents-python/running_agents/).
 2. Anthropic, [Parallel tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use).
-3. Microsoft, [AutoGen agents and parallel tool calls](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html).
-4. Google, [ADK ParallelAgent](https://adk.dev/agents/workflow-agents/parallel-agents/).
-5. LangChain, [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/use-graph-api) 与 [concurrent update errors](https://docs.langchain.com/oss/python/langgraph/errors/INVALID_CONCURRENT_GRAPH_UPDATE).
-6. Model Context Protocol, [Sampling with tools and parallel tool use](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling).
-7. Kung and Robinson, [On Optimistic Methods for Concurrency Control](https://db.cs.cmu.edu/papers/1981/kung-tods1981.pdf), ACM TODS 1981.
-8. Garcia-Molina and Salem, [Sagas](https://www.cs.princeton.edu/research/techreps/598), 1987.
-9. Mohammadi et al., [Atomix: Timely, Transactional Tool Use for Reliable Agentic Workflows](https://arxiv.org/abs/2602.14849), 2026.
-10. Lyu et al., [CoAgent: Concurrency Control for Multi-Agent Systems](https://arxiv.org/abs/2606.15376), 2026.
-11. Peng and Wu, [Stateful Governance for Concurrent Agentic Systems](https://arxiv.org/abs/2608.02764), 2026.
-12. Zhou et al., [ATCC: Adaptive Concurrency Control for Unforeseen Agentic Transactions](https://arxiv.org/abs/2603.13906), 2026.
-13. Liu et al., [Multi-agent Collaboration with State Management](https://arxiv.org/abs/2605.20563), 2026.
-14. Khan, [S-Bus: Automatic Read-Set Reconstruction for Multi-Agent LLM State Coordination](https://arxiv.org/abs/2605.17076), 2026.
-15. Pugachev, [CodeCRDT: Observation-Driven Coordination for Multi-Agent LLM Code Generation](https://arxiv.org/abs/2510.18893), 2025.
-16. Khatua et al., [CooperBench: Why Coding Agents Cannot be Your Teammates Yet](https://arxiv.org/abs/2601.13295), 2026.
-17. Ogenrwot and Businge, [AgenticFlict](https://arxiv.org/abs/2604.03551), 2026.
-18. Lamprou et al., [Controlling Opaque-Component Effects with Semisolates and Try](https://www.usenix.org/conference/osdi26/presentation/lamprou), OSDI 2026.
-19. Liargkovas et al., [hS: Speculative Script Reordering at Subprocess Granularity](https://www.usenix.org/conference/osdi26/presentation/liargkovas), OSDI 2026.
+3. Google Agent Development Kit, [Parallel agents](https://adk.dev/agents/workflow-agents/parallel-agents/).
+4. Microsoft AutoGen, [Agents and tool execution](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html).
+5. LangChain, [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/use-graph-api).
+6. Model Context Protocol, [Sampling with tools specification](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling).
+7. Philip A. Bernstein, Vassos Hadzilacos, and Nathan Goodman, [Concurrency Control and Recovery in Database Systems](https://www.microsoft.com/en-us/research/people/philbe/book/), 1987.
+8. Hector Garcia-Molina and Kenneth Salem, [Sagas](https://www.cs.princeton.edu/research/techreps/598), 1987.
+9. Marc Shapiro et al., [Conflict-Free Replicated Data Types](https://inria.hal.science/inria-00609399), 2011.
+10. Eunomia Research, [What Should an AI Agent Trace Keep? Observability Under a Fixed Evidence Budget](https://eunomia.dev/research/agent-trace-evidence-budget/), 2026.


### PR DESCRIPTION
## Why

The second Research brief was technically dense but reader-hostile. Its old title and opening required readers to understand a coined property, several English abstractions, and a runtime comparison table before they had seen the concrete problem. That confused academic tone with technical depth.

This revision keeps the durable question and stable URL, but rebuilds the article around the human reader's path from a real failure to an engineering decision.

## What changed

- retitle the English and Chinese brief in ordinary language:
  - `When Several AI Agents Work at Once, Who Makes Sure the Final Result Is Right?`
  - `多个 AI Agent 同时工作时，谁来保证最终结果是对的？`
- open with a concrete two-worktree authentication failure instead of a taxonomy or formal definition
- use code changes, shared budgets, approvals, and irreversible actions to explain the problem
- reduce the central design to a clear rule: agents may prepare work in parallel, while shared and irreversible effects pass through one validation and commit step
- move the formal term `contract-valid effect serializability` late in the article, after the reader already understands the idea
- preserve architecture depth through an effect manifest, prepare/validate/commit design, logical-resource discussion, implementation components, evaluation plan, limitations, and falsification conditions
- update both Research index pages with the reader-facing titles and descriptions

## Skill changes

- make `eunomia-research-report` explicitly target technically qualified human readers
- add a mandatory reader contract and one-pass readability gate
- distinguish focused Research briefs from broad weekly reports so narrow articles are not padded to satisfy the weekly 20/20/10 corpus rule
- treat platform Deep Research reports as research input rather than publishable prose
- require a concrete situation before taxonomies, equations, source matrices, or coined abstractions
- extend `blog-writing-style` to Research pages with progressive disclosure, terminology, table, diagram, Chinese-language, and final-reader-test rules
- revise the research-method reference around reader decisions and human-readable synthesis

## Scope

The public route is unchanged:

- `/research/parallel-agent-effect-serializability/`
- `/zh/research/parallel-agent-effect-serializability/`

No application code, routing, workflow, or deployment configuration is changed.

## Validation

Expected repository CI covers:

- Markdown and Mermaid rendering
- skill and content parsing
- lint and TypeScript checks
- full Next.js static export
- sitemap, canonical, hreflang, structured-data, link, browser, and HTTP audits

The PR should be merged only after all checks pass. The merge commit must then deploy successfully and the public English and Chinese pages must show the new titles and openings.