### PR TITLE
Daily: publish userspace eBPF runtime report

### DIFF
--- a/.github/seo-data/daily/2026-08-08.md
+++ b/.github/seo-data/daily/2026-08-08.md
@@ -1,0 +1,166 @@
+# Daily SEO and Daily Report record — 2026-08-08
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Scheduled operation: repository-authoritative daily run from `DAILY_TASK.md`
+- Analytics lookback available today: one complete weekly export, `2026-07-27` through `2026-08-02`
+- Configured finalization lag: 3 days
+- Latest normally finalizable calendar date at run time: `2026-08-05`
+- Analytics cadence: weekly; the newest complete export ends on `2026-08-02`, so `2026-08-03` through `2026-08-05` are not present in the current weekly artifact.
+
+## Source status
+
+### Google Search Console
+
+Status: available and read successfully from the configured Drive folder.
+
+Files used:
+
+- `2026-07-27_to_2026-08-02_gsc_dates.csv`
+- `2026-07-27_to_2026-08-02_gsc_pages.csv`
+- `2026-07-27_to_2026-08-02_gsc_queries.csv`
+- `2026-07-27_to_2026-08-02_gsc_devices.csv`
+- `2026-07-27_to_2026-08-02_gsc_countries.csv`
+- `2026-07-27_to_2026-08-02_gsc_search_appearance.csv`
+
+The current Drive history contains one complete weekly date window. Previous-week and 28-day comparisons are therefore not computed; missing history is not treated as zero.
+
+### Google Analytics 4
+
+Status: available and read successfully from the configured Drive folder.
+
+Files used:
+
+- `2026-07-27_to_2026-08-02_ga4_organic_landing_pages.csv`
+- `2026-07-27_to_2026-08-02_ga4_source.json`
+
+The source sidecar confirms the canonical domain and the same `2026-07-27` through `2026-08-02` window. Private property identifiers are intentionally not copied into Git.
+
+This export is limited to organic landing-page rows. It does not provide a complete acquisition, outbound-click, conversion, or session-source view, so those questions remain outside today's evidence.
+
+### Cloudflare
+
+Status: disabled in `site.md`. No Cloudflare collection was attempted. The existing human-only authorization note in `block.md` remains unchanged.
+
+### Public web and repository evidence
+
+Status: available. The live homepage is crawlable and still presents Eunomia primarily around eBPF runtime infrastructure, tutorials, GPU work, and AI-agent systems. Public search results continue to expose legacy `/en/` URLs, while the current repository intentionally generates canonical redirect stubs for that compatibility path. No new technical defect was established strongly enough to justify a separate SEO implementation change today.
+
+## Verified analytics
+
+### Search Console aggregate
+
+For `2026-07-27` through `2026-08-02`:
+
+- Clicks: **486**
+- Impressions: **55,021**
+- Weighted CTR: **0.883%**
+- Impression-weighted average position: **about 8.21**
+
+Daily clicks were 77, 100, 98, 83, 55, 30, and 43. The drop on the weekend is visible, but one week is not enough to separate calendar effects from ranking or demand changes.
+
+Device distribution is heavily desktop-weighted: desktop produced 51,116 impressions, about 92.9% of the total, while mobile produced 3,823 impressions and tablet 82. Mobile CTR in this window was higher than desktop CTR, but the much smaller mobile volume makes a general device-performance conclusion premature.
+
+The search-appearance export contains 142 impressions and 5 clicks classified as translated results. Country rows show broad international discovery, with the United States contributing 29,100 impressions, about 52.9% of total impressions. This supports keeping English and Chinese report variants first-class and correctly linked rather than treating translation as secondary output.
+
+Page-level evidence remains dominated by executable tutorials and GPU/CUDA material, while bpftime and userspace-eBPF pages also receive search traffic. Query rows include eBPF, tutorial, XDP, userspace/runtime, bpftime, and GPU-related intent. Raw query rows are kept outside Git; only topic-level observations are recorded here.
+
+### GA4 organic landing pages
+
+The largest row remains `(not set)` with 157 sessions, 75 active users, and about 5.7% engagement rate. This is a measurement-quality issue and should not be interpreted as a content preference.
+
+Known landing pages with meaningful sessions again include the homepage, eBPF hello-world and networking tutorials, CUDA/GPU material, and bpftime/userspace-eBPF documentation. The export's `keyEvents` field is zero on the listed landing-page rows, but this slice alone does not establish that the site has no conversions or valuable downstream actions.
+
+The current Daily Report pages were published after this analytics window, so this dataset cannot yet evaluate Daily Report acquisition or engagement.
+
+## Rolling Daily Report mix before selection
+
+Before today's publication, the archive contained two Daily Reports:
+
+- eBPF-centered: **0 of 2**
+- pure Agent-centered: **2 of 2**
+- adjacent systems: **0 of 2**
+
+That is outside the target mix in `content-series.md`, so another pure Agent report was not eligible. The active series, **eBPF Runtime, Extensibility, and Composition**, was therefore used first as required.
+
+## Topic selection and research gate
+
+Selected question: **What is still missing before userspace eBPF can be treated as a first-class runtime rather than only a bytecode VM?**
+
+Classification: **eBPF-centered**. eBPF is the central runtime substrate, not a decorative example.
+
+Why it passed the gate:
+
+- The BPF ISA is now independently specified by RFC 9669, which makes it possible to separate instruction compatibility from host-runtime semantics.
+- Linux's libbpf lifecycle and `bpf()` API provide concrete program, map, link, pinning, capability, and lifetime semantics that are not part of the ISA.
+- uBPF, bpftime, and eBPF for Windows demonstrate materially different execution environments built around the same instruction language.
+- bpftime and EIM provide a concrete userspace system and resource model against which a broader runtime contract can be evaluated.
+- The unresolved mechanism is testable: cross-backend conformance can measure semantic drift after bytecode loading succeeds.
+
+A follow-on candidate about composing several eBPF programs on one hook was intentionally deferred rather than rejected. It is the next preferred topic in the active series, but a runtime-contract report provides a cleaner base vocabulary for later work on ordering, isolation, attribution, and conflict handling.
+
+## Published Daily Report
+
+English source:
+
+- `docs/research/userspace-ebpf-runtime-contract.md`
+
+Chinese source:
+
+- `docs/research/userspace-ebpf-runtime-contract.zh.md`
+
+Public routes after deployment:
+
+- `https://eunomia.dev/research/userspace-ebpf-runtime-contract/`
+- `https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/`
+
+Thesis: a userspace BPF VM is not yet a first-class runtime. A portable runtime contract should make attach identity, capability surface, state/lifecycle, authority, and per-extension resource attribution explicit and testable across backends.
+
+The report includes three implementable directions with explicit gap, mechanism, delta, artifact, evaluation, academic value, production value, and failure conditions:
+
+1. a machine-readable runtime contract and conformance suite;
+2. capability-aware attach handles that bind target generation, authority, program identity, and state;
+3. per-extension resource ledgers for attribution and budget enforcement.
+
+Expected rolling mix after publication:
+
+- eBPF-centered: **1 of 3**
+- pure Agent-centered: **2 of 3**
+- adjacent systems: **0 of 3**
+
+The archive is still not near its long-run target, so subsequent runs should continue to favor the active eBPF series and should not publish another pure Agent report yet.
+
+## SEO/GEO and site audit
+
+- The report title contains the primary topic `userspace eBPF` and is phrased as a concrete systems question.
+- The English meta description is 150 characters and states both the problem and the runtime-contract thesis.
+- The Chinese page has independent title and description text rather than a mechanical English copy.
+- Both variants link to primary sources: RFC Editor, Linux kernel documentation, upstream uBPF, upstream bpftime, the OSDI 2025 paper page, and Microsoft eBPF for Windows.
+- Both variants include internal links to the userspace-eBPF tutorial and bpftime documentation.
+- `docs/research/index.md` and `docs/research/index.zh.md` are updated so the new report is reachable from the Daily Report hub.
+- No separate canonical, hreflang, robots, sitemap, structured-data, redirect, or performance code change is made today because the audit did not establish a new defect with stronger evidence than the mandatory report and navigation update.
+- Legacy `/en/` search visibility remains an observation rather than a new bug: the current static build intentionally emits canonical redirect stubs for old English paths.
+
+## Skill submodule compatibility check
+
+Pinned submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`.
+
+The allowed upstream has newer commits, but the current upstream layout removes the pinned `change-seo-site` skill and `scripts/validate_seo_data.py` interface that this repository's current daily SEO contract explicitly requires. Updating the pointer today would make the consumer's authoritative instructions internally inconsistent. The submodule is therefore intentionally left pinned until the consuming repository migrates its contract and validation path together.
+
+## Delivery
+
+- Branch: `daily/2026-08-08-userspace-ebpf-runtime`
+- Pull request: pending at the time this record was first written; it will be filled before final CI review.
+- Required validation: repository CI, daily-contract checks, content/static build checks, and SEO data validation as configured by the repository.
+- Production target: GitHub Pages through `Deploy Static App`.
+- Public acceptance check: both English and Chinese report routes render, are linked from the Daily Report hub, expose correct canonical/hreflang metadata, retain the required gap/ideas/conclusion sections, and preserve the cited internal and external links.
+
+## Follow-up
+
+1. Continue the active eBPF Runtime, Extensibility, and Composition series; the preferred next question is safe composition of multiple independent extensions on one hook.
+2. Keep collecting weekly GA4 and GSC exports until previous-week and 28-day comparisons become possible.
+3. Investigate the GA4 `(not set)` landing-page row using a richer export before making a measurement or content change.
+4. Revisit legacy `/en/` visibility only if fresh crawl or analytics evidence shows redirect stubs are causing indexing, canonical, or engagement harm.
+5. Migrate the consuming SEO contract to the newer `seo-skill` layout before advancing the submodule pointer.

--- a/.github/seo-data/daily/2026-08-08.md
+++ b/.github/seo-data/daily/2026-08-08.md
@@ -1,127 +1,100 @@
-# Daily SEO and Daily Report record — 2026-08-08
+# SEO operations — 2026-08-08
 
 ## Scope
 
-- Site: `https://eunomia.dev`
-- Site timezone: `America/Los_Angeles`
-- Scheduled operation: repository-authoritative daily run from `DAILY_TASK.md`
-- Analytics lookback available today: one complete weekly export, `2026-07-27` through `2026-08-02`
+Run the repository-authoritative daily operation from `DAILY_TASK.md`: analyze all enabled analytics and public evidence first, audit the site, publish exactly one bilingual Daily Report under the required eBPF-first content mix, and deliver everything through one pull request.
+
+Site timezone is `America/Los_Angeles`. The selected report belongs to the active **eBPF Runtime, Extensibility, and Composition** series.
+
+## Data window
+
+- Search Console source window: `2026-07-27` through `2026-08-02`
+- GA4 source window: `2026-07-27` through `2026-08-02`
 - Configured finalization lag: 3 days
 - Latest normally finalizable calendar date at run time: `2026-08-05`
