### PR TITLE
Remove Daily Report disclosure callouts

### DIFF
--- a/.agents/skills/eunomia-research-report/SKILL.md
+++ b/.agents/skills/eunomia-research-report/SKILL.md
@@ -1,41 +1,26 @@
 ---
 name: eunomia-research-report
-description: Research, write, validate, and publish source-grounded Eunomia Daily Reports for technical readers. Use when an agent needs to use platform Deep Research or direct primary-source research, identify a non-trivial systems gap, propose high-quality academic and production ideas, write bilingual AI-generated reports under the stable `/research/` URLs, or revise an existing Daily Report. Public reports are AI-generated and must never be represented as human-reviewed unless a named human review actually occurred.
+description: Research, write, validate, and publish source-grounded Eunomia Daily Reports for technical readers. Use when an agent needs to use platform Deep Research or direct primary-source research, identify a non-trivial systems gap, propose high-quality academic and production ideas, write bilingual reports under the stable `/research/` URLs, or revise an existing Daily Report.
 ---
 
 # Eunomia Daily Report
 
-Produce technically serious AI-generated analysis for the public **Daily Report**
-section. The filesystem and public URLs remain `docs/research/` and
-`/research/` for compatibility, but the reader-facing name is Daily Report.
+Produce technically serious, source-grounded analysis for the public **Daily Report** section. The repository is the source of truth for the publication contract, content, routes, and delivery workflow.
 
-The purpose is not to imitate a paper. The purpose is to help engineers and
-researchers understand a real problem, see what current work still misses, and
-find ideas worth implementing and evaluating.
+The purpose is to help engineers and researchers understand a real problem, see what current work still misses, and find ideas worth implementing and evaluating. Depth comes from evidence, mechanism, comparison, and testable design, not from academic tone or terminology density.
 
-## Non-Negotiable Public Contract
+## Public Contract
 
-Every public Daily Report must satisfy all of these rules:
+Every Daily Report must satisfy these rules:
 
-- It is explicitly labeled **AI-generated and not human-reviewed** near the top
-  and again at the bottom of the rendered page.
-- It never claims to be reviewed, peer-reviewed, maintainer-endorsed, or written
-  by a human unless that review or authorship actually happened and is recorded.
-- Human Git commit authors are not presented as article authors merely because
-  they merged generated text.
-- The title and opening are understandable to a technically qualified reader who
-  has not read the source corpus.
-- Facts, measurements, cited claims, generated synthesis, and speculative ideas
-  remain distinguishable.
-- The report contains a section explaining where current research or production
-  practice is still weak.
-- The report contains a section proposing a small number of non-trivial research
-  or systems directions with both academic and production relevance.
-- The report is not published when the scan yields only a fluent summary and no
-  defensible gap, mechanism, or useful idea.
-
-A disclosure does not excuse weak sourcing. It tells readers the correct
-editorial status while the report still aims for strong evidence and reasoning.
+- The title and opening are understandable to a technically qualified reader who has not read the source corpus.
+- Facts, measurements, cited claims, synthesis, and proposed ideas remain distinguishable.
+- The report contains a concrete section explaining where current research or production practice is still weak.
+- The report contains a small number of developed directions with both academic and production relevance.
+- The report states the assumptions behind its conclusion and the evidence that would change it, using reader-facing language.
+- The report is not published when the scan yields only a fluent summary and no defensible gap, mechanism, or useful idea.
+- Do not add provenance banners, warning boxes, generation-process badges, or footer disclaimers to the public page.
+- Do not infer an article byline from Git commit metadata.
 
 ## Required Context
 
@@ -44,23 +29,20 @@ Read these before acting:
 - `CLAUDE.md`
 - `.agents/skills/blog-writing-style/SKILL.md`
 - existing pages under `docs/research/`
-- previous related posts under `docs/blog/` and `docs/reports/`
+- related posts under `docs/blog/` and `docs/reports/`
 - `references/research-method.md`
 - `docs/papers/registry.yaml` only after a candidate question exists
-- the current rendered Daily Report disclosure implementation
 
