### PR TITLE
Make the repository authoritative for daily site operations

### DIFF
--- a/.agents/skills/eunomia-research-report/SKILL.md
+++ b/.agents/skills/eunomia-research-report/SKILL.md
@@ -5,7 +5,7 @@ description: Research, write, validate, and publish source-grounded Eunomia Dail
 
 # Eunomia Daily Report
 
-Produce technically serious, source-grounded analysis for the public **Daily Report** section. The repository is the source of truth for the publication contract, content, routes, and delivery workflow.
+Produce technically serious, source-grounded analysis for the public **Daily Report** section. The repository is the source of truth for the publication contract, content, routes, topic mix, and delivery workflow.
 
 The purpose is to help engineers and researchers understand a real problem, see what current work still misses, and find ideas worth implementing and evaluating. Depth comes from evidence, mechanism, comparison, and testable design, not from academic tone or terminology density.
 
@@ -18,7 +18,8 @@ Every Daily Report must satisfy these rules:
 - The report contains a concrete section explaining where current research or production practice is still weak.
 - The report contains a small number of developed directions with both academic and production relevance.
 - The report states the assumptions behind its conclusion and the evidence that would change it, using reader-facing language.
-- The report is not published when the scan yields only a fluent summary and no defensible gap, mechanism, or useful idea.
+- Every scheduled daily run publishes one new report. A weak candidate is rejected, but the run must continue researching another approved question until one passes the quality gates.
+- The rolling topic mix in `.github/seo-data/content-series.md` is mandatory: normally 5–7 of the most recent 10 reports explicitly center eBPF, while pure Agent topics remain at most 1–2 of 10.
 - Do not add provenance banners, warning boxes, generation-process badges, review-status text, or footer disclaimers to the public page.
 - Do not infer an article byline from Git commit metadata.
 
@@ -28,12 +29,13 @@ Read these before acting:
 
 - `CLAUDE.md`
 - `.agents/skills/blog-writing-style/SKILL.md`
+- `.github/seo-data/content-series.md`
 - existing pages under `docs/research/`
 - related posts under `docs/blog/` and `docs/reports/`
 - `references/research-method.md`
 - `docs/papers/registry.yaml` only after a candidate question exists
 
-When invoked by a scheduled repository task, also read the task entrypoint, current operating records, and any explicit publication constraints stored in the repository.
+When invoked by a scheduled repository task, also read the task entrypoint, current operating records, rolling topic mix, and any explicit publication constraints stored in the repository.
 
 ## Output Location And Metadata
 
@@ -42,7 +44,7 @@ A bilingual report uses:
 - `docs/research/<topic>.md`
 - `docs/research/<topic>.zh.md`
 
-Keep an existing URL when revising an article.
+Keep an existing URL when revising an article. Scheduled daily publication, however, requires one **new** report page; revising an existing page does not satisfy that day's publication requirement.
 
 New Daily Report frontmatter should include:
 