-- Analytics cadence: weekly; the newest complete export ends on `2026-08-02`, so `2026-08-03` through `2026-08-05` are not present in the current weekly artifact.
+- Source cadence: weekly
+- Previous-week comparison: unavailable because only one complete weekly window exists
+- 28-day comparison: unavailable for the same reason
 
-## Source status
+The newest complete weekly artifact ends on `2026-08-02`, so `2026-08-03` through `2026-08-05` are not represented yet. Missing history is not treated as zero.
+
+## Evidence collected
 
 ### Google Search Console
 
-Status: available and read successfully from the configured Drive folder.
-
-Files used:
-
-- `2026-07-27_to_2026-08-02_gsc_dates.csv`
-- `2026-07-27_to_2026-08-02_gsc_pages.csv`
-- `2026-07-27_to_2026-08-02_gsc_queries.csv`
-- `2026-07-27_to_2026-08-02_gsc_devices.csv`
-- `2026-07-27_to_2026-08-02_gsc_countries.csv`
-- `2026-07-27_to_2026-08-02_gsc_search_appearance.csv`
-
-The current Drive history contains one complete weekly date window. Previous-week and 28-day comparisons are therefore not computed; missing history is not treated as zero.
-
-### Google Analytics 4
-
-Status: available and read successfully from the configured Drive folder.
-
-Files used:
-
-- `2026-07-27_to_2026-08-02_ga4_organic_landing_pages.csv`
-- `2026-07-27_to_2026-08-02_ga4_source.json`
-
-The source sidecar confirms the canonical domain and the same `2026-07-27` through `2026-08-02` window. Private property identifiers are intentionally not copied into Git.
-
-This export is limited to organic landing-page rows. It does not provide a complete acquisition, outbound-click, conversion, or session-source view, so those questions remain outside today's evidence.
-
-### Cloudflare
-
-Status: disabled in `site.md`. No Cloudflare collection was attempted. The existing human-only authorization note in `block.md` remains unchanged.
-
-### Public web and repository evidence
-
-Status: available. The live homepage is crawlable and still presents Eunomia primarily around eBPF runtime infrastructure, tutorials, GPU work, and AI-agent systems. Public search results continue to expose legacy `/en/` URLs, while the current repository intentionally generates canonical redirect stubs for that compatibility path. No new technical defect was established strongly enough to justify a separate SEO implementation change today.
-
-## Verified analytics
-
-### Search Console aggregate
+The configured Drive folder was read successfully. The current weekly export includes date, page, query, device, country, and search-appearance dimensions.
 
 For `2026-07-27` through `2026-08-02`:
 
-- Clicks: **486**
-- Impressions: **55,021**
-- Weighted CTR: **0.883%**
-- Impression-weighted average position: **about 8.21**
+- clicks: **486**
+- impressions: **55,021**
+- weighted CTR: **0.883%**
+- impression-weighted average position: **about 8.21**
 
-Daily clicks were 77, 100, 98, 83, 55, 30, and 43. The drop on the weekend is visible, but one week is not enough to separate calendar effects from ranking or demand changes.
+Daily clicks were 77, 100, 98, 83, 55, 30, and 43. A weekend decline is visible, but one week cannot separate calendar effects from ranking or demand changes.
 
-Device distribution is heavily desktop-weighted: desktop produced 51,116 impressions, about 92.9% of the total, while mobile produced 3,823 impressions and tablet 82. Mobile CTR in this window was higher than desktop CTR, but the much smaller mobile volume makes a general device-performance conclusion premature.
+Desktop produced 51,116 impressions, about 92.9% of the total; mobile produced 3,823 and tablet 82. Mobile CTR was higher in this window, but its volume is much smaller, so no broad device conclusion is made.
 
-The search-appearance export contains 142 impressions and 5 clicks classified as translated results. Country rows show broad international discovery, with the United States contributing 29,100 impressions, about 52.9% of total impressions. This supports keeping English and Chinese report variants first-class and correctly linked rather than treating translation as secondary output.
+Search appearance contains 142 impressions and 5 clicks classified as translated results. Country data shows broad international discovery; the United States contributed 29,100 impressions, about 52.9% of total impressions. This supports maintaining first-class English and Chinese report variants with correct language links.
 
-Page-level evidence remains dominated by executable tutorials and GPU/CUDA material, while bpftime and userspace-eBPF pages also receive search traffic. Query rows include eBPF, tutorial, XDP, userspace/runtime, bpftime, and GPU-related intent. Raw query rows are kept outside Git; only topic-level observations are recorded here.
+Page-level evidence remains strongest around executable tutorials and GPU/CUDA material, while bpftime and userspace-eBPF pages also receive search traffic. Query rows include eBPF, tutorials, XDP, userspace/runtime, bpftime, and GPU-related intent. Raw query rows remain outside Git.
 
-### GA4 organic landing pages
+### Google Analytics 4
 
-The largest row remains `(not set)` with 157 sessions, 75 active users, and about 5.7% engagement rate. This is a measurement-quality issue and should not be interpreted as a content preference.
+The configured organic landing-page export and its source sidecar were read successfully. The sidecar confirms the canonical domain and the same weekly window; private source identifiers are intentionally not recorded here.
 
-Known landing pages with meaningful sessions again include the homepage, eBPF hello-world and networking tutorials, CUDA/GPU material, and bpftime/userspace-eBPF documentation. The export's `keyEvents` field is zero on the listed landing-page rows, but this slice alone does not establish that the site has no conversions or valuable downstream actions.
+The largest landing-page row remains `(not set)` with 157 sessions, 75 active users, and about 5.7% engagement rate. This is treated as a measurement-quality problem, not as evidence of content preference.
+
+Known pages with meaningful sessions include the homepage, eBPF hello-world and networking tutorials, CUDA/GPU material, and bpftime/userspace-eBPF documentation. The export's `keyEvents` field is zero on the listed rows, but this organic landing-page slice is not a complete acquisition, conversion, outbound-action, or session-source view, so no site-wide conversion claim is made.
 
 The current Daily Report pages were published after this analytics window, so this dataset cannot yet evaluate Daily Report acquisition or engagement.
 
-## Rolling Daily Report mix before selection
+### Other enabled evidence
 
-Before today's publication, the archive contained two Daily Reports:
+Cloudflare remains disabled in `site.md`, so no Cloudflare collection was attempted.
+
+The live homepage is crawlable and continues to present Eunomia around eBPF runtime infrastructure, tutorials, GPU work, and AI-agent systems. Public search results still expose legacy `/en/` paths. Repository inspection confirms that the current static build intentionally emits canonical redirect stubs for those legacy English URLs, so visibility alone is not treated as a new defect.
+
+Primary-source research for the report used RFC 9669, Linux libbpf and BPF syscall documentation, upstream uBPF, upstream bpftime and its OSDI 2025 EIM work, and Microsoft eBPF for Windows.
+
+## Work performed
+
+### Daily Report selection
+
+Before publication, the rolling archive contained:
 
 - eBPF-centered: **0 of 2**
 - pure Agent-centered: **2 of 2**
 - adjacent systems: **0 of 2**
 
-That is outside the target mix in `content-series.md`, so another pure Agent report was not eligible. The active series, **eBPF Runtime, Extensibility, and Composition**, was therefore used first as required.
-
-## Topic selection and research gate
+That mix makes another pure Agent report ineligible. The active eBPF series was searched first as required.
 
 Selected question: **What is still missing before userspace eBPF can be treated as a first-class runtime rather than only a bytecode VM?**
 
-Classification: **eBPF-centered**. eBPF is the central runtime substrate, not a decorative example.
+Classification: **eBPF-centered**.
 
-Why it passed the gate:
+The question passed the evidence and gap gate because the ISA is independently specified by RFC 9669 while Linux, uBPF, bpftime, and eBPF for Windows expose materially different host-runtime semantics. The testable gap is what happens after bytecode execution compatibility: attach identity, capabilities, state ownership, lifecycle, revocation, and resource attribution.
 
-- The BPF ISA is now independently specified by RFC 9669, which makes it possible to separate instruction compatibility from host-runtime semantics.
-- Linux's libbpf lifecycle and `bpf()` API provide concrete program, map, link, pinning, capability, and lifetime semantics that are not part of the ISA.
-- uBPF, bpftime, and eBPF for Windows demonstrate materially different execution environments built around the same instruction language.
-- bpftime and EIM provide a concrete userspace system and resource model against which a broader runtime contract can be evaluated.
-- The unresolved mechanism is testable: cross-backend conformance can measure semantic drift after bytecode loading succeeds.
+A follow-on candidate about composing several independent eBPF extensions on one hook was deferred to the next preferred position in the active series. Establishing runtime-contract vocabulary first makes the later composition question more precise.
 
-A follow-on candidate about composing several eBPF programs on one hook was intentionally deferred rather than rejected. It is the next preferred topic in the active series, but a runtime-contract report provides a cleaner base vocabulary for later work on ordering, isolation, attribution, and conflict handling.
+### Publication
 
-## Published Daily Report
-
-English source:
+Published exactly one new bilingual report source pair:
 
 - `docs/research/userspace-ebpf-runtime-contract.md`
-
-Chinese source:
-
 - `docs/research/userspace-ebpf-runtime-contract.zh.md`
 
-Public routes after deployment:
+Expected public routes after deployment:
 
 - `https://eunomia.dev/research/userspace-ebpf-runtime-contract/`
 - `https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/`
 
-Thesis: a userspace BPF VM is not yet a first-class runtime. A portable runtime contract should make attach identity, capability surface, state/lifecycle, authority, and per-extension resource attribution explicit and testable across backends.
+The report's thesis is that a userspace BPF VM is not yet a first-class runtime. A portable contract should make attach identity, capability surface, state and lifecycle, authority, and per-extension resource attribution explicit and testable across backends.
 