-When invoked by `eunomia-content-patrol`, also read the rolling publication
-queue and the current dated media workspace.
+When invoked by a scheduled repository task, also read the task entrypoint, current operating records, and any explicit publication constraints stored in the repository.
 
 ## Output Location And Metadata
 
-A public bilingual report uses:
+A bilingual report uses:
 
 - `docs/research/<topic>.md`
 - `docs/research/<topic>.zh.md`
 
-Keep the existing URL when revising an article. Do not rename `/research/` URLs
-only because the public section is called Daily Report.
+Keep an existing URL when revising an article.
 
 New Daily Report frontmatter should include:
 
@@ -73,66 +55,54 @@ tags:
   - <precise topic tags>
 research_question: "The exact question the report tries to answer"
 source_cutoff: YYYY-MM-DD
-status: ai-generated-unreviewed
+status: daily-report
 ```
-
-Do not use `reviewed-research-brief` or a human byline by default.
 
 ## Workflow
 
 ### 1. Start With A Real Reader Question
 
-Begin from a broad systems area, then search before choosing a thesis. Prefer a
-question that changes an architecture, implementation, security, operations, or
-research decision.
+Begin from a broad systems area, then search before choosing a thesis. Prefer a question that changes an architecture, implementation, security, operations, or research decision.
 
 Good questions expose one of these:
 
 - a mechanism missing from current systems;
 - conflicting results that need reconciliation;
-- a production failure not represented in benchmarks;
+- a production failure absent from benchmarks;
 - an abstraction that breaks under new workloads;
-- a capability that became possible but lacks a correct interface;
+- a capability that exists but lacks a correct interface;
 - a measurement problem that prevents comparing alternatives.
 
-Do not choose a topic because it is trending or because it can mention an
-Eunomia project.
+Do not choose a topic merely because it is trending or can mention an Eunomia project.
 
 ### 2. Use Platform Deep Research As Input
 
-When platform Deep Research is available or requested, use it for broad source
-discovery, competing explanations, and citation collection.
+When platform Deep Research is available or requested, use it for broad source discovery, competing explanations, and citation collection.
 
-Its report is research input, not publishable prose. Before using it:
+Treat its report as research input, not publishable prose. Before using it:
 
-- open and inspect the important primary sources;
-- verify dates, metrics, experimental scope, and quoted conclusions;
+- inspect the important primary sources;
+- verify dates, metrics, experimental conditions, and quoted conclusions;
 - remove unsupported extrapolation;
 - identify which sources are independent;
 - compare the candidate with existing Eunomia content;
-- rebuild the article around the reader's question rather than the tool's
-  outline;
-- record honestly when the platform report was incomplete or unavailable.
-
-Never say a page was produced by platform Deep Research unless a complete report
-was actually returned and materially used.
+- rebuild the argument around the reader's question rather than the tool's outline;
+- record internally when the platform report was incomplete or unavailable.
 
 ### 3. Build An Evidence Map
 
-For each serious source, capture privately:
+For every serious source, capture privately:
 
 - source type and primary URL;
 - publication date and event date;
 - concrete fact, mechanism, or measured result;
+- workload, scale, method, and assumptions;
 - implementation or artifact availability;
-- limitation and possible conflict of interest;
+- possible conflict of interest;
 - independent support or counterevidence;
 - which reader decision it changes.
 
-Count independent evidence, not repeated coverage. A focused report should use
-the smallest corpus that adequately supports the mechanism, alternatives, gap,
-and boundary. The broad scheduled landscape scan may use larger numeric gates,
-but a narrow Daily Report must not be padded to imitate a survey.
+Count independent evidence, not repeated coverage. A focused report should use the smallest corpus that adequately supports the mechanism, alternatives, gap, and boundary. Do not pad a narrow report to imitate a survey.
 
 ### 4. Pass The Thesis And Gap Gate
 
@@ -144,18 +114,13 @@ Before drafting, state in ordinary language:
 4. the central claim;
 5. the strongest alternative explanation;
 6. the research or production gap exposed by the evidence;
-7. what result would weaken or falsify the claim.
+7. what result would change the claim.
 
-The gap must be specific. Avoid statements such as "more research is needed" or
-"scalability remains challenging."
-
-A useful gap identifies a missing benchmark, interface, mechanism, guarantee,
-dataset, measurement, deployment property, or boundary condition.
+The gap must identify a missing benchmark, interface, mechanism, guarantee, dataset, measurement, deployment property, or boundary condition. Reject generic statements such as "more research is needed" or "scalability remains challenging."
 
 ### 5. Design The Reader Path
 
-Use a concrete recurring scenario before introducing a taxonomy, formal model,
-or coined term.
+Use a concrete recurring scenario before introducing a taxonomy, formal model, or coined term.
 
 A common progression is:
 
@@ -165,12 +130,11 @@ A common progression is:
 - what existing systems solve and leave open;
 - the proposed architecture or decision;
 - evidence and competing explanations;
-- research gaps;
+- current gaps;
 - promising directions;
-- evaluation, limits, and falsification.
+- evaluation and evidence that would change the conclusion.
 
-Do not front-load a source matrix, equation, related-work parade, or newly named
-property.
+Do not front-load a source matrix, equation, related-work parade, or newly named property.
 
 ### 6. Write The Required Gap Section
 
@@ -181,14 +145,12 @@ Use a reader-facing heading such as:
 
 Cover two to five concrete gaps. For each gap, explain:
 
-- what current papers or systems already do;
+- what leading papers or systems already achieve;
 - the exact missing capability or evidence;
-- why the omission matters to correctness, performance, security, operation, or
-  adoption;
-- what observation or experiment would show that the gap is real.
+- why the omission matters to correctness, performance, security, operation, cost, or adoption;
+- what observation or experiment would establish whether the gap is material.
 
-Do not confuse an author's limitation paragraph with a field-level gap. The
-report must synthesize across evidence.
+Do not repeat individual papers' future-work paragraphs. Synthesize across evidence.
 
 ### 7. Write The Required Ideas Section
 
@@ -197,61 +159,52 @@ Use a heading such as:
 - `## Promising directions with academic and production value`
 - `## 兼具学术价值与生产价值的方向`
 