@@ -58,11 +60,27 @@ source_cutoff: YYYY-MM-DD
 status: daily-report
 ```
 
+## Topic Selection
+
+Daily Report is eBPF-first.
+
+Before research begins:
+
+1. calculate the rolling mix from the most recent published reports;
+2. prefer the active series in `.github/seo-data/content-series.md`;
+3. keep 5–7 of the most recent 10 reports centered on eBPF;
+4. keep pure Agent reports to at most 1–2 of 10;
+5. use the remaining slots for adjacent systems topics such as Linux, profiling, networking, security, runtimes, GPU/heterogeneous systems, distributed systems, storage, and compilers.
+
+An eBPF-centered report must make eBPF essential to the mechanism, comparison, runtime boundary, or experiment. Mentioning eBPF in the introduction or future-work section does not make a report eBPF-centered.
+
+Because the current small archive already contains two Agent-centered reports, the next reports should strongly favor eBPF before another pure Agent report is considered.
+
 ## Workflow
 
 ### 1. Start With A Real Reader Question
 
-Begin from a broad systems area, then search before choosing a thesis. Prefer a question that changes an architecture, implementation, security, operations, or research decision.
+Begin from the active eBPF or approved adjacent-systems series, then search before choosing a thesis. Prefer a question that changes an architecture, implementation, security, operations, or research decision.
 
 Good questions expose one of these:
 
@@ -117,6 +135,8 @@ Before drafting, state in ordinary language:
 7. what result would change the claim.
 
 The gap must identify a missing benchmark, interface, mechanism, guarantee, dataset, measurement, deployment property, or boundary condition. Reject generic statements such as "more research is needed" or "scalability remains challenging."
+
+If the candidate fails this gate, discard it and immediately research the next candidate in the approved series roadmap. The daily run does not terminate without a report.
 
 ### 5. Design The Reader Path
 
@@ -196,21 +216,23 @@ Explain assumptions, counterexamples, and decisive future evidence in prose. Kee
 
 ### 10. Validate And Publish
 
-When publication is authorized, complete the whole delivery:
+Every scheduled daily run must finish with one new bilingual report deployed publicly.
 
 1. create a focused branch;
-2. change only files in scope;
-3. run the repository's full verification workflow;
-4. inspect the complete PR diff;
-5. merge only after required checks pass;
-6. verify that the exact merge commit deploys;
-7. inspect the public English and Chinese pages, navigation, canonical URLs, gap sections, idea sections, and rendered conclusion heading.
+2. add exactly one new Daily Report topic in English and Chinese;
+3. change only files in scope plus directly coupled navigation/metadata/operating records;
+4. run the repository's full verification workflow;
+5. inspect the complete PR diff;
+6. merge only after required checks pass;
+7. verify that the exact merge commit deploys;
+8. inspect the public English and Chinese pages, navigation, canonical URLs, gap sections, idea sections, and rendered conclusion heading;
+9. record the report's series and topic classification for the next rolling-mix calculation.
 
-A draft, open PR, or green pre-merge check is not a completed deployment.
+A draft, open PR, green pre-merge check, revision-only day, or unpublished report is not completed daily delivery.
 
 ## Publication Review
 
-Reject or revise the report when any of these are true:
+Reject or revise the candidate when any of these are true:
 
 - the title depends on an unexplained coined term;
 - the opening reads like an abstract rather than a human explanation;
@@ -222,8 +244,21 @@ Reject or revise the report when any of these are true:
 - repository-owned work is treated more generously than outside work;
 - the page contains process-oriented warning boxes, provenance notes, review-status text, or footer disclaimers;
 - the new page substantially duplicates an existing question or thesis;
-- important claims cannot be traced to primary evidence.
+- important claims cannot be traced to primary evidence;
+- the topic would violate the rolling eBPF/Agent editorial mix.
 
-## No-Report Outcome
+Rejecting one candidate does not end the daily run. Select another question from the active or approved series and repeat the research process until one report passes.
 
-If research produces interesting sources but no defensible gap and no non-trivial idea, do not publish. Record the strongest unresolved question and the evidence that would unblock it. A truthful no-report result is better than a generic summary added only to satisfy cadence.
+## Daily Fallback
+
+There is no `no-report` outcome for the scheduled daily operation.
+
+If the initial candidate lacks a defensible gap, mechanism, evidence base, or non-trivial idea:
+
+1. preserve any useful evidence internally;
+2. reject the candidate;
+3. move to the next question in the active eBPF series;
+4. if necessary, move to another approved eBPF or adjacent-systems series while respecting the rolling mix;
+5. continue until one candidate meets the full publication standard.
+
+The fallback is broader research, not weaker writing.

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,18 +1,37 @@
-# Human-only blockers
+# External blockers
 
-No human-only blockers.
+## Daily scheduler is not configured
 
-## Known non-blocking limitations
+- Blocked action: automatic once-per-day invocation of `DAILY_TASK.md`.
+- Evidence: the repository has no daily agent workflow, and no external scheduler
+  has been configured or verified.
+- Impact: the repository now defines the complete operation, but nothing invokes
+  it every day.
+- Minimal external action: create one daily task in `America/Los_Angeles` with
+  exactly this instruction:
 
-- Google Analytics 4 and Search Console Drive exports are disabled in `site.md`
-  until a public-safe export folder and filename contract are configured.
-- Cloudflare collection is disabled until a read-only supported connector or
-  GraphQL route is available.
-- Disabled sources must be reported as unavailable, never as zero traffic.
+  > Open `eunomia-bpf/eunomia.dev`, read `DAILY_TASK.md` from the current default
+  > branch, and complete the task exactly as the repository instructs. Treat the
+  > repository as authoritative.
 
-The automation is authorized to perform all normal collection, repository,
-branch, pull-request, CI-wait, self-review, squash-merge, deployment-wait,
-verification, and closeout steps. Add a blocker only when an external system
-truly requires a human-only action or the required account permission does not
-exist. Include the exact blocked action, evidence, impact, and minimal human
-action needed. Remove resolved items in the next pull request.
+Do not copy the rest of the operating policy into the scheduler.
+
+## Private analytics sources are not configured
+
+- Blocked actions: source-native Search Console, GA4, and Cloudflare analysis.
+- Evidence: all three private sources are disabled or unconfigured in `site.md`.
+- Impact: query, acquisition, engagement, edge-traffic, bot, cache, and some
+  outcome analysis remains unavailable.
+- Minimal external action: authorize or configure supported read-only access or a
+  public-safe export path for each source, without committing IDs, credentials,
+  private URLs, raw private data, or personal information.
+
+## Partial operation remains required
+
+These blockers do not justify skipping the daily operation once a scheduler
+exists. Each run must still analyze live-site technical evidence, public GitHub
+repository evidence, and public primary-source evidence; it must mark private
+sources unavailable and must never convert missing coverage into zero.
+
+Remove or narrow a blocker in the next daily pull request after the external
+condition is verified as resolved.

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,4 +1,7 @@
-# External blockers
+# Human-only blockers
+
+The entries below are external account or scheduler conditions that the repository
+cannot truthfully mark as resolved by itself.
 
 ## Daily scheduler is not configured
 

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -8,8 +8,8 @@ cannot truthfully mark as resolved by itself.
 - Blocked action: automatic once-per-day invocation of `DAILY_TASK.md`.
 - Evidence: the repository has no daily agent workflow, and no external scheduler
   has been configured or verified.
-- Impact: the repository now defines the complete operation, but nothing invokes
-  it every day.
+- Impact: the repository defines the complete operation, but nothing invokes it
+  every day.
 - Minimal external action: create one daily task in `America/Los_Angeles` with
   exactly this instruction:
 
@@ -19,22 +19,32 @@ cannot truthfully mark as resolved by itself.
 
 Do not copy the rest of the operating policy into the scheduler.
 
-## Private analytics sources are not configured
+## Cloudflare analytics is not configured
 
-- Blocked actions: source-native Search Console, GA4, and Cloudflare analysis.
-- Evidence: all three private sources are disabled or unconfigured in `site.md`.
-- Impact: query, acquisition, engagement, edge-traffic, bot, cache, and some
-  outcome analysis remains unavailable.
-- Minimal external action: authorize or configure supported read-only access or a
-  public-safe export path for each source, without committing IDs, credentials,
-  private URLs, raw private data, or personal information.
+- Blocked action: source-native edge request, bot, cache, country, and status-code
+  analysis.
+- Evidence: Cloudflare remains disabled in `site.md`.
+- Impact: daily analysis can use Search Console, GA4, live-site, GitHub, and public
+  primary-source evidence, but cannot make Cloudflare-grounded traffic or cache
+  conclusions.
+- Minimal external action: authorize a supported read-only connector or export
+  route without committing zone IDs, credentials, private URLs, raw private data,
+  or personal information.
 
-## Partial operation remains required
+## Current data-history limitation
 
-These blockers do not justify skipping the daily operation once a scheduler
-exists. Each run must still analyze live-site technical evidence, public GitHub
-repository evidence, and public primary-source evidence; it must mark private
-sources unavailable and must never convert missing coverage into zero.
+Google Drive access is verified and is not a blocker. The configured folder
+contains six Search Console exports and one GA4 organic landing-page export for
+`2026-07-27` through `2026-08-02`. Only one complete weekly window is currently
+available, so previous-week and 28-day comparisons must remain unavailable until
+additional exports appear. The GA4 export is also limited to organic landing-page
+rows and does not by itself provide complete acquisition, conversion, or outbound
+behavior coverage.
+
+These limitations do not justify skipping the daily operation once a scheduler
+exists. Each run must use the available Google exports, live-site evidence,
+public GitHub evidence, and public primary-source evidence; missing coverage must
+never be converted into zero.
 
 Remove or narrow a blocker in the next daily pull request after the external
 condition is verified as resolved.

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,23 +1,7 @@
 # Human-only blockers
 
-The entries below are external account or scheduler conditions that the repository
-cannot truthfully mark as resolved by itself.
-
-## Daily scheduler is not configured
-
-- Blocked action: automatic once-per-day invocation of `DAILY_TASK.md`.
-- Evidence: the repository has no daily agent workflow, and no external scheduler
-  has been configured or verified.
-- Impact: the repository defines the complete operation, but nothing invokes it
-  every day.
-- Minimal external action: create one daily task in `America/Los_Angeles` with
-  exactly this instruction:
-
-  > Open `eunomia-bpf/eunomia.dev`, read `DAILY_TASK.md` from the current default
-  > branch, and complete the task exactly as the repository instructs. Treat the
-  > repository as authoritative.
-
-Do not copy the rest of the operating policy into the scheduler.
+Only unresolved external conditions belong here. The daily ChatGPT scheduler is
+already configured and enabled; it is not a blocker.
 
 ## Cloudflare analytics is not configured
 
@@ -31,20 +15,21 @@ Do not copy the rest of the operating policy into the scheduler.
   route without committing zone IDs, credentials, private URLs, raw private data,
   or personal information.
 
-## Current data-history limitation
+## Current data-history constraint
 
 Google Drive access is verified and is not a blocker. The configured folder
 contains six Search Console exports and one GA4 organic landing-page export for
 `2026-07-27` through `2026-08-02`. Only one complete weekly window is currently
-available, so previous-week and 28-day comparisons must remain unavailable until
+available, so previous-week and 28-day comparisons remain unavailable until
 additional exports appear. The GA4 export is also limited to organic landing-page
 rows and does not by itself provide complete acquisition, conversion, or outbound
 behavior coverage.
 
-These limitations do not justify skipping the daily operation once a scheduler
-exists. Each run must use the available Google exports, live-site evidence,
-public GitHub evidence, and public primary-source evidence; missing coverage must
-never be converted into zero.
+These constraints never justify skipping the daily operation. Each run must use
+the available Google exports, live-site evidence, public GitHub evidence, and
+public primary-source evidence; missing coverage must never be converted into
+zero. Every run must still publish one new Daily Report under the current
+repository contract.
 
 Remove or narrow a blocker in the next daily pull request after the external
 condition is verified as resolved.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -1,135 +1,200 @@
 # Daily Report content series
 
 This file is the authoritative thematic roadmap for scheduled Daily Report work.
-The daily task should advance a coherent series rather than choose unrelated
-trending topics. Publication remains quality-gated; a series is a research
-constraint, not a quota.
+Daily Report is eBPF-first and series-driven. The goal is to build durable
+technical ownership around eBPF and adjacent systems topics rather than publish
+unrelated daily news.
+
+## Editorial mix
+
+Apply these rules to the rolling window of the most recent 10 published Daily
+Reports:
+
+- **5–7 of 10 must explicitly contain eBPF** as a central mechanism, runtime,
+  measurement substrate, comparison point, or systems boundary.
+- **Pure AI-agent topics are capped at 1–2 of 10.** Agent topics that primarily
+  study eBPF instrumentation, policy enforcement, profiling, or runtime
+  mechanisms count as eBPF-centered when eBPF is essential to the technical
+  question rather than a decorative mention.
+- The remaining reports may cover directly adjacent systems areas such as Linux
+  kernels, observability, profiling, networking, security, runtimes, GPU and
+  heterogeneous systems, distributed systems, compilers, or storage.
+- Until the archive reaches 10 reports, apply the same proportions to the
+  available set as closely as possible. The two existing Agent-centered reports
+  mean the next reports should strongly favor eBPF before another pure Agent
+  report is considered.
+
+Record the rolling mix in the daily operating record before selecting a topic.
+Do not manipulate classification to satisfy the ratio; classify by the report's
+actual central technical question.
+
+## Daily publication rule
+
+Every scheduled daily run must publish **one new Daily Report page**. `no-report`
+is not an allowed completion outcome.
+
+This is a publication requirement, not permission to lower the quality bar. If
+the first candidate fails the evidence, gap, novelty, or usefulness gates, reject
+that candidate and continue research on another question in the approved roadmap
+until one passes. Prefer changing the question over padding weak evidence or
+inventing novelty.
+
+A daily report must still provide:
+
+- a concrete reader problem;
+- primary-source evidence;
+- a non-trivial gap or unresolved mechanism;
+- a reasoned technical conclusion;
+- a small number of implementable research directions with academic and
+  production value;
+- a discriminating evaluation or evidence that would change the conclusion;
+- a thesis that does not duplicate an existing report.
 
 ## Series rules
 
-- Keep one **active series** at a time. A normal series contains roughly 4–6
-  substantial reports developed over multiple daily research runs.
-- Search inside the active series first. A new report must answer a distinct
-  question and materially advance the series argument rather than restate an
-  earlier report with different examples.
-- Prefer continuity: reuse evidence maps, unresolved questions, experiments, and
-  counterexamples from earlier reports when they remain valid.
-- An out-of-series report is allowed only for a material external development
-  with durable systems consequences. Record why it justified interrupting the
-  active series.
-- Data analysis may influence which series becomes active next. Search demand,
-  landing-page behavior, GitHub activity, reader pathways, and technical changes
-  are evidence, but they do not override the research quality gate.
-- Do not publish merely to maintain cadence. A daily research run may update the
-  evidence map, revise an existing report, or record a no-report result.
+- Keep one **active series** for normal daily publication. A series normally
+  contains 4–6 substantial reports that build on one another.
+- Search inside the active series first. Each new report must answer a distinct
+  question and materially advance the series argument.
+- Reuse valid evidence maps, unresolved questions, experiments, terminology, and
+  counterexamples from earlier reports, but never copy the thesis with a new
+  example.
+- If the active series cannot yield a publishable report on a given day, move to
+  another approved eBPF or adjacent-systems series for that run rather than
+  publishing weak material.
+- A material external development may justify an out-of-series report when it
+  has durable systems consequences and still respects the rolling topic mix.
+- Search Console, GA4, GitHub activity, reader pathways, and technical releases
+  can influence ordering inside the roadmap, but short-lived popularity does not
+  override the editorial mix or technical quality standard.
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Active series — Agent Runtime Correctness
+## Active series — eBPF Runtime, Extensibility, and Composition
 
-Working question: **What runtime guarantees are needed when an AI agent's work
-spans multiple model calls, tools, processes, checkpoints, permissions, and
-external side effects?**
+Working question: **What mechanisms are still missing if eBPF is treated as a
+programmable runtime substrate rather than only a kernel observability feature?**
 
-This series should connect correctness mechanisms that are usually discussed
-separately: concurrency, recovery, authority, effect control, and outcome
-verification.
+This series should connect kernel and userspace execution, composition, state,
+upgrade, safety, performance, and deployment boundaries.
 
-### Existing anchor
+### Preferred sequence
 
-1. **When Several AI Agents Work at Once, Who Makes Sure the Final Result Is
-   Right?**
-   - Existing page: `/research/parallel-agent-effect-serializability/`
-   - Role in the series: shows why isolated branches and locally successful
-     workers are insufficient when effects must be committed together.
+1. **What is still missing for first-class userspace eBPF?**
+   - Compare kernel eBPF, uprobes, DBI, language runtimes, and bpftime-style
+     execution.
+   - Focus on attach semantics, state, compatibility, safety, and which workloads
+     genuinely benefit from moving execution out of the kernel.
 
-### Preferred next questions
+2. **How should multiple independent eBPF extensions share one hook safely?**
+   - Study ordering, isolation, attribution, state sharing, resource accounting,
+     and conflicting policies.
+   - Compare dispatcher chains, tail calls, trampolines, vBPF-style approaches,
+     and explicit composition contracts.
 
-2. **What state has to survive checkpoint and restore together?**
-   - Investigate local workspace, external object versions, credentials,
-     delegated processes, pending effects, policy state, and replay safety.
-   - Look for a concrete recovery contract rather than another checkpoint format.
+3. **Can a stateful eBPF application be upgraded transactionally?**
+   - Go beyond replacing one program pointer.
+   - Analyze coordinated changes to programs, links, maps, pinned state, userspace
+     controllers, and rollback after partial failure.
 
-3. **When should an old approval stop authorizing a long-running agent?**
-   - Study changes in repository state, task intent, policy, credentials, tool
-     implementations, and delegation relationships between approval and effect.
-   - Compare time-based expiry with state-bound revalidation at real effect
-     boundaries.
+4. **What would an asynchronous profiler built around modern eBPF look like?**
+   - Cover syscalls, async runtimes, io_uring, work queues, task handoff, causality,
+     sampling bias, and application-defined resources.
+   - Ask which causal edges can be reconstructed online with acceptable overhead.
 
-4. **Which agent side effects can be rolled back, compensated, or must be
-   serialized?**
-   - Build a practical effect taxonomy across files, Git, databases, cloud APIs,
-     messages, payments, deployments, and credentials.
-   - Identify where transaction semantics end and compensation or prevention must
-     begin.
+5. **Which new Linux I/O hooks make previously impractical eBPF mechanisms
+   possible?**
+   - Study recent io_uring and related programmable I/O interfaces, file access,
+     policy, caching, scheduling, and fast-path control.
+   - Prefer concrete mechanisms that could not be implemented cleanly with older
+     hook sets.
 
-5. **What should the durable unit of agent work contain?**
-   - Ask whether one work unit should bind execution state, authority, effects,
-     recovery, observability, accounting, and placement.
-   - Compare request-, process-, session-, and trajectory-scoped abstractions.
+6. **Where should eBPF execution live in heterogeneous systems?**
+   - Compare kernel, userspace, DPU/NIC, GPU-adjacent, and device-side execution.
+   - Investigate state placement, verifier assumptions, memory visibility,
+     cross-device coordination, and observability/control tradeoffs.
 
-6. **How should an agent prove that a task succeeded after real side effects?**
-   - Separate tool return codes from outcome verification.
-   - Explore independent oracles, state receipts, postconditions, and failure
-     cases where every individual step reports success but the user goal is not
-     satisfied.
+These are research questions, not fixed titles. Final titles and claims must come
+from the day's evidence.
 
-Do not force these exact titles. They are research questions and continuity
-anchors. The final title and thesis must come from evidence.
+## Queued series — eBPF Observability and Profiling
 
-## Queued series — Agent Observability and Evidence
+Working question: **Which important performance and correctness questions remain
+unanswerable with today's eBPF observability stack?**
 
-Working question: **Under bounded overhead and privacy budgets, what evidence is
-needed to explain and verify long-running agent behavior?**
+Candidate topics:
 
-Existing anchor:
+1. async and syscall causal profiling across thread and process handoff;
+2. page-level memory attribution: RSS, touched versus untouched allocation,
+   mmap/brk provenance, page faults, reclaim, and memory bandwidth;
+3. sampling theory for profilers: phase locking, randomized sampling, bias, and
+   confidence intervals;
+4. always-on semantic compression that preserves diagnostic evidence instead of
+   raw event volume;
+5. application-defined resource profiling that combines static discovery,
+   runtime eBPF evidence, and online validation;
+6. causal profiling for GPU host-side bottlenecks and megakernel execution.
+
+## Queued series — eBPF Networking and Security
+
+Working question: **Where are eBPF networking and security mechanisms still
+missing deployable abstractions or correctness guarantees?**
+
+Candidate topics:
+
+1. transactional policy updates across programs, maps, links, and control planes;
+2. multi-tenant network-policy composition and conflict resolution;
+3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
+   userspace eBPF;
+4. information-flow enforcement across process, file, socket, and encrypted
+   application boundaries;
+5. verifier and runtime interfaces for richer stateful policies;
+6. portable policy execution between kernel, userspace, NIC, and DPU targets.
+
+## Queued series — GPU and Heterogeneous Runtime Systems
+
+Working question: **What runtime and observability abstractions are missing at
+CPU/GPU and host/device boundaries?**
+
+Candidate topics include GPU/CPU causal profiling, memory movement, megakernel
+observability, programmable device-side instrumentation, distributed GPU
+coordination, utilization versus allocatability, host-side scheduling noise, and
+eBPF-like programmable monitors near GPU or DPU execution.
+
+Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
+runtime is central to the mechanism being evaluated.
+
+## Queued series — Agent Systems (limited)
+
+Pure Agent systems work is intentionally a minority topic. Use this series only
+for questions with unusually strong systems consequences that are not better
+framed through eBPF, Linux, runtime, observability, or security mechanisms.
+
+Existing anchors:
 
 - `/research/agent-trace-evidence-budget/`
+- `/research/parallel-agent-effect-serializability/`
 
-Candidate sequence:
+Because these already occupy the pure-Agent budget in the current small archive,
+do not schedule another pure Agent report until the rolling mix is compliant.
 
-1. cross-layer causal tracing from agent actions to processes, files, sockets,
-   repository versions, and external objects;
-2. causal flight recorders that retain decisive evidence instead of fixed time
-   windows;
-3. diagnosis benchmarks that measure whether retained evidence distinguishes
-   competing root causes, not merely whether events were collected;
-4. asynchronous and syscall-level profiling for tool-heavy agents;
-5. trace compression that preserves semantic dependencies and uncertainty;
-6. binding trajectories to changing workspace and environment state.
+Future Agent reports should preferentially connect back to eBPF or systems
+infrastructure, for example OS-level effect tracing, eBPF policy enforcement,
+sandbox escape visibility, syscall/tool causality, or runtime resource control.
 
-## Queued series — eBPF as Runtime Infrastructure
+## Choosing the next report
 
-Working question: **Which missing runtime mechanisms become possible when eBPF
-is treated as a programmable systems substrate rather than only an observability
-feature?**
+Each daily run should:
 
-Candidate areas include userspace eBPF, multi-tenant composition, stateful and
-transactional upgrades, async profiling, new I/O hooks, policy enforcement, and
-portable execution across heterogeneous runtime boundaries. Each report must
-identify a mechanism that is not reducible to simply “add eBPF.”
+1. calculate the current rolling topic mix;
+2. start inside the active series;
+3. research multiple candidate questions if necessary;
+4. reject candidates that do not pass the evidence and novelty gates;
+5. choose one question that both passes quality review and keeps the rolling mix
+   compliant;
+6. publish exactly one new Daily Report;
+7. record the chosen series, topic classification, rejected candidates when
+   useful, and why the report materially advances the series.
 
-## Queued series — GPU Runtime and Observability
-
-Working question: **What runtime abstractions are missing for diagnosing,
-controlling, and composing modern GPU workloads?**
-
-Candidate areas include GPU/CPU causal profiling, memory movement, megakernel
-observability, programmable device-side instrumentation, distributed GPU
-coordination, utilization versus allocatability, and how host/runtime state
-changes the interpretation of device traces.
-
-## Choosing the next series
-
-Finish or deliberately pause the active series before switching. A switch should
-be justified by at least one of:
-
-- the active series has answered its main question well enough;
-- remaining questions lack evidence or testability;
-- a queued series has materially stronger technical evidence and reader demand;
-- a major systems development changes the research frontier;
-- the site's search, reader, or GitHub data shows a durable opportunity that
-  matches Eunomia's technical ownership.
-
-Record a series switch and its reason in the daily operating record and update
-this file so the repository, not chat history, remains authoritative.
+A series switch should be recorded in the daily operating record and in this
+file so the repository, not chat history, remains authoritative.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -1,0 +1,135 @@
+# Daily Report content series
+
+This file is the authoritative thematic roadmap for scheduled Daily Report work.
+The daily task should advance a coherent series rather than choose unrelated
+trending topics. Publication remains quality-gated; a series is a research
+constraint, not a quota.
+
+## Series rules
+
+- Keep one **active series** at a time. A normal series contains roughly 4–6
+  substantial reports developed over multiple daily research runs.
+- Search inside the active series first. A new report must answer a distinct
+  question and materially advance the series argument rather than restate an
+  earlier report with different examples.
+- Prefer continuity: reuse evidence maps, unresolved questions, experiments, and
+  counterexamples from earlier reports when they remain valid.
+- An out-of-series report is allowed only for a material external development
+  with durable systems consequences. Record why it justified interrupting the
+  active series.
+- Data analysis may influence which series becomes active next. Search demand,
+  landing-page behavior, GitHub activity, reader pathways, and technical changes
+  are evidence, but they do not override the research quality gate.
+- Do not publish merely to maintain cadence. A daily research run may update the
+  evidence map, revise an existing report, or record a no-report result.
+- After a series has at least three strong reports, consider a public series hub
+  and stronger internal linking. Do not create thin hub pages in advance.
+
+## Active series — Agent Runtime Correctness
+
+Working question: **What runtime guarantees are needed when an AI agent's work
+spans multiple model calls, tools, processes, checkpoints, permissions, and
+external side effects?**
+
+This series should connect correctness mechanisms that are usually discussed
+separately: concurrency, recovery, authority, effect control, and outcome
+verification.
+
+### Existing anchor
+
+1. **When Several AI Agents Work at Once, Who Makes Sure the Final Result Is
+   Right?**
+   - Existing page: `/research/parallel-agent-effect-serializability/`
+   - Role in the series: shows why isolated branches and locally successful
+     workers are insufficient when effects must be committed together.
+
+### Preferred next questions
+
+2. **What state has to survive checkpoint and restore together?**
+   - Investigate local workspace, external object versions, credentials,
+     delegated processes, pending effects, policy state, and replay safety.
+   - Look for a concrete recovery contract rather than another checkpoint format.
+
+3. **When should an old approval stop authorizing a long-running agent?**
+   - Study changes in repository state, task intent, policy, credentials, tool
+     implementations, and delegation relationships between approval and effect.
+   - Compare time-based expiry with state-bound revalidation at real effect
+     boundaries.
+
+4. **Which agent side effects can be rolled back, compensated, or must be
+   serialized?**
+   - Build a practical effect taxonomy across files, Git, databases, cloud APIs,
+     messages, payments, deployments, and credentials.
+   - Identify where transaction semantics end and compensation or prevention must
+     begin.
+
+5. **What should the durable unit of agent work contain?**
+   - Ask whether one work unit should bind execution state, authority, effects,
+     recovery, observability, accounting, and placement.
+   - Compare request-, process-, session-, and trajectory-scoped abstractions.
+
+6. **How should an agent prove that a task succeeded after real side effects?**
+   - Separate tool return codes from outcome verification.
+   - Explore independent oracles, state receipts, postconditions, and failure
+     cases where every individual step reports success but the user goal is not
+     satisfied.
+
+Do not force these exact titles. They are research questions and continuity
+anchors. The final title and thesis must come from evidence.
+
+## Queued series — Agent Observability and Evidence
+
+Working question: **Under bounded overhead and privacy budgets, what evidence is
+needed to explain and verify long-running agent behavior?**
+
+Existing anchor:
+
+- `/research/agent-trace-evidence-budget/`
+
+Candidate sequence:
+
+1. cross-layer causal tracing from agent actions to processes, files, sockets,
+   repository versions, and external objects;
+2. causal flight recorders that retain decisive evidence instead of fixed time
+   windows;
+3. diagnosis benchmarks that measure whether retained evidence distinguishes
+   competing root causes, not merely whether events were collected;
+4. asynchronous and syscall-level profiling for tool-heavy agents;
+5. trace compression that preserves semantic dependencies and uncertainty;
+6. binding trajectories to changing workspace and environment state.
+
+## Queued series — eBPF as Runtime Infrastructure
+
+Working question: **Which missing runtime mechanisms become possible when eBPF
+is treated as a programmable systems substrate rather than only an observability
+feature?**
+
+Candidate areas include userspace eBPF, multi-tenant composition, stateful and
+transactional upgrades, async profiling, new I/O hooks, policy enforcement, and
+portable execution across heterogeneous runtime boundaries. Each report must
+identify a mechanism that is not reducible to simply “add eBPF.”
+
+## Queued series — GPU Runtime and Observability
+
+Working question: **What runtime abstractions are missing for diagnosing,
+controlling, and composing modern GPU workloads?**
+
+Candidate areas include GPU/CPU causal profiling, memory movement, megakernel
+observability, programmable device-side instrumentation, distributed GPU
+coordination, utilization versus allocatability, and how host/runtime state
+changes the interpretation of device traces.
+
+## Choosing the next series
+
+Finish or deliberately pause the active series before switching. A switch should
+be justified by at least one of:
+
+- the active series has answered its main question well enough;
+- remaining questions lack evidence or testability;
+- a queued series has materially stronger technical evidence and reader demand;
+- a major systems development changes the research frontier;
+- the site's search, reader, or GitHub data shows a durable opportunity that
+  matches Eunomia's technical ownership.
+
+Record a series switch and its reason in the daily operating record and update
+this file so the repository, not chat history, remains authoritative.

--- a/.github/seo-data/daily-task.md
+++ b/.github/seo-data/daily-task.md
@@ -1,67 +1,81 @@
-# Daily SEO task
+# Daily technical SEO subtask
+
+`DAILY_TASK.md` is the only scheduled entrypoint and the authoritative daily
+operating contract. An external scheduler must not target this file directly.
+Use this file only when the daily operation evaluates or selects technical SEO
+and GEO work.
 
 ## Objective
 
-Run one fully autonomous, evidence-backed SEO operating cycle for eunomia.dev.
-No normal collection, repository, review, merge, deployment, or verification
-step requires human approval.
+Use measured search, acquisition, repository, and live-site evidence to maintain
+and improve eunomia.dev's technical discoverability, indexability,
+retrievability, and citation quality. Do not create a site edit merely because a
+daily run occurred.
 
-## Schedule
+## Required context
 
-- Frequency: daily when invoked by an authorized agent scheduler
-- Timezone: use `site.md`
-- Data window: use the lookback and finalization lag in `site.md`
-- Maximum site changes: one coherent, evidence-backed change per main pull request
+Read:
 
-## Scoped workflow override
+- `DAILY_TASK.md`;
+- `CLAUDE.md`;
+- every Markdown file under `.github/seo-data/`;
+- the newest record under `.github/seo-data/daily/`, when present;
+- `.agents/skills/seo-geo/SKILL.md`;
+- the pinned collection, change, and validation skills under
+  `.github/seo-skills`.
 
-For work invoked through this file, the fresh-branch and pull-request contract
-below replaces the repository's general direct-`main` workflow. This standing
-override is limited to SEO evidence collection, `.github/seo-data` maintenance,
-submodule updates, and evidence-backed SEO/GEO site changes. Use the `seo/`
-branch prefix from `site.md`; never push an automated SEO change directly to
-`main`.
+The root daily task controls branching, pull requests, merging, deployment,
+verification, records, and completion. Do not duplicate those rules here.
 
-## Required sequence
+## Technical analysis
 
-1. Read the pinned `$collect-seo-data` skill and, when a site change is justified,
-   `$change-seo-site`; also read repository instructions, all
-   `.github/seo-data/*.md` files, and the newest daily records.
-2. Fetch the remote default branch and create a fresh branch from it.
-3. Check whether the `seo-skills` submodule has a newer allowed commit and include
-   an available compatible update in the same main pull request.
-4. Collect evidence only from sources marked enabled in `site.md`. Record a
-   disabled, missing, stale, partial, or unavailable source explicitly; never
-   convert missing evidence into zero. Public repository and live-site evidence
-   may supplement analytics but does not replace source-native metrics.
-5. Write or append `.github/seo-data/daily/YYYY-MM-DD.md`; refresh `status.md`,
-   keep durable future work in `plan.md`, and reserve `block.md` for genuine
-   human-only or permission blockers.
-6. When evidence supports a site improvement, implement at most one coherent
-   change and define its production acceptance check before editing. Use
-   `.agents/skills/seo-geo/SKILL.md` as the site-specific technical checklist;
-   the pinned skills remain authoritative for evidence collection and delivery.
-7. Validate with the pinned validator and the smallest authoritative repository
-   checks, inspect the intended diff, push the branch, and create a real
-   non-draft pull request.
-8. Wait for every required and expected CI check, then self-review the complete
-   final diff, commits, generated output, and check results. Fix issues on the
-   same branch and repeat CI and review as needed.
-9. Squash-merge the pull request and delete its branch only after green CI and a
-   clean final self-review.
-10. For a site change, identify and wait for the production deployment triggered
-    by the exact squash commit, then verify the defined behavior on the public
-    site.
-11. Open a metadata-only closeout pull request with the verified delivery facts;
-    apply the same CI, self-review, squash-merge, and branch-deletion rules.
-12. Do not manufacture content, site edits, promotion, or visible artifacts only
-    to satisfy cadence. Promotion must follow the existing publication queue and
-    platform-specific publisher skills.
+Use every enabled source in `site.md` and the windows defined there. Missing,
+stale, partial, disabled, or inaccessible sources are unavailable, not zero.
+Public repository and live-site evidence may supplement analytics but does not
+replace source-native search or acquisition metrics.
 
-## Daily completion
+Evaluate at least:
 
-A day is complete only after its main pull request and closeout pull request are
-squash-merged. A site-change day also requires a successful production deployment
-for the exact squash commit and public verification. A failed, missing, queued,
-skipped, or cancelled CI check, a local-only commit, issue, draft pull request,
-workflow URL, or HTTP 200 alone is not completion.
+- crawl access, robots, sitemap coverage, status codes, redirects, and broken
+  internal links;
+- canonical URLs, duplicate routes, indexability, pagination, and URL stability;
+- English and Chinese `hreflang` pairs and language navigation;
+- titles, descriptions, headings, structured data, Open Graph, and semantic
+  page identity;
+- internal linking, orphan pages, hub structure, repository/paper/tutorial
+  pathways, and citation-ready source presentation;
+- rendering, performance, accessibility signals relevant to discovery, and the
+  production deployment state;
+- important query, page, landing-page, referrer, and outbound movements when
+  Search Console or analytics coverage exists.
+
+Record the evidence and interpretation in the day's shared record under
+`.github/seo-data/daily/`; do not create a second SEO-only run log.
+
+## Change gate
+
+A technical change is justified only when the evidence identifies a concrete
+problem or opportunity and the expected outcome is observable. Define the
+production acceptance check before editing.
+
+Prefer one coherent change such as:
+
+- repairing canonical, sitemap, robots, redirect, or language-alternate behavior;
+- improving one information architecture or internal-linking path;
+- correcting structured data or metadata for a well-defined page family;
+- removing an indexability or rendering defect;
+- improving retrievability for a technically important topic supported by search
+  or reader evidence.
+
+Do not bundle unrelated cleanup, speculative keyword insertion, mass-generated
+pages, promotion, or a routine skill-submodule update. Update the pinned SEO
+skills only when a compatible change is needed for the current operation or
+clearly fixes the operating mechanism.
+
+## Delivery
+
+Follow `DAILY_TASK.md`: use the daily branch and pull request, pass the
+repository's authoritative checks, self-review the complete output, squash
+merge, and verify the exact production deployment when the public site changes.
+Do not create a separate closeout pull request; use the merged pull request's
+compact closeout comment as the final delivery record.

--- a/.github/seo-data/daily-task.md
+++ b/.github/seo-data/daily-task.md
@@ -1,9 +1,8 @@
-# Daily technical SEO subtask
+# Daily SEO task
 
-`DAILY_TASK.md` is the only scheduled entrypoint and the authoritative daily
-operating contract. An external scheduler must not target this file directly.
-Use this file only when the daily operation evaluates or selects technical SEO
-and GEO work.
+This is the technical SEO subtask of the root `DAILY_TASK.md`. The root file is
+the only scheduled entrypoint and the authoritative daily operating contract. An
+external scheduler must not target this file directly.
 
 ## Objective
 
@@ -12,51 +11,33 @@ and improve eunomia.dev's technical discoverability, indexability,
 retrievability, and citation quality. Do not create a site edit merely because a
 daily run occurred.
 
-## Required context
+## Required sequence
 
-Read:
-
-- `DAILY_TASK.md`;
-- `CLAUDE.md`;
-- every Markdown file under `.github/seo-data/`;
-- the newest record under `.github/seo-data/daily/`, when present;
-- `.agents/skills/seo-geo/SKILL.md`;
-- the pinned collection, change, and validation skills under
-  `.github/seo-skills`.
+1. Read `DAILY_TASK.md`, `CLAUDE.md`, every Markdown file under
+   `.github/seo-data/`, the newest daily record when present,
+   `.agents/skills/seo-geo/SKILL.md`, and the pinned collection, change, and
+   validation skills under `.github/seo-skills`.
+2. Use every enabled source in `site.md` and the windows defined there. Missing,
+   stale, partial, disabled, or inaccessible sources are unavailable, not zero.
+3. Evaluate crawl access, robots, sitemap coverage, status codes, redirects,
+   broken links, canonical URLs, duplicate routes, indexability, pagination, URL
+   stability, `hreflang`, language navigation, metadata, structured data, Open
+   Graph, semantic page identity, internal linking, orphan pages, hub structure,
+   repository/paper/tutorial pathways, rendering, performance, accessibility,
+   and production deployment state.
+4. Analyze important query, page, landing-page, referrer, acquisition, and
+   outbound movements when source-native Search Console or analytics coverage
+   exists. Public repository and live-site evidence may supplement those sources
+   but does not replace them.
+5. Record evidence and interpretation in the day's shared record under
+   `.github/seo-data/daily/`; do not create a second SEO-only run log.
+6. Make a technical change only when evidence identifies a concrete problem or
+   opportunity and the expected production outcome is observable.
 
 The root daily task controls branching, pull requests, merging, deployment,
 verification, records, and completion. Do not duplicate those rules here.
 
 ## Technical analysis
-
-Use every enabled source in `site.md` and the windows defined there. Missing,
-stale, partial, disabled, or inaccessible sources are unavailable, not zero.
-Public repository and live-site evidence may supplement analytics but does not
-replace source-native search or acquisition metrics.
-
-Evaluate at least:
-
-- crawl access, robots, sitemap coverage, status codes, redirects, and broken
-  internal links;
-- canonical URLs, duplicate routes, indexability, pagination, and URL stability;
-- English and Chinese `hreflang` pairs and language navigation;
-- titles, descriptions, headings, structured data, Open Graph, and semantic
-  page identity;
-- internal linking, orphan pages, hub structure, repository/paper/tutorial
-  pathways, and citation-ready source presentation;
-- rendering, performance, accessibility signals relevant to discovery, and the
-  production deployment state;
-- important query, page, landing-page, referrer, and outbound movements when
-  Search Console or analytics coverage exists.
-
-Record the evidence and interpretation in the day's shared record under
-`.github/seo-data/daily/`; do not create a second SEO-only run log.
-
-## Change gate
-
-A technical change is justified only when the evidence identifies a concrete
-problem or opportunity and the expected outcome is observable. Define the
-production acceptance check before editing.
 
 Prefer one coherent change such as:
 
@@ -72,10 +53,14 @@ pages, promotion, or a routine skill-submodule update. Update the pinned SEO
 skills only when a compatible change is needed for the current operation or
 clearly fixes the operating mechanism.
 
-## Delivery
+## Daily completion
 
-Follow `DAILY_TASK.md`: use the daily branch and pull request, pass the
+Follow `DAILY_TASK.md`: use the unified `daily/` branch and pull request, pass the
 repository's authoritative checks, self-review the complete output, squash
 merge, and verify the exact production deployment when the public site changes.
 Do not create a separate closeout pull request; use the merged pull request's
 compact closeout comment as the final delivery record.
+
+A no-change result is valid when the data does not support a defensible public
+edit. A draft, local commit, queued check, or unverified deployment is not
+completion.

--- a/.github/seo-data/daily/2026-08-06.md
+++ b/.github/seo-data/daily/2026-08-06.md
@@ -4,8 +4,9 @@
 
 Verify whether the configured Google Drive contains usable eunomia.dev analytics,
 correct the repository's source-availability state, and record the first
-public-safe baseline. This was a data and operating-metadata correction; no public
-site or content change was selected.
+public-safe baseline. This record predates the final mandatory daily-publication
+contract and is retained as the analytics baseline, not as a precedent for future
+scheduled runs.
 
 ## Data window
 
@@ -56,7 +57,11 @@ Cloudflare source-native data remains unavailable.
 - recorded the verified export window and weekly refresh expectation;
 - changed Search Console and GA4 status from not configured to available;
 - removed the resolved Google Drive blocker;
-- retained Cloudflare and external scheduler as unresolved external blockers.
+- retained Cloudflare as the unresolved analytics blocker.
+
+The external daily scheduler was configured after this baseline was first written;
+its current verified state is maintained in `status.md` rather than inferred from
+this historical record.
 
 ## Validation and self-review
 
@@ -64,15 +69,16 @@ Cloudflare source-native data remains unavailable.
   personal information, or raw analytics files were added to Git;
 - aggregate calculations were recomputed from the seven Search Console date rows;
 - unavailable history was not converted into zero;
-- the GA4 observations are stated as measurement signals, not causal conclusions;
-- no public site edit or Daily Report was manufactured to satisfy cadence.
+- the GA4 observations are stated as measurement signals, not causal conclusions.
 
 ## Delivery
 
 The source-state correction is included in the repository daily-operation pull
 request. It must pass the pinned SEO data validator, repository checks, secret
-scanning, and final diff review before squash merge. No production deployment is
-required because this record and operating metadata do not alter the public site.
+scanning, and final diff review before squash merge. The final daily operating
+contract introduced by the same pull request requires one new bilingual Daily
+Report on every scheduled run and supersedes the earlier no-content baseline
+behavior.
 
 ## Decisions and follow-ups
 
@@ -84,5 +90,6 @@ required because this record and operating metadata do not alter the public site
    meaningful.
 4. Keep monitoring legacy `/en/` paths through Search Console, GA4, redirect, and
    canonical evidence.
-5. Configure the single external scheduler that invokes `DAILY_TASK.md`.
+5. Run the first scheduled daily operation under `DAILY_TASK.md` after this
+   operating contract reaches `main`, with one new eBPF-first Daily Report.
 6. Add Cloudflare only through a supported read-only route.

--- a/.github/seo-data/daily/2026-08-06.md
+++ b/.github/seo-data/daily/2026-08-06.md
@@ -1,0 +1,88 @@
+# SEO operations — 2026-08-06
+
+## Scope
+
+Verify whether the configured Google Drive contains usable eunomia.dev analytics,
+correct the repository's source-availability state, and record the first
+public-safe baseline. This was a data and operating-metadata correction; no public
+site or content change was selected.
+
+## Data window
+
+- Source window: `2026-07-27` through `2026-08-02`
+- Verification date: `2026-08-06`
+- Finalization lag: 3 days
+- Prior-period comparison: unavailable because the configured folder currently
+  contains only one complete weekly window
+- 28-day comparison: unavailable for the same reason
+
+## Evidence collected
+
+The Google Drive folder named `eunomia.dev SEO Weekly CSV` was found and read
+successfully. It contains:
+
+- Search Console dates, search appearance, devices, countries, pages, and queries
+  exports;
+- one GA4 organic landing-page export.
+
+Search Console daily totals for the verified week aggregate to:
+
+- clicks: 486
+- impressions: 55,021
+- weighted CTR: 0.883%
+- impression-weighted average position: approximately 8.21
+
+The daily click series is 77, 100, 98, 83, 55, 30, and 43. The weekend decline is
+visible, but one week cannot distinguish normal weekday seasonality from a demand,
+coverage, or ranking change.
+
+The GA4 export contains landing page, sessions, active users, engagement rate, and
+key-event fields. Tutorials and CUDA/GPU material appear among the strongest
+known landing pages. The largest row is `(not set)`, with 157 sessions and a low
+engagement rate, so attribution or landing-page measurement quality should be
+investigated before using the export for strong content or conversion decisions.
+
+A legacy `/en/` tutorial route is also present in the GA4 export, confirming that
+old English paths still receive some organic sessions and should remain part of
+canonical and redirect monitoring.
+
+Cloudflare source-native data remains unavailable.
+
+## Work performed
+
+- changed Google Drive coverage from disabled to enabled;
+- configured the folder by public-safe name rather than storing its Drive ID;
+- corrected filename patterns to `*_gsc_*.csv` and `*_ga4_*.csv`;
+- recorded the verified export window and weekly refresh expectation;
+- changed Search Console and GA4 status from not configured to available;
+- removed the resolved Google Drive blocker;
+- retained Cloudflare and external scheduler as unresolved external blockers.
+
+## Validation and self-review
+
+- no Drive IDs, property IDs, account identifiers, credentials, private URLs,
+  personal information, or raw analytics files were added to Git;
+- aggregate calculations were recomputed from the seven Search Console date rows;
+- unavailable history was not converted into zero;
+- the GA4 observations are stated as measurement signals, not causal conclusions;
+- no public site edit or Daily Report was manufactured to satisfy cadence.
+
+## Delivery
+
+The source-state correction is included in the repository daily-operation pull
+request. It must pass the pinned SEO data validator, repository checks, secret
+scanning, and final diff review before squash merge. No production deployment is
+required because this record and operating metadata do not alter the public site.
+
+## Decisions and follow-ups
+
+1. Use the configured Drive folder in every daily run while it remains readable
+   and fresh.
+2. Accumulate at least one more weekly export before calculating a previous-week
+   comparison, and enough history before making 28-day claims.
+3. Investigate the GA4 `(not set)` row and whether key events are configured and
+   meaningful.
+4. Keep monitoring legacy `/en/` paths through Search Console, GA4, redirect, and
+   canonical evidence.
+5. Configure the single external scheduler that invokes `DAILY_TASK.md`.
+6. Add Cloudflare only through a supported read-only route.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -1,4 +1,4 @@
-# SEO plan
+# Site growth plan
 
 ## Purpose
 
@@ -7,39 +7,67 @@ infrastructure, observability, enforcement, and heterogeneous-systems research.
 Optimize for technically useful discovery and citation by people and software
 agents without creating low-value, mass-generated content.
 
+`DAILY_TASK.md` is the authoritative operating entrypoint. It combines daily data
+analysis, technical SEO/GEO, and high-quality Daily Report production. This file
+stores durable goals and constraints, not duplicated scheduler instructions.
+
 ## Success signals
 
-- Search Console clicks, impressions, click-through rate, and canonical/indexing
-  state once a public-safe export path is configured; preserve each metric's
-  source-native meaning.
-- Public-safe GA4 acquisition and engaged-session signals once configured, used
-  to distinguish discovery from useful on-site follow-through.
+- Search Console clicks, impressions, CTR, query/page movement, and
+  canonical/indexing state once a public-safe read path is configured; preserve
+  each metric's source-native meaning.
+- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and
+  configured outcome signals once available, used to distinguish discovery from
+  useful on-site follow-through.
+- Cloudflare traffic, bot, status-code, and cache evidence once a supported
+  read-only route is available.
 - Stable crawlability, canonical ownership, language alternates, structured data,
-  internal links, and production verification enforced by repository CI and live
-  checks.
+  internal links, rendering, and production verification enforced by repository
+  checks and live inspection.
 - Qualified movement from relevant technical pages to public repositories,
   papers, tutorials, and demos, without inventing a blended SEO score.
-- Repeatable evidence that important pages are accurately retrievable and cited
-  for relevant technical questions; record method and date rather than claiming
-  universal AI visibility.
+- Daily analysis records that explain source coverage, movement, uncertainty,
+  competing explanations, and the next discriminating evidence.
+- Daily Report publications that expose a concrete systems gap and develop
+  implementable, testable directions rather than summarizing a trend.
 
 ## Operating constraints
 
-- Raw analytics and private identifiers stay outside Git.
-- Every automated SEO run uses a fresh `seo/` branch and a real non-draft pull
-  request; this scoped contract overrides the general direct-`main` repository
-  rule for work invoked by `daily-task.md`.
-- Required and expected CI must pass before final automated self-review.
-- A clean final review is followed by squash merge and branch deletion; normal
-  operation does not require human review.
-- Site changes wait for the exact squash commit's production deployment and
-  public verification.
-- Post-merge evidence is recorded through a metadata-only closeout pull request
-  using the same CI, self-review, and squash-merge rules.
-- Implement at most one coherent site change per main pull request, and permit a
-  no-change evidence run when no defensible improvement is supported.
-- `.agents/skills/seo-geo` remains the Eunomia-specific technical checklist;
-  `.github/seo-skills` owns shared collection and delivery mechanics.
+- The external scheduler only invokes `DAILY_TASK.md`; the repository owns all
+  operational policy and current state.
+- Data analysis runs every day. A missing private source is marked unavailable,
+  never inferred as zero.
+- Raw analytics, private identifiers, credentials, and personal information stay
+  outside Git.
+- Each run starts from the latest default branch and uses one fresh branch and one
+  real non-draft pull request.
+- The daily pull request contains the shared daily record and at most one coherent
+  public change. A no-change or data-only run is valid.
+- Do not combine unrelated technical SEO and content work. Choose the
+  highest-value evidence-backed action and keep other durable work here.
+- Required and expected CI must pass before a clean final automated self-review
+  and squash merge.
+- A public change waits for the exact squash commit's production deployment and
+  live verification.
+- Do not create a second closeout pull request. Put the verified closeout in one
+  compact comment on the merged daily pull request, then refresh `status.md` in
+  the next run.
+- `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
+- `.agents/skills/eunomia-research-report` owns Daily Report research, quality,
+  writing, and publication gates.
+- Do not manufacture content, site edits, promotion, or workflow artifacts only
+  to satisfy cadence.
 
-Short-term fixes, one-off audits, and remediation backlogs belong in GitHub
-issues, not in this durable plan.
+Short-term fixes and remediation backlogs belong in GitHub issues. Durable
+priorities that can guide a later daily run belong below.
+
+## Current priorities
+
+1. Configure and verify the external daily scheduler with the exact minimal
+   invocation in `DAILY_TASK.md`.
+2. Establish public-safe read-only Search Console and GA4 coverage; add
+   Cloudflare coverage when a supported route is available.
+3. Complete the first daily baseline using available live-site and public GitHub
+   evidence while unavailable sources remain explicit.
+4. Let measured reader/search behavior and primary-source research select future
+   technical SEO and Daily Report work.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -1,4 +1,4 @@
-# Site growth plan
+# SEO plan
 
 ## Purpose
 

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -2,23 +2,25 @@
 
 ## Purpose
 
-Make eunomia.dev a reliable canonical source for eBPF, AI-agent runtime
-infrastructure, observability, enforcement, and heterogeneous-systems research.
+Make eunomia.dev a reliable canonical source for eBPF, systems infrastructure,
+observability, profiling, networking, security, runtimes, and heterogeneous
+systems research. AI-agent infrastructure is a deliberately smaller adjacent
+topic rather than the center of the publication program.
+
 Optimize for technically useful discovery and citation by people and software
-agents without creating low-value, mass-generated content.
+agents without creating shallow, repetitive, or trend-driven content.
 
 `DAILY_TASK.md` is the authoritative operating entrypoint. It combines daily data
-analysis, technical SEO/GEO, and high-quality Daily Report production. This file
-stores durable goals and constraints, not duplicated scheduler instructions.
+analysis, technical SEO/GEO, and one mandatory new Daily Report. This file stores
+durable goals and constraints, not duplicated scheduler instructions.
 
 ## Success signals
 
 - Search Console clicks, impressions, CTR, query/page movement, and
-  canonical/indexing state once a public-safe read path is configured; preserve
-  each metric's source-native meaning.
+  canonical/indexing state; preserve each metric's source-native meaning.
 - Public-safe GA4 acquisition, engaged-session, landing-page, referral, and
-  configured outcome signals once available, used to distinguish discovery from
-  useful on-site follow-through.
+  configured outcome signals, used to distinguish discovery from useful on-site
+  follow-through.
 - Cloudflare traffic, bot, status-code, and cache evidence once a supported
   read-only route is available.
 - Stable crawlability, canonical ownership, language alternates, structured data,
@@ -28,46 +30,57 @@ stores durable goals and constraints, not duplicated scheduler instructions.
   papers, tutorials, and demos, without inventing a blended SEO score.
 - Daily analysis records that explain source coverage, movement, uncertainty,
   competing explanations, and the next discriminating evidence.
-- Daily Report publications that expose a concrete systems gap and develop
-  implementable, testable directions rather than summarizing a trend.
+- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of
+  5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
+- Daily Reports that expose a concrete systems gap and develop implementable,
+  testable directions rather than summarizing a trend.
 
 ## Operating constraints
 
-- The external scheduler only invokes `DAILY_TASK.md`; the repository owns all
-  operational policy and current state.
+- The external scheduler is already configured and only invokes the repository;
+  the repository owns all operational policy and current state.
 - Data analysis runs every day. A missing private source is marked unavailable,
   never inferred as zero.
 - Raw analytics, private identifiers, credentials, and personal information stay
   outside Git.
 - Each run starts from the latest default branch and uses one fresh branch and one
   real non-draft pull request.
-- The daily pull request contains the shared daily record and at most one coherent
-  public change. A no-change or data-only run is valid.
-- Do not combine unrelated technical SEO and content work. Choose the
-  highest-value evidence-backed action and keep other durable work here.
+- Every scheduled run must add exactly one new bilingual Daily Report. A weak
+  candidate is replaced by another approved question rather than published or
+  converted into a no-report day.
+- Technical SEO changes remain evidence-driven and may be skipped on a given day;
+  the Daily Report may not be skipped.
+- Keep the rolling topic mix compliant and classify by the report's actual central
+  mechanism, not by superficial keyword mentions.
+- Do not combine unrelated technical SEO and content work when that makes the
+  daily pull request incoherent; put unrelated durable SEO work in this plan for a
+  focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review
   and squash merge.
-- A public change waits for the exact squash commit's production deployment and
-  live verification.
+- Every daily report is a public change, so the exact squash commit must deploy
+  successfully and both language pages must be verified.
 - Do not create a second closeout pull request. Put the verified closeout in one
   compact comment on the merged daily pull request, then refresh `status.md` in
   the next run.
 - `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
 - `.agents/skills/eunomia-research-report` owns Daily Report research, quality,
   writing, and publication gates.
-- Do not manufacture content, site edits, promotion, or workflow artifacts only
-  to satisfy cadence.
 
 Short-term fixes and remediation backlogs belong in GitHub issues. Durable
 priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Configure and verify the external daily scheduler with the exact minimal
-   invocation in `DAILY_TASK.md`.
-2. Establish public-safe read-only Search Console and GA4 coverage; add
-   Cloudflare coverage when a supported route is available.
-3. Complete the first daily baseline using available live-site and public GitHub
-   evidence while unavailable sources remain explicit.
-4. Let measured reader/search behavior and primary-source research select future
-   technical SEO and Daily Report work.
+1. Complete the first scheduled daily operation using the root repository
+   contract and verify that one new eBPF-centered Daily Report reaches production.
+2. Keep upcoming reports strongly eBPF-centered until the current two pure-Agent
+   reports no longer dominate the rolling archive; maintain the long-term 5–7/10
+   eBPF and 1–2/10 pure-Agent mix.
+3. Use the verified Search Console and GA4 Drive exports in every run and build
+   enough weekly history for previous-period and 28-day comparisons.
+4. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as technical SEO
+   evidence rather than letting those issues distort content selection.
+5. Add Cloudflare coverage when a supported read-only route is available.
+6. Use search behavior, GitHub activity, primary research, kernel changes, and
+   production evidence to order questions inside the approved eBPF and adjacent
+   systems series.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -28,10 +28,15 @@
 
 ## Google data
 
-- Google Drive enabled: no
-- Google Drive folder name: not configured
-- GA4 export filename pattern: `ga4-*.csv`
-- Search Console export filename pattern: `gsc-*.csv`
+- Google Drive enabled: yes
+- Google Drive folder name: `eunomia.dev SEO Weekly CSV`
+- GA4 export filename pattern: `*_ga4_*.csv`
+- Search Console export filename pattern: `*_gsc_*.csv`
+- Verified export window: `2026-07-27` through `2026-08-02`
+- Expected refresh cadence: weekly; verify freshness and coverage on every run
+
+The Drive folder is discovered by its configured name. Do not store its folder ID,
+property IDs, account identifiers, credentials, or private URLs in Git.
 
 ## Cloudflare data
 
@@ -45,9 +50,10 @@
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-These sources support a partial daily analysis while private search, acquisition,
-or edge data remains unavailable. They do not replace Search Console, GA4, or
-Cloudflare source-native metrics.
+Search Console and GA4 exports now support source-native weekly analysis. The
+current folder contains one complete weekly window, so longer comparisons remain
+unavailable until more history is present. Public repository and live-site data
+supplement these exports but do not replace their source-native meanings.
 
 ## Deployment
 

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -10,7 +10,7 @@
 
 - Default branch: `main`
 - Authoritative daily task: `DAILY_TASK.md`
-- Automation branch prefix: `seo/`
+- Automation branch prefix: `daily/`
 - Skill submodule path: `.github/seo-skills`
 - Skill source: `https://github.com/AutoArchive/seo-skill`
 - Allowed skill update branch: `main`

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -9,10 +9,22 @@
 ## Repository
 
 - Default branch: `main`
+- Authoritative daily task: `DAILY_TASK.md`
 - Automation branch prefix: `seo/`
 - Skill submodule path: `.github/seo-skills`
 - Skill source: `https://github.com/AutoArchive/seo-skill`
 - Allowed skill update branch: `main`
+
+## Daily analysis contract
+
+- Daily analysis required: yes
+- Lookback days: 28
+- Finalization lag days: 3
+- Short comparison: latest complete 7 days versus preceding 7 days
+- Long comparison: latest complete 28 days versus the preceding comparable period
+- Missing-source treatment: report unavailable, stale, partial, or disabled; never
+  convert missing coverage into zero
+- Raw private analytics in Git: prohibited
 
 ## Google data
 
@@ -20,14 +32,22 @@
 - Google Drive folder name: not configured
 - GA4 export filename pattern: `ga4-*.csv`
 - Search Console export filename pattern: `gsc-*.csv`
-- Lookback days: 28
-- Finalization lag days: 3
 
 ## Cloudflare data
 
 - Cloudflare enabled: no
 - Zone hostname: `eunomia.dev`
 - Preferred dataset: `httpRequestsAdaptiveGroups`
+
+## Public and repository data
+
+- Live-site technical collection enabled: yes
+- Public GitHub repository evidence enabled: yes
+- Public web and primary-source evidence enabled: yes
+
+These sources support a partial daily analysis while private search, acquisition,
+or edge data remains unavailable. They do not replace Search Console, GA4, or
+Cloudflare source-native metrics.
 
 ## Deployment
 
@@ -37,4 +57,5 @@
 - Verification URL: `https://eunomia.dev/`
 
 Store only durable public metadata here. Never add property IDs, Drive IDs,
-Cloudflare IDs, account identifiers, personal emails, credentials, or private URLs.
+Cloudflare IDs, account identifiers, personal emails, credentials, or private
+URLs.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -5,14 +5,27 @@
 - Authoritative task: `DAILY_TASK.md`
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
-- External daily scheduler: not configured or verified
-- Scheduler timezone: `America/Los_Angeles`
+- External daily scheduler: configured and enabled
+- Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
 - Last completed daily run: none
 - Last verified data window: `2026-07-27` through `2026-08-02`
-- Latest daily record: `2026-08-06` (pending pull-request merge)
-- Last public-change pull request: none
+- Latest daily record: `2026-08-06` (baseline recorded before the first scheduled run)
+- Last public-change pull request: none from the unified daily operation
 - Last verified production deployment from a daily run: none
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
+
+## Current Daily Report mix
+
+The public archive currently contains two Daily Reports and both are pure
+Agent-centered topics:
+
+- `/research/agent-trace-evidence-budget/`
+- `/research/parallel-agent-effect-serializability/`
+
+Until the rolling archive becomes compliant with the repository editorial mix,
+new reports should strongly favor eBPF. The active series is **eBPF Runtime,
+Extensibility, and Composition**. The rolling target is 5–7 eBPF-centered reports
+per 10 published reports and at most 1–2 pure Agent reports per 10.
 
 ## Current signals
 
@@ -45,19 +58,20 @@ conversion conclusions.
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, and HTTP audit artifacts. Production deploys through the
 `Deploy Static App` workflow. The unified daily operation has not completed its
-first independently scheduled run.
+first scheduled run yet.
 
 ## Current focus
 
 1. Merge the repository-owned daily operating contract and verified analytics
-   baseline.
-2. Configure and verify one external daily scheduler using only the minimal
-   instruction in `DAILY_TASK.md`.
+   baseline before the first scheduled run relies on it.
+2. Publish one new eBPF-centered Daily Report per scheduled run until the rolling
+   mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer exceed
+   the 1–2 per 10 cap.
 3. Use the verified weekly GA4 and Search Console exports in every run; never mark
    them unavailable while the configured folder remains readable and fresh.
 4. Accumulate enough weekly history for previous-period and 28-day comparisons.
 5. Investigate the GA4 `(not set)` landing-page row and remaining legacy `/en/`
-   traffic before using those metrics to justify a site change.
+   traffic when selecting technical SEO work.
 6. Add Cloudflare evidence when a supported read-only path exists.
 
 This file is the current verified summary. Detailed history belongs in

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -1,6 +1,6 @@
-# Daily site operation status
+# SEO status
 
-## Operating state
+## Current state
 
 - Authoritative task: `DAILY_TASK.md`
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
@@ -14,7 +14,7 @@
 - Last verified production deployment from a daily run: none
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-## Data coverage
+## Current signals
 
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -1,29 +1,46 @@
-# SEO status
+# Daily site operation status
 
-## Current state
+## Operating state
 
-- Last completed run: none
+- Authoritative task: `DAILY_TASK.md`
+- External daily scheduler: not configured or verified
+- Scheduler timezone: `America/Los_Angeles`
+- Last completed daily run: none
 - Last data window: none
-- Last site-change pull request: none
-- Last squash merge: none
-- Last closeout pull request: none
-- Last successful production deployment: none
-- Last public verification: none
+- Latest daily record: none
+- Last public-change pull request: none
+- Last verified production deployment from a daily run: none
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-## Current signals
+## Data coverage
 
+- Live-site technical evidence: available
+- Public GitHub repository evidence: available
+- Public web and primary-source evidence: available
 - Google Analytics 4: not configured
 - Google Search Console: not configured
 - Cloudflare: not configured
-- Technical baseline: the repository already generates sitemap, robots, canonical,
-  hreflang, Open Graph, structured data, and HTTP audit artifacts; the new SEO
-  operating workflow has not yet completed its first independent baseline run.
 
-## Active focus
+Until the private sources are connected, daily analysis is partial. It must still
+inspect live-site and public repository evidence, state the missing coverage, and
+must not present unavailable metrics as zero.
 
-- Complete the first public-safe evidence and technical baseline run.
-- Keep unavailable analytics sources explicit rather than inferring zero traffic.
-- Select future site changes from verified evidence, not from a fixed output quota.
+## Current technical baseline
 
-This file is the current verified summary. Detailed history belongs in `daily/`.
+The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
+structured data, and HTTP audit artifacts. Production deploys through the
+`Deploy Static App` workflow. The unified daily operation has not completed its
+first independent baseline run.
+
+## Current focus
+
+1. Merge the repository-owned daily operating contract.
+2. Configure and verify one external daily scheduler using only the minimal
+   instruction in `DAILY_TASK.md`.
+3. Configure public-safe, read-only Search Console and GA4 collection; add
+   Cloudflare when a supported path exists.
+4. Run the first mandatory daily analysis with available evidence and record a
+   defensible technical SEO, Daily Report, or no-change decision.
+
+This file is the current verified summary. Detailed history belongs in
+`.github/seo-data/daily/` and the merged daily pull requests.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,6 +3,8 @@
 ## Operating state
 
 - Authoritative task: `DAILY_TASK.md`
+- Technical SEO subtask: `.github/seo-data/daily-task.md`
+- Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: not configured or verified
 - Scheduler timezone: `America/Los_Angeles`
 - Last completed daily run: none

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -9,7 +9,7 @@
 - Scheduler timezone: `America/Los_Angeles`
 - Last completed daily run: none
 - Last verified data window: `2026-07-27` through `2026-08-02`
-- Latest daily record: none
+- Latest daily record: `2026-08-06` (pending pull-request merge)
 - Last public-change pull request: none
 - Last verified production deployment from a daily run: none
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
@@ -49,7 +49,8 @@ first independently scheduled run.
 
 ## Current focus
 
-1. Merge the repository-owned daily operating contract.
+1. Merge the repository-owned daily operating contract and verified analytics
+   baseline.
 2. Configure and verify one external daily scheduler using only the minimal
    instruction in `DAILY_TASK.md`.
 3. Use the verified weekly GA4 and Search Console exports in every run; never mark

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -8,7 +8,7 @@
 - External daily scheduler: not configured or verified
 - Scheduler timezone: `America/Los_Angeles`
 - Last completed daily run: none
-- Last data window: none
+- Last verified data window: `2026-07-27` through `2026-08-02`
 - Latest daily record: none
 - Last public-change pull request: none
 - Last verified production deployment from a daily run: none
@@ -19,30 +19,45 @@
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
-- Google Analytics 4: not configured
-- Google Search Console: not configured
+- Google Analytics 4: weekly Drive export available and verified
+- Google Search Console: six weekly Drive exports available and verified
 - Cloudflare: not configured
 
-Until the private sources are connected, daily analysis is partial. It must still
-inspect live-site and public repository evidence, state the missing coverage, and
-must not present unavailable metrics as zero.
+The verified Drive folder contains Search Console exports for dates, search
+appearance, devices, countries, pages, and queries, plus a GA4 organic landing-page
+export. The current coverage is one complete weekly window, so source-native
+seven-day analysis is possible but prior-period and 28-day comparisons are not yet
+supported by the available history.
+
+For `2026-07-27` through `2026-08-02`, Search Console reports 486 clicks and
+55,021 impressions, for a weighted CTR of 0.883% and an impression-weighted
+average position of approximately 8.21. The daily series falls sharply over the
+weekend, but a single week cannot distinguish a weekday effect from a real demand
+or ranking change.
+
+The GA4 organic landing-page export shows tutorials and CUDA/GPU material among
+the strongest known landing pages. Its largest row is `(not set)`, which should be
+treated as a measurement-quality problem before drawing strong content or
+conversion conclusions.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, and HTTP audit artifacts. Production deploys through the
 `Deploy Static App` workflow. The unified daily operation has not completed its
-first independent baseline run.
+first independently scheduled run.
 
 ## Current focus
 
 1. Merge the repository-owned daily operating contract.
 2. Configure and verify one external daily scheduler using only the minimal
    instruction in `DAILY_TASK.md`.
-3. Configure public-safe, read-only Search Console and GA4 collection; add
-   Cloudflare when a supported path exists.
-4. Run the first mandatory daily analysis with available evidence and record a
-   defensible technical SEO, Daily Report, or no-change decision.
+3. Use the verified weekly GA4 and Search Console exports in every run; never mark
+   them unavailable while the configured folder remains readable and fresh.
+4. Accumulate enough weekly history for previous-period and 28-day comparisons.
+5. Investigate the GA4 `(not set)` landing-page row and remaining legacy `/en/`
+   traffic before using those metrics to justify a site change.
+6. Add Cloudflare evidence when a supported read-only path exists.
 
 This file is the current verified summary. Detailed history belongs in
 `.github/seo-data/daily/` and the merged daily pull requests.

--- a/.github/workflows/app-static-pages.yml
+++ b/.github/workflows/app-static-pages.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: static-app-pages-${{ github.ref }}
-  queue: max
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   sync-external-docs:

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -7,6 +7,7 @@ on:
       - ".gitmodules"
       - ".github/seo-skills"
       - ".github/seo-data/**"
+      - ".agents/skills/eunomia-research-report/**"
       - ".github/workflows/seo-data-validate.yml"
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - ".gitmodules"
       - ".github/seo-skills"
       - ".github/seo-data/**"
+      - ".agents/skills/eunomia-research-report/**"
       - ".github/workflows/seo-data-validate.yml"
   workflow_dispatch:
 
@@ -48,22 +50,38 @@ jobs:
         run: |
           set -euo pipefail
           test -f DAILY_TASK.md
+          test -f .github/seo-data/content-series.md
+          test -f .agents/skills/eunomia-research-report/SKILL.md
           grep -Fq "# Daily site operation" DAILY_TASK.md
           grep -Fq "## Scheduler contract" DAILY_TASK.md
           grep -Fq "## Daily responsibilities" DAILY_TASK.md
           grep -Fq "## 1. Analyze data first" DAILY_TASK.md
-          grep -Fq "## 2. Choose zero or one coherent public change" DAILY_TASK.md
+          grep -Fq "## 2. Select today's report and SEO work" DAILY_TASK.md
           grep -Fq "## 3. Deliver and verify" DAILY_TASK.md
           python - <<'PY'
           from pathlib import Path
 
-          text = Path("DAILY_TASK.md").read_text(encoding="utf-8")
+          daily = Path("DAILY_TASK.md").read_text(encoding="utf-8")
+          series = Path(".github/seo-data/content-series.md").read_text(encoding="utf-8")
+          report_skill = Path(".agents/skills/eunomia-research-report/SKILL.md").read_text(encoding="utf-8")
+
           scheduler_quote = " ".join(
               line.removeprefix("> ").strip()
-              for line in text.splitlines()
+              for line in daily.splitlines()
               if line.startswith("> ")
           )
           assert "Treat the repository as authoritative." in scheduler_quote
+
+          # Daily publication is mandatory; a weak candidate must be replaced,
+          # not converted into a no-report day.
+          assert "exactly **one new Daily Report page every run**" in daily
+          assert "`no-report`" in daily and "not completion" in daily
+          assert "There is no `no-report` outcome" in report_skill
+
+          # Topic mix is a repository-enforced editorial contract.
+          assert "5–7 of 10" in series
+          assert "Pure AI-agent topics are capped at 1–2 of 10" in series
+          assert "Active series — eBPF Runtime, Extensibility, and Composition" in series
           PY
 
       - name: Set up Python

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -65,6 +65,10 @@ jobs:
           series = Path(".github/seo-data/content-series.md").read_text(encoding="utf-8")
           report_skill = Path(".agents/skills/eunomia-research-report/SKILL.md").read_text(encoding="utf-8")
 
+          daily_flat = " ".join(daily.split())
+          series_flat = " ".join(series.split())
+          report_flat = " ".join(report_skill.split())
+
           scheduler_quote = " ".join(
               line.removeprefix("> ").strip()
               for line in daily.splitlines()
@@ -74,14 +78,14 @@ jobs:
 
           # Daily publication is mandatory; a weak candidate must be replaced,
           # not converted into a no-report day.
-          assert "exactly **one new Daily Report page every run**" in daily
-          assert "`no-report`" in daily and "not completion" in daily
-          assert "There is no `no-report` outcome" in report_skill
+          assert "exactly **one new Daily Report page every run**" in daily_flat
+          assert "`no-report`" in daily_flat and "not completion" in daily_flat
+          assert "There is no `no-report` outcome" in report_flat
 
           # Topic mix is a repository-enforced editorial contract.
-          assert "5–7 of 10" in series
-          assert "Pure AI-agent topics are capped at 1–2 of 10" in series
-          assert "Active series — eBPF Runtime, Extensibility, and Composition" in series
+          assert "5–7 of 10" in series_flat
+          assert "Pure AI-agent topics are capped at 1–2 of 10" in series_flat
+          assert "Active series — eBPF Runtime, Extensibility, and Composition" in series_flat
           PY
 
       - name: Set up Python

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -3,6 +3,7 @@ name: Validate SEO Operations
 on:
   pull_request:
     paths:
+      - "DAILY_TASK.md"
       - ".gitmodules"
       - ".github/seo-skills"
       - ".github/seo-data/**"
@@ -11,6 +12,7 @@ on:
     branches:
       - main
     paths:
+      - "DAILY_TASK.md"
       - ".gitmodules"
       - ".github/seo-skills"
       - ".github/seo-data/**"

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -50,11 +50,21 @@ jobs:
           test -f DAILY_TASK.md
           grep -Fq "# Daily site operation" DAILY_TASK.md
           grep -Fq "## Scheduler contract" DAILY_TASK.md
-          grep -Fq "Treat the repository as authoritative." DAILY_TASK.md
           grep -Fq "## Daily responsibilities" DAILY_TASK.md
           grep -Fq "## 1. Analyze data first" DAILY_TASK.md
           grep -Fq "## 2. Choose zero or one coherent public change" DAILY_TASK.md
           grep -Fq "## 3. Deliver and verify" DAILY_TASK.md
+          python - <<'PY'
+          from pathlib import Path
+
+          text = Path("DAILY_TASK.md").read_text(encoding="utf-8")
+          scheduler_quote = " ".join(
+              line.removeprefix("> ").strip()
+              for line in text.splitlines()
+              if line.startswith("> ")
+          )
+          assert "Treat the repository as authoritative." in scheduler_quote
+          PY
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -43,6 +43,19 @@ jobs:
           test "$(git config -f .gitmodules --get 'submodule..github/seo-skills.url')" = \
             "https://github.com/AutoArchive/seo-skill.git"
 
+      - name: Validate authoritative daily task contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f DAILY_TASK.md
+          grep -Fq "# Daily site operation" DAILY_TASK.md
+          grep -Fq "## Scheduler contract" DAILY_TASK.md
+          grep -Fq "Treat the repository as authoritative." DAILY_TASK.md
+          grep -Fq "## Daily responsibilities" DAILY_TASK.md
+          grep -Fq "## 1. Analyze data first" DAILY_TASK.md
+          grep -Fq "## 2. Choose zero or one coherent public change" DAILY_TASK.md
+          grep -Fq "## 3. Deliver and verify" DAILY_TASK.md
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/DAILY_TASK.md
+++ b/DAILY_TASK.md
@@ -16,7 +16,8 @@ Run once per day in the timezone declared in `.github/seo-data/site.md`. Maintai
 exactly one external scheduler for this operation; do not split analytics, SEO,
 and content production into independent schedules that can race or diverge. The
 scheduler owns only timing and invocation. This repository owns scope, data
-sources, quality gates, delivery rules, and operating state.
+sources, quality gates, delivery rules, content-series strategy, and operating
+state.
 
 ## Daily responsibilities
 
@@ -28,9 +29,10 @@ Every run performs these three responsibilities in order:
 2. **Technical SEO and GEO.** Inspect crawlability, indexing signals, canonical
    ownership, language alternates, structured data, internal links, performance,
    and retrievability. Make a change only when evidence supports it.
-3. **Technical content production.** Research a Daily Report candidate and
-   publish only when it passes the repository's evidence, gap, novelty, and
-   usefulness gates. Daily research does not impose a daily publication quota.
+3. **Technical content production.** Research a Daily Report candidate inside the
+   active content series and publish only when it passes the repository's
+   evidence, gap, novelty, continuity, and usefulness gates. Daily research does
+   not impose a daily publication quota.
 
 Data should determine the work. Do not manufacture an article, SEO edit, or
 visible artifact merely to satisfy cadence.
@@ -45,6 +47,8 @@ Start from the latest remote default branch and read:
 - `.github/seo-data/status.md`;
 - `.github/seo-data/plan.md`;
 - `.github/seo-data/block.md`;
+- `.github/seo-data/content-series.md` for the active Daily Report series and
+  thematic roadmap;
 - the newest record under `.github/seo-data/daily/`, when present;
 - `.github/seo-data/daily-task.md` for the technical SEO subtask;
 - `.agents/skills/seo-geo/SKILL.md` and the pinned `.github/seo-skills` skills;
@@ -92,18 +96,25 @@ and the next evidence that would distinguish competing explanations.
 After analysis, choose the highest-value action supported by evidence:
 
 - one coherent technical SEO/GEO improvement;
-- one strong Daily Report or revision;
+- one strong Daily Report or revision inside the active series;
 - a content change together with directly coupled technical metadata;
 - or no public change, with the reason recorded.
+
+For content work, **series continuity is the default**. Search and research inside
+the active series first. A new report must advance a distinct question in the
+series instead of restating an existing thesis with different examples. Leave the
+active series only for a material external development with durable systems
+consequences, and record why that interruption was justified. Do not switch
+series merely because another topic is trending.
 
 Do not ship unrelated SEO and content edits in one pull request. Put durable
 future work in `plan.md`; use `block.md` only for real external permission or
 human-only blockers.
 
 For technical SEO, follow `.github/seo-data/daily-task.md`. For a Daily Report,
-follow `.agents/skills/eunomia-research-report/SKILL.md`. A fluent summary without
-a defensible systems gap, mechanism, and testable direction is a no-publish
-result.
+follow `.agents/skills/eunomia-research-report/SKILL.md` and
+`.github/seo-data/content-series.md`. A fluent summary without a defensible
+systems gap, mechanism, and testable direction is a no-publish result.
 
 ## 3. Deliver and verify
 
@@ -134,6 +145,8 @@ A daily run is complete only when:
 - `status.md`, `plan.md`, and `block.md` reflect current verified state as needed;
 - the run selected at most one coherent public change or recorded a defensible
   no-change decision;
+- any Daily Report work follows the active series or explicitly records a justified
+  interruption;
 - the pull request passed CI, final self-review, and squash merge;
 - any public change deployed from the exact merge commit and was verified;
 - the merged pull request contains the compact closeout record.

--- a/DAILY_TASK.md
+++ b/DAILY_TASK.md
@@ -12,7 +12,9 @@ The external scheduler should contain only this instruction:
 > branch, and complete the task exactly as the repository instructs. Treat the
 > repository as authoritative.
 
-Run once per day in the timezone declared in `.github/seo-data/site.md`. The
+Run once per day in the timezone declared in `.github/seo-data/site.md`. Maintain
+exactly one external scheduler for this operation; do not split analytics, SEO,
+and content production into independent schedules that can race or diverge. The
 scheduler owns only timing and invocation. This repository owns scope, data
 sources, quality gates, delivery rules, and operating state.
 

--- a/DAILY_TASK.md
+++ b/DAILY_TASK.md
@@ -1,0 +1,140 @@
+# Daily site operation
+
+This file is the single authoritative entrypoint for the scheduled eunomia.dev
+operation. The current default branch of this repository is the source of truth.
+Do not copy operational policy into an external scheduler.
+
+## Scheduler contract
+
+The external scheduler should contain only this instruction:
+
+> Open `eunomia-bpf/eunomia.dev`, read `DAILY_TASK.md` from the current default
+> branch, and complete the task exactly as the repository instructs. Treat the
+> repository as authoritative.
+
+Run once per day in the timezone declared in `.github/seo-data/site.md`. The
+scheduler owns only timing and invocation. This repository owns scope, data
+sources, quality gates, delivery rules, and operating state.
+
+## Daily responsibilities
+
+Every run performs these three responsibilities in order:
+
+1. **Data analysis.** Collect and analyze the available search, acquisition,
+   traffic, repository, and live-site evidence. This step is mandatory even when
+   no public change is justified.
+2. **Technical SEO and GEO.** Inspect crawlability, indexing signals, canonical
+   ownership, language alternates, structured data, internal links, performance,
+   and retrievability. Make a change only when evidence supports it.
+3. **Technical content production.** Research a Daily Report candidate and
+   publish only when it passes the repository's evidence, gap, novelty, and
+   usefulness gates. Daily research does not impose a daily publication quota.
+
+Data should determine the work. Do not manufacture an article, SEO edit, or
+visible artifact merely to satisfy cadence.
+
+## Required context
+
+Start from the latest remote default branch and read:
+
+- `CLAUDE.md`;
+- this file;
+- `.github/seo-data/site.md`;
+- `.github/seo-data/status.md`;
+- `.github/seo-data/plan.md`;
+- `.github/seo-data/block.md`;
+- the newest record under `.github/seo-data/daily/`, when present;
+- `.github/seo-data/daily-task.md` for the technical SEO subtask;
+- `.agents/skills/seo-geo/SKILL.md` and the pinned `.github/seo-skills` skills;
+- `.agents/skills/eunomia-research-report/SKILL.md` and its research-method
+  reference for Daily Report work.
+
+Resolve conflicts in favor of the most specific current repository instruction.
+Do not rely on copied scheduler text, an old run summary, or chat history.
+
+## 1. Analyze data first
+
+Use every source marked enabled in `.github/seo-data/site.md`. Report disabled,
+missing, stale, partial, or unavailable sources explicitly; never convert missing
+coverage into zero traffic or zero demand.
+
+Use the finalization lag and lookback window from `site.md`. At minimum compare:
+
+- the latest complete 7-day window with the preceding 7 days;
+- the latest complete 28-day window with the preceding comparable period when
+  enough history exists;
+- important pages, queries, referrers, repositories, or technical signals
+  against their own prior baseline rather than an invented blended score.
+
+Analyze, when available:
+
+- Search Console clicks, impressions, CTR, average position, queries, pages,
+  countries, devices, canonical and indexing state;
+- GA4 users, sessions, engaged sessions, engagement, landing pages, acquisition
+  sources, outbound repository/paper/tutorial movement, and configured outcomes;
+- Cloudflare requests, unique visitors, bots, status codes, cache behavior,
+  countries, and unusual traffic changes;
+- GitHub repository traffic, referrers, clones, stars, forks, releases, issues,
+  and relevant community movement when access and semantics are available;
+- live-site crawl, HTTP behavior, sitemap, robots, canonical, hreflang,
+  structured data, broken links, performance, rendering, and deployment health.
+
+Store no raw private analytics, credentials, account identifiers, or personal
+information in Git. Write a compact, source-attributed daily analysis to
+`.github/seo-data/daily/YYYY-MM-DD.md` and refresh `status.md`. A daily record
+must state coverage, windows, material changes, likely explanations, uncertainty,
+and the next evidence that would distinguish competing explanations.
+
+## 2. Choose zero or one coherent public change
+
+After analysis, choose the highest-value action supported by evidence:
+
+- one coherent technical SEO/GEO improvement;
+- one strong Daily Report or revision;
+- a content change together with directly coupled technical metadata;
+- or no public change, with the reason recorded.
+
+Do not ship unrelated SEO and content edits in one pull request. Put durable
+future work in `plan.md`; use `block.md` only for real external permission or
+human-only blockers.
+
+For technical SEO, follow `.github/seo-data/daily-task.md`. For a Daily Report,
+follow `.agents/skills/eunomia-research-report/SKILL.md`. A fluent summary without
+a defensible systems gap, mechanism, and testable direction is a no-publish
+result.
+
+## 3. Deliver and verify
+
+Use one fresh branch and one non-draft pull request for the daily record and its
+single coherent change. A data-only or no-change run may use a metadata-only pull
+request. Do not create a second closeout pull request.
+
+Before merge:
+
+1. run the relevant authoritative repository checks;
+2. inspect the complete diff and generated output;
+3. wait for required and expected CI;
+4. fix issues on the same branch;
+5. squash-merge only after a clean final self-review.
+
+For a public site change, wait for the production deployment of the exact squash
+commit and verify the defined behavior on the public site. Add one compact
+closeout comment to the merged pull request with the merge commit, deployment,
+public verification, data coverage, and any remaining uncertainty. The pull
+request and its closeout comment are part of the repository's operating record.
+The next daily run updates `status.md` from those verified facts.
+
+## Completion criteria
+
+A daily run is complete only when:
+
+- the daily data analysis exists with explicit source coverage;
+- `status.md`, `plan.md`, and `block.md` reflect current verified state as needed;
+- the run selected at most one coherent public change or recorded a defensible
+  no-change decision;
+- the pull request passed CI, final self-review, and squash merge;
+- any public change deployed from the exact merge commit and was verified;
+- the merged pull request contains the compact closeout record.
+
+A draft, local commit, issue, queued workflow, HTTP 200 alone, or unverified
+publication is not completion.

--- a/DAILY_TASK.md
+++ b/DAILY_TASK.md
@@ -24,18 +24,20 @@ state.
 Every run performs these three responsibilities in order:
 
 1. **Data analysis.** Collect and analyze the available search, acquisition,
-   traffic, repository, and live-site evidence. This step is mandatory even when
-   no public change is justified.
+   traffic, repository, and live-site evidence. This step is mandatory.
 2. **Technical SEO and GEO.** Inspect crawlability, indexing signals, canonical
    ownership, language alternates, structured data, internal links, performance,
-   and retrievability. Make a change only when evidence supports it.
-3. **Technical content production.** Research a Daily Report candidate inside the
-   active content series and publish only when it passes the repository's
-   evidence, gap, novelty, continuity, and usefulness gates. Daily research does
-   not impose a daily publication quota.
+   and retrievability. Make a site change only when evidence supports it.
+3. **Technical content production.** Publish exactly **one new Daily Report page
+   every run**. Research inside the active content series first and enforce the
+   rolling topic mix in `.github/seo-data/content-series.md`. If a candidate
+   fails the evidence, gap, novelty, continuity, or usefulness gates, reject that
+   candidate and continue researching another approved question until one passes.
+   The daily publication requirement never lowers the quality bar.
 
-Data should determine the work. Do not manufacture an article, SEO edit, or
-visible artifact merely to satisfy cadence.
+Data analysis and series strategy should determine which report is worth
+publishing. Do not fill the quota with a weak summary, recycled thesis, or
+superficial trend piece; change the candidate instead.
 
 ## Required context
 
@@ -47,8 +49,8 @@ Start from the latest remote default branch and read:
 - `.github/seo-data/status.md`;
 - `.github/seo-data/plan.md`;
 - `.github/seo-data/block.md`;
-- `.github/seo-data/content-series.md` for the active Daily Report series and
-  thematic roadmap;
+- `.github/seo-data/content-series.md` for the active Daily Report series,
+  eBPF/content mix, and thematic roadmap;
 - the newest record under `.github/seo-data/daily/`, when present;
 - `.github/seo-data/daily-task.md` for the technical SEO subtask;
 - `.agents/skills/seo-geo/SKILL.md` and the pinned `.github/seo-skills` skills;
@@ -91,36 +93,44 @@ information in Git. Write a compact, source-attributed daily analysis to
 must state coverage, windows, material changes, likely explanations, uncertainty,
 and the next evidence that would distinguish competing explanations.
 
-## 2. Choose zero or one coherent public change
+Before topic selection, calculate the rolling Daily Report mix defined in
+`.github/seo-data/content-series.md` and record it in the daily analysis.
 
-After analysis, choose the highest-value action supported by evidence:
+## 2. Select today's report and SEO work
 
-- one coherent technical SEO/GEO improvement;
-- one strong Daily Report or revision inside the active series;
-- a content change together with directly coupled technical metadata;
-- or no public change, with the reason recorded.
+The run must publish one new Daily Report. Select it by this sequence:
 
-For content work, **series continuity is the default**. Search and research inside
-the active series first. A new report must advance a distinct question in the
-series instead of restating an existing thesis with different examples. Leave the
-active series only for a material external development with durable systems
-consequences, and record why that interruption was justified. Do not switch
-series merely because another topic is trending.
+1. inspect the rolling topic mix;
+2. search and research inside the active series first;
+3. build evidence for more than one candidate when necessary;
+4. reject weak candidates rather than weakening the publication standard;
+5. select one distinct question that passes the report skill's evidence, gap,
+   mechanism, originality, usefulness, and evaluation gates;
+6. keep the rolling mix compliant: normally 5–7 of the most recent 10 reports
+   explicitly center eBPF, while pure Agent reports remain at most 1–2 of 10;
+7. publish one new bilingual Daily Report and update series continuity records.
 
-Do not ship unrelated SEO and content edits in one pull request. Put durable
-future work in `plan.md`; use `block.md` only for real external permission or
-human-only blockers.
+For technical SEO, make at most one coherent site change when the day's evidence
+supports it. Prefer a change directly coupled to the report or to an important
+measured technical issue. If an unrelated SEO change would make the daily PR
+hard to review, put it in `plan.md` for a focused follow-up rather than mixing
+unrelated work.
 
-For technical SEO, follow `.github/seo-data/daily-task.md`. For a Daily Report,
+For content work, **series continuity is the default**. A new report must advance
+a distinct question instead of restating an existing thesis with different
+examples. Leave the active series only when another approved series yields a
+stronger report or a material external development has durable systems
+consequences. Record any switch.
+
+For technical SEO, follow `.github/seo-data/daily-task.md`. For Daily Report,
 follow `.agents/skills/eunomia-research-report/SKILL.md` and
-`.github/seo-data/content-series.md`. A fluent summary without a defensible
-systems gap, mechanism, and testable direction is a no-publish result.
+`.github/seo-data/content-series.md`.
 
 ## 3. Deliver and verify
 
-Use one fresh branch and one non-draft pull request for the daily record and its
-single coherent change. A data-only or no-change run may use a metadata-only pull
-request. Do not create a second closeout pull request.
+Use one fresh branch and one non-draft pull request for the daily analysis, the
+mandatory new Daily Report, and any directly coupled SEO change. Do not create a
+second closeout pull request.
 
 Before merge:
 
@@ -130,26 +140,33 @@ Before merge:
 4. fix issues on the same branch;
 5. squash-merge only after a clean final self-review.
 
-For a public site change, wait for the production deployment of the exact squash
-commit and verify the defined behavior on the public site. Add one compact
-closeout comment to the merged pull request with the merge commit, deployment,
-public verification, data coverage, and any remaining uncertainty. The pull
-request and its closeout comment are part of the repository's operating record.
-The next daily run updates `status.md` from those verified facts.
+Wait for the production deployment of the exact squash commit and verify the new
+English and Chinese report pages on the public site, including navigation,
+canonical URLs, language alternates, internal links, gap section, idea section,
+and conclusion boundary. Verify any coupled SEO behavior as well.
+
+Add one compact closeout comment to the merged pull request with the merge commit,
+deployment, public verification, data coverage, selected series and topic class,
+and any remaining uncertainty. The pull request and its closeout comment are
+part of the repository's operating record. The next daily run updates
+`status.md` from those verified facts.
 
 ## Completion criteria
 
 A daily run is complete only when:
 
 - the daily data analysis exists with explicit source coverage;
-- `status.md`, `plan.md`, and `block.md` reflect current verified state as needed;
-- the run selected at most one coherent public change or recorded a defensible
-  no-change decision;
-- any Daily Report work follows the active series or explicitly records a justified
-  interruption;
+- the current rolling Daily Report topic mix was calculated and recorded;
+- `status.md`, `plan.md`, `block.md`, and `content-series.md` reflect current
+  verified state as needed;
+- exactly one new bilingual Daily Report was added and passes the content quality
+  gates;
+- the report follows the active or another approved series and keeps the rolling
+  topic mix compliant;
 - the pull request passed CI, final self-review, and squash merge;
-- any public change deployed from the exact merge commit and was verified;
+- the exact merge commit deployed successfully;
+- the new public English and Chinese report pages were verified;
 - the merged pull request contains the compact closeout record.
 
-A draft, local commit, issue, queued workflow, HTTP 200 alone, or unverified
-publication is not completion.
+`no-report`, a revision-only day, a data-only day, a draft, local commit, issue,
+queued workflow, HTTP 200 alone, or unverified publication is not completion.


### PR DESCRIPTION
## Why

The repository had an SEO-only daily-task document, but no unified daily operation. Data analysis, technical SEO, and Daily Report production were split across separate instructions. The repository also incorrectly recorded GA4 and Search Console as unavailable before checking the connected Google Drive.

This PR makes the repository the single operating authority, includes the verified analytics baseline, and defines the daily content program as an eBPF-first series rather than unrelated daily topics.

## What changed

- add root `DAILY_TASK.md` as the single authoritative scheduled entrypoint
- keep the external scheduler minimal; all data, SEO, content, quality, series, delivery, and state rules live in the repository
- make daily data analysis mandatory before SEO and content decisions
- compare complete 7-day and 28-day windows when source coverage permits
- require exactly one new bilingual Daily Report every scheduled run; `no-report`, revision-only, and data-only days do not count as completion
- if a candidate is weak, reject it and continue researching another approved question rather than lowering the quality bar
- add `.github/seo-data/content-series.md` as the authoritative series roadmap
- enforce a rolling topic mix: normally 5–7 of the most recent 10 reports explicitly center eBPF; pure Agent topics are capped at 1–2 of 10
- make `eBPF Runtime, Extensibility, and Composition` the active series; queue eBPF observability/profiling, eBPF networking/security, GPU/heterogeneous systems, and a deliberately limited Agent series
- use one daily pull request plus a compact closeout comment instead of a second closeout pull request
- make `.github/seo-data/daily-task.md` a technical SEO subtask instead of a scheduler entrypoint
- extend `Validate SEO Operations` so it checks the root scheduler contract, mandatory daily publication, and the eBPF/Agent content mix

## Verified Google Drive coverage

The connected Drive contains a folder named `eunomia.dev SEO Weekly CSV` with:

- six Search Console exports: dates, search appearance, devices, countries, pages, and queries
- one GA4 organic landing-page export
- verified source window: `2026-07-27` through `2026-08-02`

The repository discovers the folder by name, uses filename patterns `*_gsc_*.csv` and `*_ga4_*.csv`, and does not store Drive IDs, property IDs, account IDs, credentials, or private URLs.

The first public-safe baseline is recorded in `.github/seo-data/daily/2026-08-06.md`. Search Console reports 486 clicks and 55,021 impressions for the week, a weighted CTR of 0.883%, and an impression-weighted average position of approximately 8.21. Longer period comparisons remain unavailable until more weekly history appears. Cloudflare remains unconfigured.

## Scheduler

The external ChatGPT task `Eunomia Daily Ops` is enabled and runs daily in `America/Los_Angeles`. Its instruction remains intentionally minimal and delegates all operational policy to the repository. Once this PR lands, `DAILY_TASK.md` becomes the normal entrypoint.

Repository scheduler contract:

> Open `eunomia-bpf/eunomia.dev`, read `DAILY_TASK.md` from the current default branch, and complete the task exactly as the repository instructs. Treat the repository as authoritative.

## Validation and acceptance

- `Validate SEO Operations`, `Deploy Static App`, and GitGuardian run against the exact final PR head
- root `DAILY_TASK.md` is the single scheduled operating entrypoint
- data analysis is required every day
- every scheduled run must deploy one new bilingual Daily Report
- the rolling content mix is recorded before topic selection and kept eBPF-first
- verified Drive exports are used when readable and fresh; missing history is unavailable, never zero
- technical SEO and Daily Report skills remain the implementation and quality authorities for their respective subtasks
- no secrets, analytics property IDs, account IDs, Drive IDs, raw private data, or private URLs are committed
- the PR is squash-merged only after green checks and a clean final diff review