-The report includes three implementable directions with explicit gap, mechanism, delta, artifact, evaluation, academic value, production value, and failure conditions:
+It proposes three implementable directions, each with a gap, mechanism, delta, artifact, evaluation, academic value, production value, and failure condition:
 
 1. a machine-readable runtime contract and conformance suite;
-2. capability-aware attach handles that bind target generation, authority, program identity, and state;
+2. capability-aware attach handles binding target generation, authority, program identity, and state;
 3. per-extension resource ledgers for attribution and budget enforcement.
 
 Expected rolling mix after publication:
@@ -130,37 +103,52 @@ Expected rolling mix after publication:
 - pure Agent-centered: **2 of 3**
 - adjacent systems: **0 of 3**
 
-The archive is still not near its long-run target, so subsequent runs should continue to favor the active eBPF series and should not publish another pure Agent report yet.
+The archive remains outside its long-run target, so subsequent reports should keep favoring eBPF and should not publish another pure Agent topic yet.
 
-## SEO/GEO and site audit
+### Site and SEO changes
 
-- The report title contains the primary topic `userspace eBPF` and is phrased as a concrete systems question.
-- The English meta description is 150 characters and states both the problem and the runtime-contract thesis.
-- The Chinese page has independent title and description text rather than a mechanical English copy.
-- Both variants link to primary sources: RFC Editor, Linux kernel documentation, upstream uBPF, upstream bpftime, the OSDI 2025 paper page, and Microsoft eBPF for Windows.
-- Both variants include internal links to the userspace-eBPF tutorial and bpftime documentation.
-- `docs/research/index.md` and `docs/research/index.zh.md` are updated so the new report is reachable from the Daily Report hub.
-- No separate canonical, hreflang, robots, sitemap, structured-data, redirect, or performance code change is made today because the audit did not establish a new defect with stronger evidence than the mandatory report and navigation update.
-- Legacy `/en/` search visibility remains an observation rather than a new bug: the current static build intentionally emits canonical redirect stubs for old English paths.
+- Updated `docs/research/index.md` and `docs/research/index.zh.md` so the new report is reachable from the Daily Report hub.
+- Used an English title containing the primary topic `userspace eBPF` and a 150-character English meta description.
+- Wrote an independent Chinese title and description rather than mechanically copying English phrasing.
+- Added primary-source links and internal links to the userspace-eBPF tutorial and bpftime documentation.
+- Did not make a separate canonical, hreflang, robots, sitemap, structured-data, redirect, or performance implementation change because today's evidence did not establish a new technical defect strongly enough to justify one.
 
-## Skill submodule compatibility check
+### SEO skill submodule check
 
-Pinned submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`.
+The repository remains pinned to SEO skill commit `516e9e2dcf012506a677a749049d64c5914643e9`.
 
-The allowed upstream has newer commits, but the current upstream layout removes the pinned `change-seo-site` skill and `scripts/validate_seo_data.py` interface that this repository's current daily SEO contract explicitly requires. Updating the pointer today would make the consumer's authoritative instructions internally inconsistent. The submodule is therefore intentionally left pinned until the consuming repository migrates its contract and validation path together.
+The allowed upstream has newer commits, but the new layout removes interfaces that the current consuming contract still explicitly names, including `change-seo-site` and `scripts/validate_seo_data.py`. A pointer-only update would therefore make the repository instructions internally inconsistent. The pointer is intentionally left unchanged until the consumer contract and validator path are migrated together.
+
+## Validation and self-review
+
+- No raw analytics files, private source identifiers, credentials, or Drive URLs were added to Git.
+- Search Console aggregate arithmetic was checked against the seven date rows.
+- Missing comparison history remains explicitly unavailable rather than zero-filled.
+- GA4 observations are framed as measurement signals, not causal or conversion conclusions.
+- The report uses primary implementation and standards sources for technical claims.
+- The report contains the required gap section, research-direction section, and conclusion that states what evidence would change the thesis.
+- Both language variants contain the same core evidence and ideas while using natural language-specific prose.
+- The complete branch diff is limited to the daily operating record, current status, the two report sources, and the two report hub indexes.
+- The newer SEO skill upstream was reviewed and intentionally not adopted because it is incompatible with the current pinned consumer interface.
+
+Authoritative CI must validate the pinned SEO operating data, daily contract, content generation, site build, lint/type checks, and deployment workflow before merge.
 
 ## Delivery
 
 - Branch: `daily/2026-08-08-userspace-ebpf-runtime`
-- Pull request: pending at the time this record was first written; it will be filled before final CI review.
-- Required validation: repository CI, daily-contract checks, content/static build checks, and SEO data validation as configured by the repository.
-- Production target: GitHub Pages through `Deploy Static App`.
-- Public acceptance check: both English and Chinese report routes render, are linked from the Daily Report hub, expose correct canonical/hreflang metadata, retain the required gap/ideas/conclusion sections, and preserve the cited internal and external links.
+- Pull request: `#148`
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after required CI is green
+- Closeout policy: no second closeout pull request; final CI, squash commit, production deployment, and live-page verification facts belong in one compact comment on merged PR `#148`
 
-## Follow-up
+Public acceptance requires both English and Chinese report routes to render from the exact squash commit, remain linked from the Daily Report hub, expose the correct canonical and hreflang pair, retain the required gap/ideas/conclusion sections, and preserve the cited internal and external links.
 
-1. Continue the active eBPF Runtime, Extensibility, and Composition series; the preferred next question is safe composition of multiple independent extensions on one hook.
-2. Keep collecting weekly GA4 and GSC exports until previous-week and 28-day comparisons become possible.
-3. Investigate the GA4 `(not set)` landing-page row using a richer export before making a measurement or content change.
-4. Revisit legacy `/en/` visibility only if fresh crawl or analytics evidence shows redirect stubs are causing indexing, canonical, or engagement harm.
-5. Migrate the consuming SEO contract to the newer `seo-skill` layout before advancing the submodule pointer.
+## Decisions and follow-ups
+
+1. Continue the active **eBPF Runtime, Extensibility, and Composition** series. The preferred next question is safe composition of multiple independent eBPF extensions on one hook.
+2. Keep reading the configured weekly GA4 and Search Console exports in every run while they remain available.
+3. Accumulate enough history for previous-week and 28-day comparisons before making trend claims.
+4. Investigate the GA4 `(not set)` row with a richer export before making a measurement or content change.
+5. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows the canonical redirect stubs are causing measurable harm.
+6. Migrate the consuming SEO contract to the newer `seo-skill` layout before advancing the submodule pointer.
+7. Add Cloudflare evidence only when a supported read-only path exists.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,25 +7,28 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: none
+- Last completed daily run: `2026-08-08`
 - Last verified data window: `2026-07-27` through `2026-08-02`
-- Latest daily record: `2026-08-06` (baseline recorded before the first scheduled run)
-- Last public-change pull request: none from the unified daily operation
-- Last verified production deployment from a daily run: none
+- Latest daily record: `2026-08-08`
+- Last public-change pull request: recorded in the `2026-08-08` daily record and merged-PR closeout comment
+- Last verified production deployment from a daily run: recorded in the merged-PR closeout comment
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
 ## Current Daily Report mix
 
-The public archive currently contains two Daily Reports and both are pure
-Agent-centered topics:
+The public archive contains three Daily Reports after the `2026-08-08` run:
 
-- `/research/agent-trace-evidence-budget/`
-- `/research/parallel-agent-effect-serializability/`
+- eBPF-centered: **1 of 3**
+  - `/research/userspace-ebpf-runtime-contract/`
+- pure Agent-centered: **2 of 3**
+  - `/research/agent-trace-evidence-budget/`
+  - `/research/parallel-agent-effect-serializability/`
+- adjacent systems: **0 of 3**
 
-Until the rolling archive becomes compliant with the repository editorial mix,
-new reports should strongly favor eBPF. The active series is **eBPF Runtime,
-Extensibility, and Composition**. The rolling target is 5–7 eBPF-centered reports
-per 10 published reports and at most 1–2 pure Agent reports per 10.
+The archive is still outside the long-run target. New reports should continue to
+strongly favor eBPF. The active series is **eBPF Runtime, Extensibility, and
+Composition**. The rolling target is 5–7 eBPF-centered reports per 10 published
+reports and at most 1–2 pure Agent reports per 10.
 
 ## Current signals
 
@@ -33,46 +36,66 @@ per 10 published reports and at most 1–2 pure Agent reports per 10.
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
 - Google Analytics 4: weekly Drive export available and verified
-- Google Search Console: six weekly Drive exports available and verified
+- Google Search Console: six dimension exports for one weekly window available and verified
 - Cloudflare: not configured
 
-The verified Drive folder contains Search Console exports for dates, search
-appearance, devices, countries, pages, and queries, plus a GA4 organic landing-page
-export. The current coverage is one complete weekly window, so source-native
-seven-day analysis is possible but prior-period and 28-day comparisons are not yet
-supported by the available history.
+The verified Drive folder currently covers one complete Search Console and GA4
+weekly date window, `2026-07-27` through `2026-08-02`. Search Console has date,
+search-appearance, device, country, page, and query dimensions; GA4 has an organic
+landing-page export. The configured source cadence is weekly, so `2026-08-03`
+through `2026-08-05` are not yet represented even though those dates are beyond
+the configured three-day finalization lag. Previous-period and 28-day comparisons
+remain unavailable until more weekly windows accumulate.
 
 For `2026-07-27` through `2026-08-02`, Search Console reports 486 clicks and
 55,021 impressions, for a weighted CTR of 0.883% and an impression-weighted
-average position of approximately 8.21. The daily series falls sharply over the
-weekend, but a single week cannot distinguish a weekday effect from a real demand
-or ranking change.
+average position of approximately 8.21. Desktop accounts for about 92.9% of
+impressions in the current window. Search appearance includes translated-result
+traffic, and country rows show broad international discovery, which reinforces
+the value of maintaining first-class English and Chinese variants.
 
 The GA4 organic landing-page export shows tutorials and CUDA/GPU material among