-Prefer two or three developed ideas over a long list. Every idea must include:
+Prefer two or three developed ideas over a brainstorm list. Every idea must include:
 
-1. **Gap:** the concrete missing mechanism or evidence it addresses.
-2. **Mechanism:** what the proposed system, abstraction, dataset, or algorithm
-   would actually do.
-3. **Delta:** how it differs from the strongest related work.
+1. **Gap:** the missing mechanism or evidence it addresses.
+2. **Mechanism:** what the proposed system, abstraction, dataset, protocol, or algorithm actually does.
+3. **Delta:** how it differs from the strongest adjacent work.
 4. **Artifact:** what can be implemented, released, or reproduced.
-5. **Evaluation:** workloads, baselines, metrics, and an ablation or
-   counterexample that distinguishes the idea.
+5. **Evaluation:** workloads, baselines, metrics, and an ablation or counterexample that distinguishes the idea.
 6. **Academic value:** the generalizable question, property, or method.
-7. **Production value:** who could deploy it and what cost or failure it reduces.
-8. **Failure condition:** a result that would show the extra mechanism is not
-   worth its complexity.
+7. **Production value:** who can deploy it and which cost or failure it reduces.
+8. **Failure condition:** a result showing the extra mechanism is not worth its complexity.
 
-Reject ideas that are only "apply an LLM," "build a platform," "add eBPF," or
-"use a better model." The mechanism must remain meaningful when the marketing
-label is removed.
+Reject ideas that are only "apply an LLM," "build a platform," "add eBPF," or "use a better model." The mechanism must remain meaningful when the label is removed.
 
 ### 8. Write Bilingual Pages Naturally
 
-English and Chinese versions share evidence, claims, and idea quality, not
-sentence boundaries.
+English and Chinese versions share evidence, claims, and idea quality, not sentence boundaries.
 
 In Chinese:
 
 - use Chinese for ordinary concepts;
