### PR TITLE
Remove Daily Report template boundary labels

### DIFF
--- a/app/components/DailyReportFooterNote.tsx
+++ b/app/components/DailyReportFooterNote.tsx
@@ -1,6 +1,0 @@
-import type { Locale } from "../lib/site-data";
-
-export function DailyReportFooterNote(props: { locale: Locale }) {
-  void props.locale;
-  return null;
-}

--- a/app/lib/daily-report.ts
+++ b/app/lib/daily-report.ts
@@ -1,0 +1,69 @@
+import type { DocsPage, HeadingEntry } from "./content/types";
+import type { Locale } from "./site-data";
+
+export function isDailyReportPath(path: string): boolean {
+  return /^\/(?:zh\/)?research(?:\/|$)/.test(path);
+}
+
+export function getDailyReportLabel(locale: Locale): string {
+  return locale === "zh" ? "每日报告" : "Daily Report";
+}
+
+function getDailyReportTags(tags: string[] | undefined, locale: Locale): string[] {
+  const label = getDailyReportLabel(locale);
+  return (tags ?? []).map((tag) => (tag === "Research" ? label : tag));
+}
+
+const dailyReportTextReplacements: Record<Locale, ReadonlyArray<readonly [string, string]>> = {
+  en: [
+    ["scope-limitations-and-falsification", "what-would-change-this-conclusion"],
+    ["Scope, limitations, and falsification", "What would change this conclusion?"],
+    ["The design also has real limits:", "The design still leaves several hard problems:"]
+  ],
+  zh: [
+    ["适用范围、局限与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围局限与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围、局限性与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围局限性与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围、局限与可证伪性", "哪些结果会改变这个判断"],
+    ["适用范围局限与可证伪性", "哪些结果会改变这个判断"],
+    ["适用范围、局限性和可证伪性", "哪些结果会改变这个判断"],
+    ["适用范围局限性和可证伪性", "哪些结果会改变这个判断"],
+    ["适用范围、限制与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围限制与可证伪条件", "哪些结果会改变这个判断"],
+    ["适用范围与可证伪条件", "哪些结果会改变这个判断"],
+    ["它也有明显局限：", "它仍有几个无法绕开的难点："]
+  ]
+};
+
+export function rewriteDailyReportText(value: string, locale: Locale): string {
+  return dailyReportTextReplacements[locale].reduce(
+    (current, [source, replacement]) => current.split(source).join(replacement),
+    value
+  );
+}
+
+export function rewriteDailyReportHeadings(
+  headings: HeadingEntry[] | undefined,
+  locale: Locale
+): HeadingEntry[] {
+  return (headings ?? []).map((heading) => ({
+    ...heading,
+    id: rewriteDailyReportText(heading.id, locale),
+    text: rewriteDailyReportText(heading.text, locale)
+  }));
+}
+
+export function prepareDailyReportPage(page: DocsPage, locale: Locale): DocsPage {
+  if (!isDailyReportPath(page.path)) {
+    return page;
+  }
+
+  return {
+    ...page,
+    bodyHtml: rewriteDailyReportText(page.bodyHtml, locale),
+    headings: rewriteDailyReportHeadings(page.headings, locale),
+    tags: getDailyReportTags(page.tags, locale),
+    metadata: null
+  };
+}

--- a/app/lib/page-factories.tsx
+++ b/app/lib/page-factories.tsx
@@ -4,7 +4,6 @@ import { AgentSystemLayerPresentation } from "../components/AgentSystemLayerPres
 import { BlogListing } from "../components/BlogListing";
 import { CardGrid } from "../components/CardGrid";
 import { DailyReportResearchDirections } from "../components/DailyReportEnhancements";