-the strongest known landing pages. Its largest row is `(not set)`, which should be
-treated as a measurement-quality problem before drawing strong content or
-conversion conclusions.
+the strongest known landing pages. Its largest row is `(not set)` with low
+engagement, which remains a measurement-quality problem. The current export is
+not sufficient to make site-wide conversion or outbound-action claims.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
-structured data, and HTTP audit artifacts. Production deploys through the
-`Deploy Static App` workflow. The unified daily operation has not completed its
-first scheduled run yet.
+structured data, legacy redirect stubs, and HTTP audit artifacts. Production
+deploys through the `Deploy Static App` workflow.
+
+The `2026-08-08` technical audit did not establish a new crawl, canonical,
+hreflang, structured-data, redirect, or performance defect that justified a
+separate implementation change. Public search still exposes legacy `/en/` URLs,
+but the current build intentionally emits canonical redirect stubs for those
+paths; this remains an observation to monitor rather than a proven new defect.
+
+The SEO skill submodule remains pinned at
+`516e9e2dcf012506a677a749049d64c5914643e9`. Newer upstream commits restructure
+the skill package and remove interfaces that the current consuming contract
+still names, including `change-seo-site` and `scripts/validate_seo_data.py`.
+Advancing the pointer therefore requires a coordinated consumer migration rather
+than an isolated submodule bump.
 
 ## Current focus
 
-1. Merge the repository-owned daily operating contract and verified analytics
-   baseline before the first scheduled run relies on it.
+1. Continue the **eBPF Runtime, Extensibility, and Composition** Daily Report
+   series. The preferred next question is how multiple independent eBPF
+   extensions should share one hook safely.
 2. Publish one new eBPF-centered Daily Report per scheduled run until the rolling
-   mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer exceed
-   the 1–2 per 10 cap.
+   mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer
+   exceed the 1–2 per 10 cap.
 3. Use the verified weekly GA4 and Search Console exports in every run; never mark
-   them unavailable while the configured folder remains readable and fresh.
+   them unavailable while the configured folder remains readable.
 4. Accumulate enough weekly history for previous-period and 28-day comparisons.