-- retain English only for proper nouns, identifiers, code, and useful terms of
-  art;
+- retain English only for proper nouns, identifiers, code, and useful terms of art;
 - do not make the grammar depend on a stack of English nouns;
 - explain a formal term in Chinese before relying on its English name.
 
-### 9. Preserve Editorial Status In Rendering
+### 9. Use Reader-Facing Conclusion Boundaries
 
-Before publication, verify that every `/research/` and `/zh/research/` page:
+Do not publish headings such as `Scope, limitations, and falsification` or direct Chinese translations of that template.
 
-- displays the AI-generated, not-human-reviewed notice near the top;
-- repeats the notice at the bottom;
-- uses the public label Daily Report or 每日报告 in navigation and section UI;
-- does not expose a human author through article metadata by default;
-- keeps canonical and hreflang URLs unchanged;
-- remains linked from the Blog menu and Blog landing page.
+Use a natural heading such as:
+
+- `## What would change this conclusion?`
+- `## 哪些结果会改变这个判断？`
+
+Explain assumptions, counterexamples, and decisive future evidence in prose. Keep the concepts, remove the template language.
 
 ### 10. Validate And Publish
 
-When the user or an authorized queue item requests publication, complete the
-whole delivery:
+When publication is authorized, complete the whole delivery:
 
 1. create a focused branch;
-2. change only the Daily Report content, rendering, or skill files in scope;
+2. change only files in scope;
 3. run the repository's full verification workflow;
 4. inspect the complete PR diff;
 5. merge only after required checks pass;
 6. verify that the exact merge commit deploys;
-7. check the public English and Chinese pages, disclosure text, navigation,
-   canonical URLs, and the new gap and idea sections.
+7. inspect the public English and Chinese pages, navigation, canonical URLs, gap sections, idea sections, and rendered conclusion heading.
 
 A draft, open PR, or green pre-merge check is not a completed deployment.
 
@@ -262,19 +215,15 @@ Reject or revise the report when any of these are true:
 - the title depends on an unexplained coined term;
 - the opening reads like an abstract rather than a human explanation;
 - the report summarizes papers one by one;
-- the gap section contains generic limitations;
-- the ideas section lacks an implementable artifact or discriminating
-  evaluation;
+- the gap section contains generic complaints;
+- the ideas section lacks an implementable artifact or discriminating evaluation;
 - academic value is claimed only because the topic is new;
 - production value is claimed without a deployable boundary or user;
 - repository-owned work is treated more generously than outside work;
-- the disclosure is missing or suggests human review that did not occur;
+- the page contains process-oriented warning boxes or provenance notes that distract from the analysis;
 - the new page substantially duplicates an existing question or thesis;
 - important claims cannot be traced to primary evidence.
 
 ## No-Report Outcome
 
-If research produces interesting sources but no defensible gap and no
-non-trivial idea, do not publish. Record the strongest unresolved question and
-what evidence would unblock it. A truthful no-report result is better than an
-AI-generated summary added only to satisfy cadence.
+If research produces interesting sources but no defensible gap and no non-trivial idea, do not publish. Record the strongest unresolved question and the evidence that would unblock it. A truthful no-report result is better than a generic summary added only to satisfy cadence.

--- a/.agents/skills/eunomia-research-report/references/research-method.md
+++ b/.agents/skills/eunomia-research-report/references/research-method.md
@@ -1,26 +1,14 @@
 # Daily Report Research Method
 
-Use this reference for source coverage, evidence grading, gap analysis, idea
-design, and public report structure. The public section is called **Daily
-Report**, while its stable filesystem and URLs remain `docs/research/` and
-`/research/`.
-
-Every public report is AI-generated and not human-reviewed unless a named human
-review is explicitly recorded. This editorial status must be visible near the
-top and bottom of every rendered page.
+Use this reference for source coverage, evidence grading, gap analysis, idea design, and public report structure. The repository is the authoritative specification for the Daily Report workflow.
 
 ## Research Windows
 