-import { DailyReportFooterNote } from "../components/DailyReportFooterNote";
 import { HomePageHero, HomePageLanding } from "../components/HomePageLanding";
 import {
   AgentRuntimeInfrastructurePage,
@@ -21,10 +20,14 @@ import type {
   BlogEntry,
   DocsPage,
   GitMetadata,
-  HeadingEntry,
   LocaleAlternates
 } from "./content/types";
 import type { MkdocsHomeConfig } from "./content/mkdocs-config";
+import {
+  getDailyReportLabel,
+  isDailyReportPath,
+  prepareDailyReportPage
+} from "./daily-report";
 import type { Locale } from "./site-data";
 
 export type HomePageData = {
@@ -47,56 +50,6 @@ function getDocsRobots(path: string): string | undefined {
   return /\/(blogs|zh\/blogs)\//.test(path) || path === "/about/" || path === "/zh/about/"
     ? "noindex,follow"
     : undefined;
-}
-
-function isDailyReportPath(path: string): boolean {
-  return /^\/(?:zh\/)?research(?:\/|$)/.test(path);
-}
-
-function getDailyReportLabel(locale: Locale): string {
-  return locale === "zh" ? "每日报告" : "Daily Report";
-}
-
-function getDailyReportTags(tags: string[] | undefined, locale: Locale): string[] {
-  const label = getDailyReportLabel(locale);
-  return (tags ?? []).map((tag) => (tag === "Research" ? label : tag));
-}
-
-const dailyReportTextReplacements: Record<Locale, ReadonlyArray<readonly [string, string]>> = {
-  en: [
-    ["Scope, limitations, and falsification", "What would change this conclusion?"],
-    ["scope-limitations-and-falsification", "what-would-change-this-conclusion"]
-  ],
-  zh: [
-    ["适用范围、局限与可证伪条件", "哪些结果会改变这个判断？"],
-    ["适用范围局限与可证伪条件", "哪些结果会改变这个判断"],
-    ["适用范围、局限性与可证伪条件", "哪些结果会改变这个判断？"],
-    ["适用范围局限性与可证伪条件", "哪些结果会改变这个判断"],
-    ["适用范围、局限与可证伪性", "哪些结果会改变这个判断？"],
-    ["适用范围局限与可证伪性", "哪些结果会改变这个判断"],
-    ["适用范围、局限性和可证伪性", "哪些结果会改变这个判断？"],
-    ["适用范围局限性和可证伪性", "哪些结果会改变这个判断"],
-    ["适用范围、限制与可证伪条件", "哪些结果会改变这个判断？"],
-    ["适用范围限制与可证伪条件", "哪些结果会改变这个判断"]
-  ]
-};
-
-function rewriteDailyReportText(value: string, locale: Locale): string {
-  return dailyReportTextReplacements[locale].reduce(
-    (current, [source, replacement]) => current.split(source).join(replacement),
-    value
-  );
-}
-
-function rewriteDailyReportHeadings(
-  headings: HeadingEntry[] | undefined,
-  locale: Locale
-): HeadingEntry[] {
-  return (headings ?? []).map((heading) => ({
-    ...heading,
-    id: rewriteDailyReportText(heading.id, locale),
-    text: rewriteDailyReportText(heading.text, locale)
-  }));
 }
 
 function renderCustomReactPage(kind: NonNullable<DocsPage["reactPage"]>, locale: Locale, page: DocsPage) {
@@ -122,67 +75,65 @@ function renderCustomReactPage(kind: NonNullable<DocsPage["reactPage"]>, locale:
 }
 
 function renderDocsBody(page: DocsPage, locale: Locale) {
-  if (page.reactPage) {
-    return renderCustomReactPage(page.reactPage, locale, page);
+  const renderedPage = prepareDailyReportPage(page, locale);
+
+  if (renderedPage.reactPage) {
+    return renderCustomReactPage(renderedPage.reactPage, locale, renderedPage);
   }
 
   if (
-    page.landingPage &&
-    page.projectCatalog &&
-    (page.landingPage.variant === "project-index" || page.landingPage.variant === "project-focus")
+    renderedPage.landingPage &&
+    renderedPage.projectCatalog &&
+    (renderedPage.landingPage.variant === "project-index" ||
+      renderedPage.landingPage.variant === "project-focus")
   ) {
     return (
       <ProjectLandingPage
-        landing={page.landingPage}
-        projectGroups={page.projectCatalog.projectGroups}
-        projects={page.projectCatalog.projects}
+        landing={renderedPage.landingPage}
+        projectGroups={renderedPage.projectCatalog.projectGroups}
+        projects={renderedPage.projectCatalog.projects}
         locale={locale}
       />
     );
   }
 
   // Blog index: render the React blog listing component instead of markdown.
-  if (page.blogEntries) {
+  if (renderedPage.blogEntries) {
     return (
       <BlogListing
-        title={page.title}
-        description={page.description}
-        entries={page.blogEntries}
+        title={renderedPage.title}
+        description={renderedPage.description}
+        entries={renderedPage.blogEntries}
         locale={locale}
       />
     );
   }
 
-  const dailyReport = isDailyReportPath(page.path);
-  const headings =
-    page.layout === "document"
-      ? dailyReport
-        ? rewriteDailyReportHeadings(page.headings, locale)
-        : page.headings
-      : [];
-  const bodyHtml = dailyReport ? rewriteDailyReportText(page.bodyHtml, locale) : page.bodyHtml;
+  const dailyReport = isDailyReportPath(renderedPage.path);
+  const headings = renderedPage.layout === "document" ? renderedPage.headings : [];
 
   return (
     <ArticleLayout
       locale={locale}
-      path={page.path}
-      title={page.title}
-      description={page.descriptionIsExcerpt ? "" : page.description}
-      tags={dailyReport ? getDailyReportTags(page.tags, locale) : page.tags}
-      publishedAt={page.date}
-      sourceHref={page.sourcePath}
-      metadata={dailyReport ? null : page.metadata}
+      path={renderedPage.path}
+      title={renderedPage.title}
+      description={renderedPage.descriptionIsExcerpt ? "" : renderedPage.description}
+      tags={renderedPage.tags}
+      publishedAt={renderedPage.date}
+      sourceHref={renderedPage.sourcePath}
+      metadata={renderedPage.metadata}
       headings={headings}
-      continuation={page.layout === "document" ? page.continuation : undefined}
+      continuation={renderedPage.layout === "document" ? renderedPage.continuation : undefined}
       tocTitle={getTocTitle(locale)}
-      showBreadcrumbs={page.layout === "document"}
-      footerNote={dailyReport ? <DailyReportFooterNote locale={locale} /> : undefined}
+      showBreadcrumbs={renderedPage.layout === "document"}
     >
-      <MarkdownContent html={bodyHtml} />
-      {dailyReport ? <DailyReportResearchDirections locale={locale} path={page.path} /> : null}
-      {page.cards?.length ? (
+      <MarkdownContent html={renderedPage.bodyHtml} />
+      {dailyReport ? (
+        <DailyReportResearchDirections locale={locale} path={renderedPage.path} />
+      ) : null}
+      {renderedPage.cards?.length ? (
         <section className="mt-12">
-          <CardGrid cards={page.cards} compact />
+          <CardGrid cards={renderedPage.cards} compact />
         </section>
       ) : null}
     </ArticleLayout>
@@ -198,27 +149,28 @@ export function DocsPageView({
   locale: Locale;
   eyebrow: string;
 }) {
-  const dailyReport = isDailyReportPath(page.path);
+  const renderedPage = prepareDailyReportPage(page, locale);
+  const dailyReport = isDailyReportPath(renderedPage.path);
 
   return (
     <>
       <SeoHead
-        title={page.title}
-        description={page.description}
-        path={page.path}
-        alternates={canonicalAlternates(page.alternates)}
-        article={page.layout === "document"}
-        publishedAt={page.date}
-        metadata={dailyReport ? null : page.metadata}
-        robots={getDocsRobots(page.path)}
-        isTutorial={/\/(tutorials|zh\/tutorials)\//.test(page.path)}
-        isCodeProject={/\/(bpftime|eunomia-bpf|GPTtrace)\/?/.test(page.path)}
+        title={renderedPage.title}
+        description={renderedPage.description}
+        path={renderedPage.path}
+        alternates={canonicalAlternates(renderedPage.alternates)}
+        article={renderedPage.layout === "document"}
+        publishedAt={renderedPage.date}
+        metadata={renderedPage.metadata}
+        robots={getDocsRobots(renderedPage.path)}
+        isTutorial={/\/(tutorials|zh\/tutorials)\//.test(renderedPage.path)}
+        isCodeProject={/\/(bpftime|eunomia-bpf|GPTtrace)\/?/.test(renderedPage.path)}
         repoUrl={
-          page.path.includes("/bpftime")
+          renderedPage.path.includes("/bpftime")
             ? "https://github.com/eunomia-bpf/bpftime"
-            : page.path.includes("/eunomia-bpf")
+            : renderedPage.path.includes("/eunomia-bpf")
               ? "https://github.com/eunomia-bpf/eunomia-bpf"
-              : page.path.includes("/GPTtrace")
+              : renderedPage.path.includes("/GPTtrace")
                 ? "https://github.com/eunomia-bpf/GPTtrace"
                 : undefined
         }
@@ -226,14 +178,14 @@ export function DocsPageView({
       <SiteChrome
         locale={locale}
         eyebrow={dailyReport ? getDailyReportLabel(locale) : eyebrow}
-        title={page.title}
-        intro={page.description}
+        title={renderedPage.title}
+        intro={renderedPage.description}
         leadMode="none"
-        currentPath={page.path}
-        sidebar={page.reactPage ? undefined : page.sidebar}
-        alternates={page.alternates}
+        currentPath={renderedPage.path}
+        sidebar={renderedPage.reactPage ? undefined : renderedPage.sidebar}
+        alternates={renderedPage.alternates}
       >
-        {renderDocsBody(page, locale)}
+        {renderDocsBody(renderedPage, locale)}
       </SiteChrome>
     </>
   );

--- a/app/lib/route-builders.ts
+++ b/app/lib/route-builders.ts
@@ -4,6 +4,7 @@ import { loadHomePage, resolveContentPage } from "./content";
 import { listRenderableRoutesForLocale } from "./content/manifest";
 import { buildSearchSidebar } from "./content/sidebar";
 import type { SidebarGroup } from "./content/types";
+import { prepareDailyReportPage } from "./daily-report";
 import type { HomePageData } from "./page-factories";
 import type { ContentPageProps } from "./page-builders";
 import { localizePath } from "./paths";
@@ -71,7 +72,7 @@ export function createContentPageRoute(locale: Locale) {
     return {
       props: {
         eyebrow: resolved.eyebrow,
-        page: resolved.page
+        page: prepareDailyReportPage(resolved.page, locale)
       }
     };
   };


### PR DESCRIPTION
## Superseded

`main` advanced through PR #143 while this PR was running. PR #143 directly fixed the source report headings and removed the accidentally published internal rules page, so this branch now conflicts and contains redundant normalization work.

The remaining required change, removing the final public footer status line and the repository rules that would reintroduce it, is being replayed as a minimal patch from the latest `main`.