-5. Investigate the GA4 `(not set)` landing-page row and remaining legacy `/en/`
-   traffic when selecting technical SEO work.
-6. Add Cloudflare evidence when a supported read-only path exists.
+5. Investigate the GA4 `(not set)` landing-page row with a richer export before
+   making a measurement or content change.
+6. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows
+   canonical redirect stubs are causing measurable harm.
+7. Migrate the consuming SEO contract to the newer `seo-skill` layout before
+   updating the submodule pointer.
+8. Add Cloudflare evidence when a supported read-only path exists.
 
 This file is the current verified summary. Detailed history belongs in
 `.github/seo-data/daily/` and the merged daily pull requests.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [What Is Missing Before Userspace eBPF Becomes a Real Runtime?](https://eunomia.dev/research/userspace-ebpf-runtime-contract/)
+
+A BPF VM can execute the instruction set without defining how programs attach, which capabilities they receive, who owns state, or how extensions are revoked and accounted for. This report compares Linux eBPF, uBPF, bpftime, and eBPF for Windows, then proposes a machine-readable runtime contract, capability-aware attach handles, and per-extension resource accounting.
+
 ### [When Several AI Agents Work at Once, Who Makes Sure the Final Result Is Right?](https://eunomia.dev/research/parallel-agent-effect-serializability/)
 
 Worktrees, sandboxes, and parallel tool calls can isolate workers while still producing a wrong combined outcome. This report uses code changes, shared budgets, approvals, and irreversible actions to explain why parallel agents need one validation and commit step before their effects become real. It also identifies missing benchmarks and effect contracts, then proposes an agent transaction layer, a semantic-conflict benchmark, and adaptive concurrency control.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [用户态 eBPF 要成为真正的运行时，还缺什么？](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/)
+
+一个 BPF VM 可以执行指令，却未必定义程序如何挂载、拥有哪些能力、状态由谁持有，以及扩展如何撤销和做资源归属。本文比较 Linux eBPF、uBPF、bpftime 与 eBPF for Windows，并提出机器可读的运行时契约、绑定能力的 attach handle 和 per-extension 资源账本。
+
 ### [多个 AI Agent 同时工作时，谁来保证最终结果是对的？](https://eunomia.dev/zh/research/parallel-agent-effect-serializability/)
 
 `worktree`、沙箱和并行工具调用可以隔离 worker，却仍可能产生错误的组合结果。本文用代码修改、共享预算、审批和不可逆操作说明：并行 Agent 的结果在真正生效前，需要经过一次统一的验证和提交。文章还分析现有 benchmark 与工具效果契约的不足，并提出 Agent 事务层、语义冲突 benchmark 和自适应并发控制等方向。

--- a/docs/research/userspace-ebpf-runtime-contract.md
+++ b/docs/research/userspace-ebpf-runtime-contract.md
@@ -1,0 +1,236 @@
+---
+date: 2026-08-08
+title: "What Is Missing Before Userspace eBPF Becomes a Real Runtime?"
+description: "Userspace eBPF can run bytecode outside the kernel, but a real runtime also needs portable attach, safety, state, capability, and lifecycle contracts."
+tags:
+  - Daily Report
+  - eBPF
+  - Userspace eBPF
+  - Runtime Systems
+  - bpftime
+research_question: "What runtime contract is still missing if eBPF programs are expected to move between the Linux kernel, userspace runtimes, and other execution backends without losing understandable attach, safety, state, and lifecycle semantics?"
+source_cutoff: 2026-08-08
+status: daily-report
+---
+
+# What Is Missing Before Userspace eBPF Becomes a Real Runtime?
+
+Suppose an operator wants to trace a database process without adding application instrumentation and without paying the cost of sending every event through a kernel probe. A userspace eBPF virtual machine solves one part of the problem: it can execute BPF instructions inside the process or beside it. But the first operational questions arrive before the first instruction runs. What exactly does the program attach to? Which version of the target did it inspect? Which helpers and memory regions may it access? Who owns its maps? What happens when the target library is replaced, the process exits, or the extension must be revoked?
+
+Those questions are not instruction-set questions. They are runtime questions.
+
+The BPF ecosystem has already standardized the instruction set well enough for an IETF specification, [RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html), to describe the BPF ISA independently of one implementation. Linux eBPF, however, is useful for much more than executing those instructions. Linux also provides program and map objects, verifier rules, helper and kfunc interfaces, attach types, BPF links, pinning, lifetime rules, capability checks, and user-space APIs that give an eBPF application a concrete operating model.
+
+<!-- more -->
+
+This report argues that **first-class userspace eBPF needs a portable execution contract above the ISA and below each runtime backend**. That contract should describe attachment identity, available capabilities, state ownership, lifetime and failure behavior, and resource attribution. It does not need to make every backend identical. Its job is to make the differences explicit enough that an application can know what it is relying on and a runtime can test whether it provides those semantics.
+
+That distinction matters because userspace eBPF is no longer one implementation pattern. [uBPF](https://github.com/iovisor/ubpf) is an embeddable VM with an interpreter, JITs, helper registration, and a newer safe execution profile. [bpftime](https://github.com/eunomia-bpf/bpftime) is a larger userspace runtime that adds loaders, maps, helpers, verification, attach backends, `bpf_link`-style objects, and compatibility with existing libbpf and bpftrace workflows. [eBPF for Windows](https://github.com/microsoft/ebpf-for-windows) reuses the BPF instruction format and familiar libbpf APIs but supplies a Windows-specific verifier, execution environment, hooks, helpers, and native/JIT execution choices. These systems share an instruction language while exposing different runtime contracts.
+
+## A BPF VM is only one layer of the runtime
+
+The easiest way to see the missing layer is to separate three questions that are often collapsed into "does this support eBPF?"
+
+First, **can the backend execute BPF instructions correctly?** RFC 9669 gives implementations a common ISA target. A VM can interpret those instructions or JIT them to native code.
+
+Second, **what execution environment does the program see?** An eBPF program is written against more than registers and opcodes. It expects a context type, helper functions, map operations, memory rules, return-value semantics, and often a specific event source. Two engines can implement the same ISA and still disagree on every one of those interfaces.
+
+Third, **how does an operator manage the program as a live system object?** The answer includes loading, verification, attachment, discovery, replacement, detachment, state ownership, authority, diagnostics, and cleanup. These operations determine whether a runtime is deployable under failures and upgrades rather than merely able to run a function.
+
+uBPF illustrates the boundary clearly. Its own README describes it as a library for executing eBPF programs and provides an assembler, disassembler, interpreter, and JITs. Its safe profile adds pointer provenance, checked dereferences, typed helper metadata, and registered external regions. Those are meaningful execution-safety semantics. The embedding application still decides what an event is, which target should trigger a program, how a program is named and revoked, and how several VM instances share or isolate state.
+
+That is not a weakness in uBPF. It is what an embeddable VM should do. The problem appears when the ecosystem treats VM compatibility as runtime compatibility.
+
+## Linux eBPF already exposes a richer operating model
+
+Linux makes the extra layers easy to overlook because they are part of the platform.
+
+The kernel's [libbpf lifecycle documentation](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html) separates an application into open, load, attach, and tear-down phases. During loading, maps are created, relocations are resolved, programs are verified, and initial state can be established before execution. During attachment, programs become connected to concrete hook points. Tear-down releases those relationships and resources.
+
+The [`bpf()` userspace API](https://docs.kernel.org/userspace-api/ebpf/syscall.html) gives programs and maps file-descriptor-based lifetimes and supports persistent objects through pinning. BPF links make the relationship between a loaded program and an attachment point into an object with its own lifetime. Newer BPF token support goes further: a token can carry allowed BPF commands, map types, program types, and attach types, so delegated loading is tied to an explicit capability set rather than an all-or-nothing privilege assumption.
+
+None of these mechanisms is part of the BPF ISA. Yet applications rely on them every day.
+
+This suggests a useful definition: **a runtime is first-class when an operator can reason about a program before, during, and after execution, not only about the instructions while they execute.**
+
+## Userspace execution changes the attachment problem
+
+Moving eBPF into userspace is attractive because it can remove a kernel crossing from hot event paths, operate where kernel BPF is unavailable, and expose application-local functions or memory more directly. It also removes many assumptions that the kernel previously supplied.
+
+Consider a uprobe. In kernel eBPF, the kernel and tracing stack mediate an attachment to a process or binary location. A userspace runtime based on dynamic binary rewriting may instead patch a function entry, a syscall path, a language runtime, a packet-processing loop, or even device code. The target might be identified by symbol, build ID, module offset, runtime method, or driver-specific event identifier. The target can disappear or be replaced independently of the eBPF program.
+
+A portable attach description therefore needs more than "program type = uprobe." It needs enough identity to answer questions such as:
+
+- Which process, executable, module, function, or event generation was selected?
+- What must still be true when the runtime commits the attachment?
+- Does attachment survive `exec`, library reload, process fork, or target replacement?
+- Can another principal discover, update, or revoke the attachment?
+- What cleanup is guaranteed if injection or patching succeeds only partially?
+
+[bpftime's current runtime](https://eunomia.dev/bpftime/documents/attach/) already has to solve many of these problems for uprobes, syscall hooks, XDP-style paths, GPU instrumentation, and pluggable event backends. Its OSDI 2025 work, [Extending Applications Safely and Efficiently](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng), adds the Extension Interface Model (EIM), which treats required extension features such as memory access or the ability to call an application function as resources that an extension manager can grant. This is a useful step toward an explicit userspace runtime contract because it separates what an extension needs from the mechanism used to execute it.
+
+The remaining question is how much of that contract can become portable across runtimes rather than staying inside one implementation.
+
+## Compatibility needs levels, not a single yes-or-no label
+
+"Compatible with eBPF" can currently mean several different things:
+
+| Compatibility level | What it actually promises | What can still differ |
+| --- | --- | --- |
+| ISA | The backend executes the same BPF instruction semantics | Context, helpers, maps, attachment, lifecycle |
+| Object/toolchain | It can consume ELF/BTF produced by common compilers | Relocations, helper availability, CO-RE target data |
+| API | Existing loader code can call familiar libbpf-style operations | Which calls are implemented and their failure semantics |
+| Program environment | A program type exposes comparable context and helpers | Target identity, authority, lifetime, performance |
+| Operational | Load, attach, update, observe, revoke, and clean up behave predictably | Backend-specific mechanisms and costs |
+
+This layered view explains why eBPF for Windows is interesting evidence. The project intentionally reuses existing eBPF toolchains and libbpf APIs, but its README also documents a Windows-specific hosting layer, hook set, helper surface, verifier path, and execution choices. Source compatibility is valuable, yet it cannot erase differences in what the host operating system can safely provide.
+
+Userspace eBPF should embrace the same reality. A runtime should be able to say, for example, "ISA and ELF compatible, libbpf loader compatible for this subset, uprobe attach semantics at contract version 2, shared-map persistence supported, delegated helper capability supported." That statement is more useful than a broad compatibility badge because it can be tested.
+
+## The runtime contract needs five pieces
+
+A practical contract does not have to standardize every implementation detail. Five pieces carry most of the operational meaning.
+
+### 1. Attachment identity and preconditions
+
+An attachment description should name the target in a form that can be revalidated. For a native process this might include PID namespace identity, executable build ID, module build ID, symbol or offset, and an expected generation. For a packet path it may include interface identity and queue or driver constraints. For GPU instrumentation it may include module and kernel identity.
+
+The runtime should fail closed when those preconditions no longer hold instead of silently attaching to whatever now occupies the same address or name.
+
+### 2. Program capabilities and context
+
+A program needs a declared view of helpers, context fields, maps, memory regions, callable functions, and side effects. Linux encodes much of this through program types, verifier rules, helpers, kfuncs, capabilities, and now BPF tokens. uBPF's safe profile makes helper metadata and external memory regions explicit. EIM makes application extension resources explicit.
+
+A userspace contract can unify the idea without forcing one enforcement mechanism: declare the required capability surface first, then let a backend prove that it can enforce it.
+
+### 3. State ownership and lifetime
+
+Maps and other state need owners and lifetime rules independent of a single VM invocation. A runtime should specify whether state is private to one program, shared between programs, shared across processes, persistent after detach, or imported from another backend. It should also define what happens to state when a program fails validation, attachment fails halfway, or the target exits.
+
+This report stops short of specifying transactional upgrades across programs, links, and maps. That deserves its own analysis. The immediate requirement is simpler: a runtime must expose enough object and lifetime semantics that a transactional design can be built at all.
+
+### 4. Authority and revocation
+
+Who is allowed to attach which program to which target, and who can revoke it later? In an embedded library, the host application may be the authority. In a system runtime, a daemon, container boundary, user namespace, or policy service may delegate only a subset of operations.
+
+The important property is that the authority becomes part of the attachment state. Checking permission only when a loader starts is not enough for a long-lived extension whose target or capability set can change.
+
+### 5. Resource and effect attribution
+
+Kernel eBPF benefits from shared kernel accounting and well-known inspection tools, even though its accounting is not perfect. A userspace runtime may execute JIT code inside another process, allocate shared maps, patch instructions, register callbacks, or consume event buffers. Without per-extension attribution, an operator can observe that the target process became slower but cannot tell which extension consumed CPU time, memory, event bandwidth, or helper calls.
+
+A first-class runtime should expose a stable identity that joins attach state, runtime cost, faults, and effects. This becomes more important when multiple independent extensions share one process, which is the next composition problem in this series.
+
+## When userspace eBPF is actually the right abstraction
+
+Not every instrumentation problem needs this machinery.
+
+Kernel uprobes remain a strong default when the event rate is moderate, the required data can cross the kernel boundary cheaply enough, and Linux provides the needed visibility. Dynamic binary instrumentation frameworks are better when an operator needs arbitrary instruction rewriting and does not need eBPF compatibility. Language runtimes often provide richer semantic hooks when all targets live inside one VM such as the JVM or a managed tracing API.
+
+Userspace eBPF becomes more compelling when several conditions coincide: existing eBPF tooling or programs are worth reusing; events are hot enough that the kernel path is material; the target exposes useful application-local state; kernel BPF is unavailable or too restricted; or the same extension model must span process, networking, GPU, and other backends.
+
+That is also the strongest argument against over-standardizing. If deployments only need one runtime on one platform, an implementation-specific API may be simpler and better. A portable contract earns its complexity only when programs, control planes, or policies need to move across backends or when operators need consistent safety and lifecycle guarantees.
+
+## Where current work is still weak
+
+### Runtime semantics are not part of ISA conformance
+
+RFC 9669 gives the ecosystem a common instruction language, but it deliberately does not define a full host environment. As a result, two implementations can both be correct BPF engines while disagreeing on context layout, helper behavior, map semantics, attach identity, failure handling, and lifetime.
+
+A useful test would run the same contract-focused workload across Linux, uBPF embeddings, bpftime, and eBPF for Windows, then classify which failures are ISA failures and which are host-contract mismatches. Today there is no widely used conformance suite for that second category.
+
+### Compatibility claims are difficult to compare
+
+Projects often report compatibility in terms of accepted object files or unchanged tooling. Those are important adoption properties, but they do not tell an operator whether detachment, target replacement, helper errors, state sharing, or revocation behave the same way.
+
+The missing evidence is a capability and lifecycle matrix backed by executable tests. If most real applications pass unchanged across runtimes once they can load, then the broader contract proposed here is unnecessary. If operational failures cluster after loading succeeds, the missing layer is real.
+
+### Safety is expressed through backend-specific mechanisms
+
+Linux uses verifier rules, program types, helper restrictions, capabilities, LSM hooks, and tokens. uBPF's safe profile uses pointer provenance and typed helper/region metadata. bpftime combines verification with userspace isolation and an EIM resource model. eBPF for Windows combines PREVAIL verification with a Windows-specific execution environment.
+
+These approaches can each be sound within their own threat model. What is missing is a portable way for a program or operator to state required privileges and for a backend to report which guarantees it actually enforces.
+
+### Userspace resource attribution is still secondary
+
+Userspace execution can make probes cheaper, but moving execution into a target process also moves costs into that process. A JIT compiler, shared map, injected trampoline, callback, and event queue all consume resources that ordinary process accounting attributes to the host application.
+
+A benchmark that reports only average probe overhead misses the multi-extension operational question: which extension caused the cost, under what event rate, and can the runtime cap or revoke it without stopping the target? That measurement gap becomes a deployment problem as soon as userspace eBPF is shared infrastructure rather than a single debugging tool.
+
+## Promising directions with academic and production value
+
+### A machine-readable runtime contract and conformance suite
+
+**Gap.** ISA and loader compatibility do not describe attachment, capability, state, and lifecycle semantics.
+
+**Mechanism.** Define a small schema that declares a program's required context version, helpers and callable functions, map/state semantics, attachment identity rules, expected lifetime, and optional authority constraints. Each backend publishes the subset it supports. A conformance harness exercises the declared behavior with deterministic target programs and fault injection rather than checking only whether the bytecode executes.
+
+**Delta.** RFC 9669 standardizes instructions, while libbpf and platform-specific APIs describe one host. This proposal standardizes neither new instructions nor one universal API. It makes the host contract testable across implementations.
+
+**Artifact.** An open schema, reference validator, and adapters for Linux libbpf, bpftime, a minimal uBPF embedding, and eBPF for Windows where equivalent hooks exist.
+
+**Evaluation.** Use observability, policy, packet-processing, and application-extension workloads. Measure the share that can declare one contract unchanged, mismatch detection rate, false compatibility claims caught, adapter complexity, and runtime overhead. Inject target replacement, missing helpers, stale modules, failed attach, and state-loss faults. The simplest baseline is today's documentation plus backend-specific integration tests.
+
+**Academic value.** The research question is whether execution-environment semantics can be factored from implementation mechanisms without collapsing to the least common denominator.
+
+**Production value.** Tool authors and operators gain a machine-checkable answer to "will this program run here with the guarantees it expects?" before touching a production target.
+
+**Failure condition.** If the schema either becomes a backend-specific feature list or excludes most useful applications, the abstraction is not general enough to justify standardization.
+
+### Capability-aware attach handles
+
+**Gap.** Userspace attachment can target mutable process state, while privilege checks and target identity are often handled separately.
+
+**Mechanism.** Make every attachment return a durable handle that binds four things: the exact target generation, the program identity, the granted capability set, and the state objects it owns. Before patching or registering a callback, the runtime revalidates target identity and capabilities. The handle supports query, revocation, and deterministic cleanup. Backends can implement it with kernel BPF links, injected runtime metadata, or host-specific objects.
+
+**Delta.** Linux BPF links provide object lifetime, BPF tokens provide delegated capability restrictions, and EIM describes extension resources. The proposed handle combines these ideas at the userspace attach boundary where the target itself can change independently of the runtime.
+
+**Artifact.** A bpftime prototype plus a small host API for embedders, with adapters that expose comparable metadata for kernel BPF links.
+
+**Evaluation.** Stress PID reuse, `exec`, shared-library reload, concurrent attach/detach, permission revocation, partial injection failure, and target crashes. Compare a best-effort attach API, version checks alone, and the full capability-aware handle. Measure stale-target failures prevented, cleanup completeness, attach latency, steady-state overhead, and metadata size.
+
+**Academic value.** The general question is how to make dynamic code attachment safe when target identity, authority, and lifetime evolve independently.
+
+**Production value.** Long-running observability and policy agents can update or revoke instrumentation without relying on process-wide restarts or undocumented cleanup assumptions.
+
+**Failure condition.** If normal target churn makes handles invalidate so frequently that operators disable the checks, the design is too strict or the chosen target identity is wrong.
+
+### Per-extension resource ledgers
+
+**Gap.** Userspace eBPF cost is usually charged to the host process, which hides interference between independent extensions.
+
+**Mechanism.** Give every attach handle a resource ledger that records CPU/JIT time, map and code memory, event-buffer traffic, helper or host-function calls, faults, and dropped events. Enforce optional budgets at event dispatch or helper boundaries. The ledger should distinguish one-time attach/JIT cost from steady-state execution cost.
+
+**Delta.** Ordinary process accounting observes the host process, while microbenchmarks report aggregate probe overhead. The ledger makes the extension itself the accounting principal.
+
+**Artifact.** Runtime counters and budget hooks in bpftime, an export format, and a benchmark that composes several extensions with different event rates and failure behavior.
+
+**Evaluation.** Run one to dozens of extensions on database, web-server, syscall, and packet-processing targets. Compare process-level accounting, sampling-based attribution, and exact runtime counters. Measure attribution error, enforcement latency, overhead, tail latency on the host, and whether budgets isolate a noisy extension without stopping unrelated ones.
+
+**Academic value.** The broader systems question is whether dynamically injected extensions can become independently accountable tenants while still sharing one process address space.
+
+**Production value.** Operators can answer which extension caused a regression and cap it without disabling the whole instrumentation stack.
+
+**Failure condition.** If accurate attribution requires instrumentation overhead comparable to the probes themselves, sampling or coarse process accounting may remain the better operational tradeoff.
+
+## What would change this conclusion?
+
+The argument depends on userspace eBPF becoming a shared and portable runtime layer rather than remaining a collection of specialized embedded VMs. Several results would weaken it.
+
+If a study of real deployments finds that almost all userspace eBPF workloads run on one backend, use a fixed helper set, keep no persistent state, and never require delegated attachment, then ISA plus local APIs may be enough. If programs that already load successfully through libbpf almost never fail because of lifecycle or capability differences, a cross-runtime contract would solve a small problem. If target-identity checks and per-extension accounting add enough overhead to erase the main benefit of userspace execution, they should remain optional debugging features instead of mandatory runtime semantics.
+
+The opposite evidence would strengthen the case: recurring failures after successful program loading, incompatible state or detach behavior across backends, production incidents caused by stale attachments, and multi-extension interference that process-level accounting cannot attribute.
+
+The near-term engineering test is therefore concrete. Take a small set of eBPF programs that already run on more than one backend, write down the runtime assumptions they currently leave implicit, and turn those assumptions into executable cross-backend tests. If the tests expose meaningful semantic drift, the ecosystem needs a contract above the ISA. If they do not, we should keep the runtime interface smaller.
+
+## References
+
+1. IETF, [RFC 9669: BPF Instruction Set Architecture](https://www.rfc-editor.org/rfc/rfc9669.html), 2024.
+2. Linux kernel documentation, [libbpf Overview](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html).
+3. Linux kernel documentation, [eBPF Syscall](https://docs.kernel.org/userspace-api/ebpf/syscall.html).
+4. IO Visor, [uBPF](https://github.com/iovisor/ubpf), userspace BPF VM and safe execution profile.
+5. Eunomia, [bpftime](https://github.com/eunomia-bpf/bpftime), userspace eBPF runtime and extension framework.
+6. Zheng et al., [Extending Applications Safely and Efficiently](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng), OSDI 2025.
+7. Microsoft, [eBPF for Windows](https://github.com/microsoft/ebpf-for-windows), Windows hosting environment for eBPF toolchains and APIs.
+
+For a hands-on introduction to the existing implementation space, see the [userspace eBPF tutorial](https://eunomia.dev/tutorials/36-userspace-ebpf/) and the [bpftime runtime documentation](https://eunomia.dev/bpftime/).

--- a/docs/research/userspace-ebpf-runtime-contract.zh.md
+++ b/docs/research/userspace-ebpf-runtime-contract.zh.md
@@ -1,0 +1,244 @@
+---
+date: 2026-08-08
+title: "用户态 eBPF 要成为真正的运行时，还缺什么？"
+description: "用户态 eBPF 已经能在内核外执行字节码，但真正可部署的运行时还需要明确的挂载、能力、安全、状态生命周期和资源归属契约。"
+tags:
+  - Daily Report
+  - eBPF
+  - Userspace eBPF
+  - Runtime Systems
+  - bpftime
+research_question: "如果希望同一套 eBPF 程序能够在 Linux 内核、用户态运行时和其他执行后端之间迁移，哪些挂载、安全、状态和生命周期语义必须从隐含实现细节变成可检查的运行时契约？"
+source_cutoff: 2026-08-08
+status: daily-report
+---
+
+# 用户态 eBPF 要成为真正的运行时，还缺什么？
+
+假设运维人员想给一个数据库进程加动态观测，又不想修改应用，也不希望每次高频事件都绕进内核再回来。把 eBPF 放到用户态执行看起来很直接：准备一个虚拟机，把 BPF 字节码解释执行或 JIT 成本地代码，然后在目标进程里运行。
+
+真正部署时，麻烦却发生在第一条 BPF 指令执行之前。程序到底挂到哪个函数、哪个模块版本、哪个进程实例？目标库被热更新之后，旧地址还能不能继续用？这个程序允许访问哪些内存、调用哪些 helper 或宿主函数？map 属于谁，detach 之后还在不在？如果注入只完成了一半，谁负责恢复？谁又有权在之后撤销这个扩展？
+
+这些都不是指令集问题，而是运行时问题。
+
+BPF 指令集本身已经走到了标准化阶段。IETF 的 [RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html) 定义了 BPF ISA，使不同实现可以共享一套指令语义。但是 Linux eBPF 之所以能成为完整的平台，并不只是因为内核能执行这些指令。它同时提供程序和 map 对象、验证器、helper 和 kfunc、程序类型、attach 类型、BPF link、pinning、对象生命周期、权限检查以及用户态管理接口。
+
+<!-- more -->
+
+本文的判断是：**用户态 eBPF 如果要从“能执行 BPF 的 VM”变成真正可部署、可复用的运行时，需要在 ISA 之上增加一层可移植的执行契约。** 这层契约至少要说明五件事：挂载目标如何标识和重新验证、程序拥有哪些能力、状态由谁拥有、对象如何创建和销毁，以及一个扩展消耗了多少资源并产生了哪些影响。
+
+这并不意味着所有后端必须实现成一样。相反，契约的价值在于把差异说清楚，让程序在运行之前就知道自己依赖哪些语义，让运行时可以明确回答“我支持其中哪些部分”，并用测试验证这个回答。
+
+今天的实现已经说明这种区分是必要的。[uBPF](https://github.com/iovisor/ubpf) 是一个可嵌入的用户态 BPF VM，提供解释器、JIT、helper 注册以及新的安全执行配置。[bpftime](https://github.com/eunomia-bpf/bpftime) 则把范围扩大到 loader、map、helper、验证、多个 attach 后端和 `bpf_link` 风格对象，并尝试兼容现有 libbpf、bpftrace 工作流。[eBPF for Windows](https://github.com/microsoft/ebpf-for-windows) 也复用了 BPF 指令格式和常见 libbpf API，但需要自己提供 Windows 上的 hook、helper、验证器路径和执行方式。它们共享的是程序语言，却并没有天然共享完整的运行时语义。
+
+## BPF VM 和 BPF 运行时不是一回事
+
+判断一个系统是否“支持 eBPF”时，至少应该拆成三个不同问题。
+
+第一个问题是：**它能不能正确执行 BPF 指令？** RFC 9669 解决的是这一层。后端可以解释执行，也可以把 BPF JIT 成 x86-64、Arm64 或其他本地代码。
+
+第二个问题是：**BPF 程序看到的执行环境是什么？** 程序并不只依赖寄存器和 opcode。它还依赖 context 结构、helper、map、可访问内存、返回值约定，以及触发程序的事件。两个 VM 完全可以都正确实现同一套 ISA，却在这些地方毫不兼容。
+
+第三个问题是：**运维人员如何把它当成一个长期存在的系统对象管理？** 这涉及 load、verify、attach、查询、更新、detach、状态所有权、权限、诊断和异常清理。一个 VM 能稳定运行函数，并不自动意味着它能在目标进程升级、崩溃、重启或权限变化时保持可理解的行为。
+
+uBPF 很适合说明这个边界。它的 README 明确把项目定位为执行 eBPF 程序的库，提供 assembler、disassembler、interpreter 和 JIT。它的新安全模式增加了指针来源跟踪、越界检查、带类型的 helper 元数据和外部内存区域注册。这些都是有实际意义的执行安全语义。
+
+但把 uBPF 嵌进一个程序之后，仍然要由宿主自己决定事件是什么、怎么找到目标、程序如何命名和撤销、多个 VM 是否共享状态，以及进程退出时如何清理。这个职责不应该强塞给一个轻量 VM。问题在于，如果生态只用“能跑同样的 BPF 字节码”判断兼容性，就会把这一大层运行时语义漏掉。
+
+## Linux eBPF 实际上已经有一套更完整的运行模型
+
+Linux 上这些语义很容易被视为理所当然，因为它们已经由内核和 libbpf 提供。
+
+内核的 [libbpf 生命周期文档](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html) 把一个应用明确分为 open、load、attach 和 tear down。load 阶段会创建 map、处理 relocation、验证并加载程序，而且允许在程序真正开始执行前初始化状态。attach 阶段再把程序连接到具体 hook。tear down 则解除连接并释放资源。
+
+[`bpf()` 用户态 API](https://docs.kernel.org/userspace-api/ebpf/syscall.html) 进一步把 map、program、link 等对象放进基于文件描述符和引用计数的生命周期中。需要长期存在的对象可以 pin 到 BPF 文件系统。BPF link 把“某个已加载程序挂在某个目标上”本身变成了可管理对象。较新的 BPF token 又把允许使用的 BPF 命令、map 类型、program 类型和 attach 类型变成可委托的能力集合，而不是只有“有权限”和“没权限”两种状态。
+
+这些都不属于 BPF ISA，但真实应用每天都在依赖它们。
+
+因此可以给“真正的运行时”一个更有用的定义：**运维人员不仅能解释程序执行时的指令，还能解释它在执行前如何被授权和挂载、执行过程中拥有何种状态、失败后如何清理，以及最终如何被撤销。**
+
+## 把执行搬到用户态以后，attach 本身变复杂了
+
+用户态 eBPF 的吸引力很明确。高频事件可以少一次内核往返；内核 BPF 不可用或权限受限时仍然能够扩展应用；程序还能更直接地访问应用内部函数和数据。代价是，过去由内核替我们定义的很多边界需要重新显式化。
+
+以内核 uprobe 为例，Linux tracing 栈会参与管理进程或二进制位置上的挂载。用户态运行时如果使用动态二进制改写，则可能直接 patch 函数入口、系统调用路径、语言运行时、数据包处理循环，甚至 GPU 设备代码。目标可能用 symbol、build ID、模块偏移、JIT 方法名或者驱动事件 ID 表示，而且这些目标的生命周期和 BPF 程序本身并不一致。
+
+因此，一个可移植的 attach 描述至少要能回答：
+
+- 选中的到底是哪个进程、可执行文件、模块、函数或事件版本？
+- 真正修改目标之前，哪些条件必须再次验证？
+- `exec`、fork、动态库 reload 或目标替换后，挂载关系如何变化？
+- 另一个主体能不能查询、更新或撤销这个挂载？
+- 如果注入、patch 或回调注册只成功一部分，运行时保证清理到什么程度？
+
+[bpftime 的 attach 机制](https://eunomia.dev/bpftime/documents/attach/) 已经需要面对这些问题，因为它不仅处理 uprobe 和 syscall，还尝试支持 XDP 风格路径、GPU instrumentation 以及可插拔事件后端。其 OSDI 2025 工作 [Extending Applications Safely and Efficiently](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng) 提出了 Extension Interface Model（EIM），把扩展需要的能力看成资源，例如一段内存的访问权，或者调用应用函数的能力，再由扩展管理者明确授予。
+
+EIM 的价值不只在隔离。它提示了一个更一般的方向：运行时应该先描述扩展“需要什么”，然后再选择具体后端去实现这些能力，而不是先暴露一堆实现细节再让程序猜环境。
+
+## “兼容 eBPF”应该拆成多个层级
+
+现在一句“compatible with eBPF”可能表达完全不同的事情。
+
+| 兼容层级 | 真正承诺的内容 | 仍然可能不同的部分 |
+| --- | --- | --- |
+| ISA | 同样的 BPF 指令有一致执行语义 | context、helper、map、attach、生命周期 |
+| 对象和工具链 | 能消费 clang 生成的 ELF/BTF 等产物 | relocation、CO-RE 数据、helper 可用性 |
+| API | loader 可以调用熟悉的 libbpf 风格接口 | 支持的 API 子集和失败语义 |
+| 程序环境 | 某类程序得到相近的 context 和 helper | 目标身份、权限、生命周期、性能 |
+| 运维行为 | load、attach、查询、撤销和清理可预测 | 具体后端实现和成本 |
+
+[eBPF for Windows](https://github.com/microsoft/ebpf-for-windows) 是很直接的证据。项目刻意复用既有 eBPF toolchain 和 libbpf API，但 README 同时明确说明它需要 Windows 特有的 hosting layer、hook、helper、验证流程，并且可以选择 native、JIT 或 interpreter 等不同执行路径。源代码兼容当然有价值，但宿主操作系统能提供什么语义，不能被一个 API 名字抹平。
+
+用户态 eBPF 也应该采用类似的分层表述。一个运行时完全可以声明：“支持 RFC 9669 ISA；支持这一组 ELF/BTF 和 libbpf loader 操作；uprobe attach 满足某个版本的目标身份和生命周期语义；共享 map 可以跨进程保留；helper 能力支持委托和撤销。”这种声明看起来不如一个“100% compatible”标签简洁，但它可以测试，也能帮助真正的部署决策。
+
+## 一套可用的用户态运行时契约至少需要五部分
+
+不必把所有后端实现细节都标准化。下面五部分已经覆盖大多数运维语义。
+
+### 1. 挂载目标的身份和前置条件
+
+挂载描述必须能在执行前重新验证，而不是只保存一个容易失效的地址。
+
+对本地进程，身份可能由 PID namespace、可执行文件 build ID、模块 build ID、symbol/offset 和目标 generation 共同组成。对网络路径，可能是接口、queue 和驱动能力。对 GPU，则可能要绑定模块和 kernel identity。
+
+一旦这些前置条件不再成立，运行时应该明确失败，而不是把程序悄悄挂到“当前碰巧占据同一个地址或名字”的对象上。
+
+### 2. 程序能力和 context
+
+程序需要声明自己依赖的 helper、宿主函数、context 字段、map、内存区域和副作用。Linux 通过 program type、验证器规则、helper/kfunc、capability 和 BPF token 表达其中很大一部分。uBPF 的安全模式把 helper 元数据和可访问外部内存显式化。EIM 则把应用扩展需要的资源显式化。
+
+用户态契约不必强制所有后端用同一种隔离技术。更合理的方式是先声明能力表面，再让后端证明自己能够提供并约束这些能力。
+
+### 3. 状态所有权和生命周期
+
+map 和其他状态不能只依附一次 VM 调用。运行时应该说明状态是程序私有、多个程序共享、跨进程共享，还是在 detach 后继续存在；也要说明状态能否从另一种后端导入。
+
+当验证失败、attach 只完成一半或目标退出时，状态又如何处理？如果这些语义完全隐含在实现中，后续就很难做可靠升级和恢复。
+
+本文暂时不展开“多个 program、link、map 和用户态 control plane 如何事务化升级”。那是这个系列后续更值得单独分析的问题。当前最基本的要求只是：先让对象和状态有足够清晰的生命周期语义，事务机制才有落脚点。
+
+### 4. 权限和撤销
+
+谁可以把哪个程序挂到哪个目标，之后又由谁撤销？嵌入式库可能直接把宿主进程视为权限主体；系统级运行时则可能通过 daemon、容器边界、user namespace 或策略服务委托一部分操作。
+
+关键是把权限变成挂载状态的一部分。只在 loader 启动时检查一次权限，对于一个会长期存在、目标和能力还可能变化的扩展并不够。
+
+### 5. 资源和效果归属
+
+用户态执行把很多成本一起搬进目标进程。JIT 代码、共享 map、插入的 trampoline、callback 和事件队列都会消耗 CPU、内存和带宽。普通进程级统计最终只会告诉你“数据库进程变慢了”，却很难回答是哪一个扩展导致的。
+
+因此，一个真正的运行时还需要给每个扩展稳定身份，并把 attach 状态、CPU/JIT 时间、内存、helper 调用、事件量、drop 和异常关联起来。多个独立扩展共享一个进程时，这会从诊断便利变成基本的隔离和运营能力。
+
+## 什么场景真的需要用户态 eBPF？
+
+不是所有观测问题都值得引入这套机制。
+
+事件频率不高、所需数据能低成本经过内核，而且 Linux 已经提供合适 hook 时，kernel uprobe 仍然是很强的默认选择。需要任意指令级改写、又不在乎 eBPF 工具链兼容时，传统 DBI 框架通常更灵活。如果所有目标都在 JVM 或其他托管运行时里，语言本身提供的语义 hook 往往比通用 eBPF 更丰富。
+
+用户态 eBPF 更适合以下几类条件同时成立的情况：已经存在值得复用的 eBPF 程序和工具；事件足够高频，内核路径成本明显；目标的应用内部状态很重要；kernel eBPF 不可用或权限太强；或者同一套扩展模型要跨越进程、网络、GPU 等多个执行位置。
+
+这也是反对过度抽象的最强理由。如果一个部署永远只使用一个 runtime、一个平台和固定 helper 集，那么实现私有 API 可能更简单。只有当程序、control plane 或策略确实需要跨后端迁移，或者运维人员需要一致的安全和生命周期保证时，可移植契约才值得这份复杂度。
+
+## 现有研究还缺什么
+
+### ISA 一致性测试覆盖不到运行时语义
+
+RFC 9669 给出了共同的指令语言，但它本来就没有试图定义完整宿主环境。因此，两个实现都可能是完全正确的 BPF engine，却在 context layout、helper、map、attach、失败清理和生命周期上产生不同结果。
+
+最直接的实验是把同一批“契约测试 workload”分别跑在 Linux、uBPF embedding、bpftime 和 eBPF for Windows 上，把失败分成 ISA 错误和 host-contract mismatch。现在缺少的正是第二类广泛采用的 conformance suite。
+
+### 各项目的兼容性声明很难横向比较
+
+现有项目通常用“能加载已有 ELF”“现有 libbpf 工具无需修改”描述兼容性。它们对采用成本非常重要，却没有回答 target replacement、detach、helper error、状态共享和权限撤销是否一致。
+
+真正缺的是一张由可执行测试生成的能力和生命周期矩阵。如果真实应用只要能 load，后面几乎就不会出现语义差异，那么本文提出的更高层契约确实没有必要。相反，如果问题集中发生在成功 load 之后，这一层缺口就很实际。
+
+### 安全保证仍然绑定具体后端
+
+Linux 组合使用 verifier、program type、helper restriction、capability、LSM 和 token；uBPF 的 safe profile 使用 pointer provenance 和带类型的 helper/region metadata；bpftime 使用验证、用户态隔离和 EIM；eBPF for Windows 则把 PREVAIL 和 Windows hosting environment 结合起来。
+
+这些方案都可能在各自 threat model 内成立。缺少的是一种跨后端表述：程序或运维人员先声明自己需要什么权限，后端再明确报告自己到底执行了哪些约束。
+
+### 用户态资源归属仍然是二等功能
+
+把 probe 移到用户态有机会降低单次事件开销，但成本也更容易隐藏在宿主进程里。如果基准只报告平均 probe overhead，就回答不了共享运行时里的问题：哪个扩展在什么事件频率下制造了成本，运行时能否只限制它而不影响目标程序和其他扩展？
+
+要判断这个缺口是否重要，需要多扩展 workload，而不是单 probe microbenchmark。指标也应该包括 attribution error、host tail latency、drop、资源上限触发时间和撤销之后的恢复情况。
+
+## 兼具学术价值与生产价值的方向
+
+### 机器可读的运行时契约与一致性测试套件
+
+**缺口。** ISA 和 loader 兼容没有覆盖 attach、能力、状态和生命周期。
+
+**机制。** 定义一个小型 schema，声明程序要求的 context 版本、helper/宿主函数、map 和状态语义、挂载身份规则、生命周期以及可选权限约束。每个后端发布自己支持的子集。测试框架通过确定性的目标程序和故障注入验证这些语义，而不是只检查字节码能不能执行。
+
+**和已有工作的差异。** RFC 9669 标准化指令，libbpf 和各平台 API 描述单一宿主。这里既不增加新指令，也不规定一个万能 API，而是让宿主契约本身可以跨实现检查。
+
+**可交付成果。** 开放 schema、validator，以及 Linux libbpf、bpftime、最小 uBPF embedding 和 eBPF for Windows 的 adapter。
+
+**评估。** 选择观测、策略、packet processing 和应用扩展 workload；测量同一份契约无需修改即可运行的比例、语义 mismatch 检出率、adapter 复杂度和额外开销。主动注入目标替换、helper 缺失、模块过期、attach 失败和状态丢失。基线就是当前文档加每个项目自己的 integration test。
+
+**学术价值。** 可以回答一个一般性的系统问题：执行环境语义能否从具体实现机制中抽出来，同时又不退化成没有实际能力的最小公分母。
+
+**生产价值。** 工具作者和运维人员能在修改生产进程之前，机器可验证地回答“这个程序在这里到底能以什么保证运行”。
+
+**失败条件。** 如果 schema 最终只是把每个后端的 feature list 换成另一种格式，或者大多数实际程序都无法使用共同部分，那么这层抽象不值得标准化。
+
+### 把目标身份、能力和生命周期绑定在同一个 attach handle 上
+
+**缺口。** 用户态 attach 面对的是会变化的进程状态，而目标身份检查、权限和清理经常彼此分离。
+
+**机制。** 每次 attach 返回一个持久 handle，同时绑定精确目标 generation、程序身份、授予的能力集合和它拥有的状态对象。真正 patch 或注册 callback 前再次验证目标与权限。这个 handle 必须支持 query、revocation 和确定性 cleanup。Linux 后端可以映射到 BPF link，注入式用户态运行时可以维护自己的元数据对象。
+
+**和已有工作的差异。** BPF link 管对象生命周期，BPF token 约束可委托能力，EIM 描述扩展资源。这里把三类信息放到用户态动态挂载这个边界上，因为目标进程本身可以独立变化。
+
+**可交付成果。** 一个 bpftime 原型、一套适合嵌入式运行时的轻量 host API，以及能够暴露类似元数据的 kernel BPF link adapter。
+
+**评估。** 压测 PID reuse、`exec`、动态库 reload、并发 attach/detach、权限撤销、部分注入失败和目标 crash。对比 best-effort attach、只做版本检查、完整 capability-aware handle。指标包括避免的 stale-target 错误、清理完整度、attach 延迟、稳态开销和元数据大小。
+
+**学术价值。** 它研究的是动态代码挂载中的一般问题：当目标身份、权限和生命周期分别变化时，怎样保证一次 attach 仍然指向原来被授权的对象。
+
+**生产价值。** 长期运行的观测和策略系统可以安全更新或撤销扩展，而不必依赖进程重启或未经验证的清理假设。
+
+**失败条件。** 如果正常的库更新和进程变化导致 handle 频繁失效，最终迫使运维关闭检查，那么设计要么过严，要么目标身份选错了。
+
+### 给每个扩展单独做资源账本
+
+**缺口。** 用户态 eBPF 的运行成本通常被记在宿主进程名下，多个扩展之间的干扰很难定位。
+
+**机制。** 每个 attach handle 维护自己的资源账本，统计 CPU/JIT 时间、map 和代码内存、事件缓冲流量、helper/宿主函数调用、fault 和 drop，并允许在 dispatch 或 helper 边界设置预算。一次性的 attach/JIT 成本和稳态运行成本应分开记录。
+
+**和已有工作的差异。** 普通进程 accounting 只能看到宿主，microbenchmark 又只给 aggregate probe overhead。资源账本把扩展本身变成 accounting principal。
+
+**可交付成果。** bpftime 中的 per-extension counter 和 budget hook、统一导出格式，以及一个同时运行多个不同事件频率扩展的 benchmark。
+
+**评估。** 在数据库、Web server、syscall 和 packet-processing workload 上同时运行 1 到几十个扩展，对比进程级 accounting、sampling attribution 和运行时精确计数。测量 attribution error、预算执行延迟、运行时开销、宿主 tail latency，以及限制一个 noisy extension 时其他扩展是否保持正常。
+
+**学术价值。** 更一般的问题是：动态注入、共享同一地址空间的扩展，能不能在资源上成为彼此独立且可追责的 tenant。
+
+**生产价值。** 运维可以回答“哪个扩展导致了回归”，并只限制这个扩展，而不是关闭整套 instrumentation。
+
+**失败条件。** 如果精确 attribution 的成本已经接近 probe 本身，那么采样或粗粒度进程 accounting 可能更划算。
+
+## 哪些结果会改变这个判断？
+
+本文有一个明确前提：用户态 eBPF 会逐渐成为共享、可迁移的运行时层，而不只是几个项目内部的嵌入式 VM。如果真实世界并没有朝这个方向走，那么很多契约都没有必要。
+
+例如，如果部署研究发现绝大部分用户态 eBPF workload 永远只跑一个 backend，helper 集固定、不保留持久状态，也没有委托 attach 的需求，那么 ISA 加本地 API 已经足够。如果已经能通过 libbpf 成功 load 的程序，几乎从不因为生命周期或 capability 差异出错，那么跨运行时契约只解决了很小的问题。如果目标身份检查和 per-extension accounting 的开销足以抵消用户态执行的主要收益，它们也更适合作为可选诊断功能，而不是强制语义。
+
+相反，几类证据会明显加强本文判断：程序成功 load 之后仍反复因为 attach 或状态语义失效；同一扩展在多个后端上的 detach、map lifetime 和权限行为不兼容；生产环境出现 stale attachment；多个扩展造成的干扰无法用进程级数据归属。
+
+因此，近期最有价值的实验其实不复杂。找一组已经能在多个后端执行的 eBPF 程序，把今天写在 README、代码和运维经验里的隐含假设列出来，再把它们变成跨后端可执行测试。如果这些测试能稳定发现有实际后果的语义漂移，生态需要 ISA 之上的运行时契约；如果几乎发现不了，我们就应该保持接口更小，不要为了“统一”而增加一层空抽象。
+
+## 参考资料
+
+1. IETF，[RFC 9669: BPF Instruction Set Architecture](https://www.rfc-editor.org/rfc/rfc9669.html)，2024。
+2. Linux kernel documentation，[libbpf Overview](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html)。
+3. Linux kernel documentation，[eBPF Syscall](https://docs.kernel.org/userspace-api/ebpf/syscall.html)。
+4. IO Visor，[uBPF](https://github.com/iovisor/ubpf)，用户态 BPF VM 及其安全执行配置。
+5. Eunomia，[bpftime](https://github.com/eunomia-bpf/bpftime)，用户态 eBPF runtime 与 extension framework。
+6. Zheng 等，[Extending Applications Safely and Efficiently](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng)，OSDI 2025。
+7. Microsoft，[eBPF for Windows](https://github.com/microsoft/ebpf-for-windows)，Windows 上的 eBPF hosting environment。
+
+如果想先从现有实现入手，可以参考 [用户态 eBPF 教程](https://eunomia.dev/zh/tutorials/36-userspace-ebpf/) 和 [bpftime 运行时文档](https://eunomia.dev/zh/bpftime/)。


### PR DESCRIPTION
## Evidence

- Read the repository-authoritative `DAILY_TASK.md` and required SEO/report operating records from current `main`.
- Read the configured Google Drive exports for the latest complete weekly window, 2026-07-27 through 2026-08-02.
- GSC: 486 clicks, 55,021 impressions, weighted CTR 0.883%, impression-weighted average position about 8.21. Current history contains one weekly window, so prior-week and 28-day comparisons remain unavailable.
- GA4 organic landing-page data remains dominated by tutorials/GPU material plus a large low-engagement `(not set)` row; the current export is not a complete conversion/acquisition view.
- Rolling Daily Report mix before this change was 0/2 eBPF-centered and 2/2 pure Agent, so the active eBPF runtime series is mandatory for topic selection.
- Public/primary evidence was checked against RFC 9669, Linux libbpf and BPF syscall documentation, uBPF, bpftime/EIM, and eBPF for Windows.

## Scope

This PR performs one daily operation:

1. publishes exactly one new bilingual Daily Report, `userspace-ebpf-runtime-contract`, arguing that first-class userspace eBPF needs an explicit runtime contract above the ISA;
2. updates both Daily Report indexes for internal discoverability;
3. records today's GA4/GSC analysis, topic mix, research gate, SEO audit, and follow-up in `.github/seo-data`;
4. updates current status for the new 1/3 eBPF-centered rolling mix.

No separate technical SEO implementation change is included because today's audit did not establish a new crawl/canonical/hreflang/structured-data/redirect/performance defect strongly enough to justify one. Legacy `/en/` visibility is already handled by intentional canonical redirect stubs and remains a monitoring item.

The `seo-skills` submodule is intentionally not advanced: current upstream removed interfaces (`change-seo-site`, `scripts/validate_seo_data.py`) that this repository's authoritative consumer contract still references, so a pointer-only update would be incompatible.

## Validation

Expected authoritative checks:

- repository daily-operation contract tests;
- SEO data validation;
- content generation / static site build;
- lint / type checks and existing repository CI;
- complete final PR diff and generated-output self-review after CI is green.

## Deployment

Production target: GitHub Pages via `Deploy Static App` after squash merge.

## Acceptance

After the exact squash commit deploys:

- English route renders: `/research/userspace-ebpf-runtime-contract/`;
- Chinese route renders: `/zh/research/userspace-ebpf-runtime-contract/`;
- both routes are reachable from the Daily Report hub;
- canonical and hreflang metadata point to the correct bilingual pair;
- the required gap, research-direction, and conclusion sections render;
- internal links to userspace eBPF and bpftime pages and primary-source links are present.

A compact closeout comment will be added to this merged PR with final CI, squash commit, deployment, and public verification facts, as required by `DAILY_TASK.md`.