-Use the latest seven days for current releases, papers, incidents, and public
-engineering discussion when the assignment depends on recent change. Read the
-latest 48 hours first, then widen to 7-30 days for mechanisms, contradictions,
-and deployment evidence.
+Use the latest seven days for current releases, papers, incidents, and engineering discussion when the assignment depends on recent change. Read the latest 48 hours first, then widen to 7-30 days for mechanisms, contradictions, and deployment evidence.
 
-Use older primary sources for theory, standards, prior art, and baselines.
-Confirm both the publication date and the date of the underlying event.
+Use older primary sources for theory, standards, prior art, and baselines. Confirm both the publication date and the date of the underlying event.
 
-A durable Daily Report does not need a news hook. It still needs a source cutoff
-so readers can tell which evidence the analysis includes.
+A durable Daily Report does not need a news hook. It still needs a source cutoff so later updates can tell which evidence the analysis included.
 
 ## Source Families
 
@@ -34,12 +22,9 @@ Prefer sources that expose inspectable evidence:
 - production measurements with enough methodology to interpret them;
 - official documentation for current runtime behavior.
 
-Marketing pages and social posts can establish that someone announced or
-observed something. They do not establish a general technical fact without
-corroboration.
+Marketing pages and social posts can establish what someone announced or observed. They do not establish a general technical fact without corroboration.
 
-Count independent evidence, not links. Ten articles repeating one announcement
-are one evidence cluster.
+Count independent evidence, not links. Ten articles repeating one announcement are one evidence cluster.
 
 ## Evidence Map
 
@@ -50,12 +35,11 @@ For every serious source, record privately:
 - concrete claim or measured result;
 - method, workload, scale, and assumptions;
 - available code, data, logs, or implementation detail;
-- limitation and possible conflict of interest;
+- possible conflict of interest;
 - independent support or counterevidence;
 - which architecture or engineering decision it changes.
 
-A source counts only when it changes the analysis through a fact, mechanism,
-comparison, contradiction, deployment failure, or useful question.
+A source counts only when it changes the analysis through a fact, mechanism, comparison, contradiction, deployment failure, or useful question.
 
 ## Evidence Lattice
 
@@ -67,13 +51,11 @@ A strong report normally combines several roles:
 - **Counterevidence:** a workload or result that narrows the central claim.
 - **Measurement evidence:** a method that can distinguish alternatives.
 
-A focused report should use the smallest corpus that supports its question,
-strongest alternative, gap, and boundary. Do not pad it to resemble a survey.
+A focused report should use the smallest corpus that supports its question, strongest alternative, gap, and boundary. Do not pad it to resemble a survey.
 
 ## Topic Selection
 
-Prefer a question that changes a decision and exposes a concrete gap. Useful
-signals include:
+Prefer a question that changes a decision and exposes a concrete gap. Useful signals include:
 
 - papers and production experience disagree;
 - a new workload breaks an old abstraction;
@@ -81,26 +63,20 @@ signals include:
 - a capability exists but lacks a safe or portable interface;
 - systems optimize a proxy that does not measure the real outcome;
 - a mechanism works only because of an unstated workload assumption;
-- an operational problem cannot be compared because there is no shared metric or
-  dataset.
+- an operational problem cannot be compared because no shared metric or dataset exists.
 
-Compare the candidate with existing Daily Reports and Blog posts. A new title,
-product, example, or coined term does not make the thesis new.
+Compare the candidate with existing Daily Reports and Blog posts. A new title, product, example, or coined term does not make the thesis new.
 
 ## Gap Analysis
 
-The gap section must synthesize the field rather than repeat limitation
-paragraphs from individual papers.
+The gap section must synthesize the field rather than repeat future-work paragraphs from individual papers.
 
 A strong gap has four parts:
 
 1. **Current capability:** what leading systems already achieve.
-2. **Missing element:** the exact interface, guarantee, dataset, measurement,
-   mechanism, or deployment property that is absent.
-3. **Consequence:** why the absence matters to correctness, performance,
-   security, cost, operation, or adoption.
-4. **Test:** what experiment or observation would establish whether the gap is
-   material.
+2. **Missing element:** the exact interface, guarantee, dataset, measurement, mechanism, or deployment property that is absent.
+3. **Consequence:** why the absence matters to correctness, performance, security, cost, operation, or adoption.
+4. **Test:** what experiment or observation would establish whether the gap is material.
 
 Examples of specific gaps:
 
@@ -117,14 +93,13 @@ Reject generic statements such as:
 - scalability remains a challenge;
 - security could be improved;
 - future work should evaluate more models;
-- an LLM could automate the process.
+- a model could automate the process.
 
 ## Idea Design
 
-The ideas section is the main value of the Daily Report. Prefer two or three
-ideas that can support a real artifact and discriminating evaluation.
+The ideas section is the main value of the Daily Report. Prefer two or three ideas that can support a real artifact and discriminating evaluation.
 
-For each idea, write an internal design card before public prose:
+For each idea, write an internal design card before public prose.
 
 ### Gap
 
@@ -132,14 +107,11 @@ What exact missing capability or evidence does the idea address?
 
 ### Mechanism
 
-What components, state, control path, algorithm, abstraction, or protocol would
-exist? Describe the system without relying on labels such as AI-powered,
-agentic, intelligent, or eBPF-based.
+What components, state, control path, algorithm, abstraction, or protocol would exist? Describe the system without relying on marketing labels.
 
 ### Delta From Related Work
 
-Name the strongest adjacent approach and state the technical difference. A new
-application domain alone is usually not enough novelty.
+Name the strongest adjacent approach and state the technical difference. A new application domain alone is usually not enough novelty.
 
 ### Artifact
 
@@ -169,24 +141,21 @@ Specify:
 
 ### Academic Value
 
-State the generalizable research question, property, model, or method. Do not
-claim academic value only because the topic is recent.
+State the generalizable research question, property, model, or method. Do not claim academic value only because the topic is recent.
 
 ### Production Value
 
-Identify the operator or developer who could deploy the artifact, the boundary
-where it integrates, and the failure, cost, or manual work it reduces.
+Identify the operator or developer who could deploy the artifact, the boundary where it integrates, and the failure, cost, or manual work it reduces.
 
 ### Failure Condition
 
-State what result would show that the extra mechanism is unnecessary, too
-expensive, too inaccurate, or not general enough.
+State what result would show that the extra mechanism is unnecessary, too expensive, too inaccurate, or not general enough.
 
 ## Idea Quality Tests
 
 An idea is not ready when it is only:
 
-- apply an LLM to classify events;
+- apply a model to classify events;
 - use eBPF to observe more data;
 - build a unified platform;
 - add a control plane;
@@ -205,11 +174,9 @@ Ask instead:
 
 ## Human-Readable Synthesis
 
-The public page is not a research notebook and not the direct output of platform
-Deep Research.
+The public page is not a research notebook and not the direct output of a search tool.
 
-Write for a technically qualified reader who has not read the sources. A useful
-progression is:
+Write for a technically qualified reader who has not read the sources. A useful progression is:
 
 1. concrete situation and consequence;
 2. why the obvious solution appears sufficient;
@@ -218,71 +185,56 @@ progression is:
 5. architecture or engineering consequence;
 6. current gaps;
 7. promising directions;
-8. evaluation, limitations, and falsification.
+8. evidence that would change the conclusion.
 
-Use a recurring scenario when possible. Introduce a formal term only after the
-reader understands the pattern it names.
+Use a recurring scenario when possible. Introduce a formal term only after the reader understands the pattern it names.
 
-Do not begin with a source matrix, field overview, taxonomy, formula, or coined
-abstraction.
+Do not begin with a source matrix, field overview, taxonomy, formula, or coined abstraction.
 
 ## Required Public Sections
 
-Every Daily Report article must render these functions, either from Markdown or
-from a route-specific rendering component:
+Every Daily Report article must render these functions, either from Markdown or from a route-specific rendering component:
 
 - `Where current work is still weak` / `现有研究还缺什么`
-- `Promising directions with academic and production value` /
-  `兼具学术价值与生产价值的方向`
+- `Promising directions with academic and production value` / `兼具学术价值与生产价值的方向`
 
-The gap section should contain two to five concrete gaps. The idea section should
-contain a small number of developed directions, not a brainstorm list.
+The gap section should contain two to five concrete gaps. The idea section should contain a small number of developed directions, not a brainstorm list.
 
-## Disclosure And Metadata
+For assumptions, counterexamples, and decisive future evidence, use a natural heading such as:
 
-New pages use `Daily Report` as the public tag and
-`status: ai-generated-unreviewed` by default.
+- `What would change this conclusion?`
+- `哪些结果会改变这个判断？`
 
-The rendered page must say, near the top and bottom, that:
+Do not use a templated heading built around the words `scope` or `limitations`.
 
-- it was generated with automated research and writing tools;
-- no human editor verified every citation, fact, metric, or recommendation;
-- errors may remain;
-- readers should inspect primary sources and independently validate important
-  conclusions.
+## Public Presentation
 
-Do not expose a human Git committer as an article author by default.
+The public page should read as a carefully edited technical report. Do not add process-oriented banners, warning boxes, generation badges, provenance callouts, or footer disclaimers. Keep the reader's attention on the question, evidence, reasoning, gaps, and proposed directions.
+
+Do not expose a Git committer as the article author merely because they merged the text.
 
 ## Bilingual Writing
 
-English and Chinese versions share evidence and claims, not sentence boundaries.
-Write each version naturally.
+English and Chinese versions share evidence and claims, not sentence boundaries. Write each version naturally.
 
-In Chinese, use Chinese for ordinary concepts. Keep English for proper nouns,
-identifiers, code, and useful terms of art. Do not let a sentence's grammar rely
-on a stack of English nouns.
+In Chinese, use Chinese for ordinary concepts. Keep English for proper nouns, identifiers, code, and useful terms of art. Do not let a sentence's grammar rely on a stack of English nouns.
 
 ## Publication Validation
 
 Before merge, verify:
 
-- title, description, opening, gaps, ideas, limits, and references;
+- title, description, opening, gaps, ideas, decisive counterevidence, and references;
 - primary-source support for central factual claims;
-- disclosure near the top and bottom of every section page;
-- Daily Report labels in desktop and mobile navigation and the Blog call to
-  action;
+- no process-oriented public callouts or empty visual note boxes;
+- Daily Report labels in desktop and mobile navigation and the Blog call to action;
 - stable `/research/` and `/zh/research/` canonical URLs;
 - bilingual hreflang pairs;
-- no human author metadata on unreviewed AI pages;
+- no inferred human author metadata;
 - sitemap, structured data, internal links, and browser rendering;
 - full repository CI.
 
-After merge, verify the exact merge commit deployed and inspect the public
-English and Chinese pages.
+After merge, verify that the exact merge commit deployed and inspect the public English and Chinese pages.
 
 ## No-Report Outcome
 
-Do not publish when the scan produces only interesting sources or a fluent
-summary. Record the strongest unresolved question and the evidence required to
-support a real gap and testable idea. Cadence never overrides the publication
-contract.
+Do not publish when the scan produces only interesting sources or a fluent summary. Record the strongest unresolved question and the evidence required to support a real gap and testable idea. Cadence never overrides the publication contract.

--- a/app/components/DailyReportEnhancements.tsx
+++ b/app/components/DailyReportEnhancements.tsx
@@ -1,10 +1,5 @@
 import type { Locale } from "../lib/site-data";
 
-type DailyReportDisclosureProps = {
-  locale: Locale;
-  placement: "top" | "footer";
-};
-
 type DirectionItem = {
   title: string;
   body: string;
@@ -21,38 +16,6 @@ type DirectionCopy = {
 
 function canonicalReportPath(path: string): string {
   return path.startsWith("/zh/") ? path.slice(3) : path;
-}
-
-export function DailyReportDisclosure({ locale, placement }: DailyReportDisclosureProps) {
-  const copy =
-    locale === "zh"
-      ? {
-          title: "AI 生成，未经人工审核",
-          top:
-            "本页由自动化研究与写作工具生成，尚无人逐项核验引用、事实、数字和建议。请把它当作研究起点，回看一手来源，并在用于生产系统或重要决策前独立验证。",
-          footer:
-            "披露：本页由 AI 生成，未经过人工编辑审核，仍可能包含遗漏、误读或错误。请通过页面中的一手来源核验关键结论，并可通过源码链接提交修正。"
-        }
-      : {
-          title: "AI-generated and not human-reviewed",
-          top:
-            "This page was produced with automated research and writing tools. No human editor has verified every citation, fact, metric, or recommendation. Treat it as a starting point, check the primary sources, and independently validate it before using it in production or important decisions.",
-          footer:
-            "Disclosure: this page is AI-generated and has not received human editorial review. Omissions, misreadings, and errors may remain. Verify important claims against the primary sources and use the source link to propose corrections."
-        };
-
-  return (
-    <aside
-      role="note"
-      className={[
-        "border border-amber-300 bg-amber-50 px-5 py-4 text-amber-950",
-        placement === "top" ? "mb-8" : "mt-12"
-      ].join(" ")}
-    >
-      <p className="font-semibold">{copy.title}</p>
-      <p className="mt-2 text-sm leading-6">{placement === "top" ? copy.top : copy.footer}</p>
-    </aside>
-  );
 }
 
 const traceDirections: Record<Locale, DirectionCopy> = {

--- a/app/components/DailyReportFooterNote.tsx
+++ b/app/components/DailyReportFooterNote.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from "../lib/site-data";
 
-export function DailyReportFooterNote(_props: { locale: Locale }) {
+export function DailyReportFooterNote(props: { locale: Locale }) {
+  void props.locale;
   return null;
 }

--- a/app/components/DailyReportFooterNote.tsx
+++ b/app/components/DailyReportFooterNote.tsx
@@ -1,3 +1,5 @@
-export function DailyReportFooterNote() {
+import type { Locale } from "../lib/site-data";
+
+export function DailyReportFooterNote(_props: { locale: Locale }) {
   return null;
 }

--- a/app/components/DailyReportFooterNote.tsx
+++ b/app/components/DailyReportFooterNote.tsx
@@ -1,14 +1,3 @@
-import type { Locale } from "../lib/site-data";
-
-export function DailyReportFooterNote({ locale }: { locale: Locale }) {
-  const text =
-    locale === "zh"
-      ? "本页由自动化工具生成，未经人工逐项核验；使用前请结合引用的一手资料独立验证。"
-      : "Generated automatically and not individually verified by an editor; check the cited primary sources before relying on it.";
-
-  return (
-    <p role="note" className="mt-4 max-w-3xl text-[11px] leading-5 text-slate-400">
-      {text}
-    </p>
-  );
+export function DailyReportFooterNote() {
+  return null;
 }


### PR DESCRIPTION
## What changed

- remove the rendered Daily Report footer disclaimer
- remove the obsolete yellow disclosure component and all of its public generation/review wording
- keep the existing Daily Report articles, research-gap sections, proposed directions, navigation, URLs, canonical metadata, and bilingual links unchanged
- update the Daily Report skill and research-method reference so future reports do not reintroduce provenance banners, warning boxes, badges, or footer disclaimers
- keep assumptions and counterevidence in natural reader-facing sections such as `What would change this conclusion?` rather than a templated `Scope, limitations, and falsification` heading

## Public result

Daily Report pages should read as carefully edited technical reports. The public pages should contain no yellow disclosure box, no generation-process statement, no review-status warning, and no small footer disclaimer.

## Validation and deployment acceptance

- full repository verification passes
- GitGuardian passes
- all existing `/research/` and `/zh/research/` routes remain unchanged
- current English and Chinese reports still render their gap and idea sections
- generated HTML contains none of the removed disclosure phrases or amber callout classes
- the exact squash merge commit deploys successfully to GitHub Pages
- the production artifact and public pages are checked after deployment