### PR TITLE
Daily: publish eBPF hook composition report

### DIFF
--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -78,6 +78,18 @@ programmable runtime substrate rather than only a kernel observability feature?*
 This series should connect kernel and userspace execution, composition, state,
 upgrade, safety, performance, and deployment boundaries.
 
+### Published progress
+
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
+   first-class userspace eBPF needs explicit attachment, capability, state,
+   lifetime, and attribution contracts above ISA compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
+   multi-program problem beyond dispatch and ordering to effect visibility,
+   outcome resolution, shared-state ownership, and versioned hook composition.
+3. Preferred next question: transactional upgrade of stateful eBPF applications
+   across programs, links, maps, pinned state, userspace controllers, and
+   rollback after partial failure.
+
 ### Preferred sequence
 
 1. **What is still missing for first-class userspace eBPF?**

--- a/.github/seo-data/daily/2026-08-09.md
+++ b/.github/seo-data/daily/2026-08-09.md
@@ -1,0 +1,79 @@
+# Daily analysis — 2026-08-09
+
+## Coverage
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | Drive export for `2026-07-27` through `2026-08-02`; date, query, page, country, device, and search-appearance dimensions | available, but partial relative to the current finalizable date |
+| Google Analytics 4 | Drive organic landing-page export for `2026-07-27` through `2026-08-02` | available, but partial relative to the current finalizable date |
+| Public GitHub | current public repository state and recent commits checked on `2026-08-09` | available |
+| Live site | current public pages and search-visible routes checked on `2026-08-09`; generated output is also required in PR/deployment verification | available |
+| Public web / primary research sources | Linux kernel documentation, libxdp, USENIX, arXiv, and the published SIGCOMM 2026 tutorial program, checked through `2026-08-09` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
+
+The configured finalization lag is three days, so data through `2026-08-06` is now old enough to be finalizable. The configured Drive folder still contains only the weekly `2026-07-27` through `2026-08-02` Search Console and GA4 window. Therefore `2026-08-03` through `2026-08-06` are currently unrepresented in the enabled Google exports. This is missing coverage, not zero traffic.
+
+Only one complete weekly Google window is available. A latest-7-days versus previous-7-days comparison and a latest-28-days versus prior comparable period cannot yet be computed from the enabled exports without inventing history. Keep accumulating weekly exports before making period-over-period claims.
+
+## Search and traffic evidence
+
+Because no new weekly export has arrived since the previous run, the verified Search Console baseline is unchanged rather than newly declining or growing.
+
+For `2026-07-27` through `2026-08-02`, Search Console reports **486 clicks** and **55,021 impressions**, a weighted CTR of **0.883%**, and an impression-weighted average position of approximately **8.21**. Desktop contributes 51,116 impressions, about **92.9%** of the current window. The United States contributes 29,100 impressions, about **52.9%**, while China, Hong Kong, India, Singapore, Japan, Germany, the United Kingdom, Canada, and other countries also contribute measurable discovery. Search appearance contains translated-result traffic, which remains evidence for preserving first-class English and Chinese routes.
+
+The strongest known landing/search surfaces remain practical eBPF and accelerator material. Search Console page rows include `/tutorials/1-helloworld/` at 24 clicks / 530 impressions, the homepage at 17 / 860, the Chinese GPU architecture tutorial at 16 / 284, the CUDA events tutorial at 13 / 190, PTX assembly at 11 / 1,513, XDP at 9 / 938, TC at 8 / 497, and HTTP tracing at 8 / 593. Query rows include `ebpf` at 7 clicks / 149 impressions, `ebpf example` at 3 / 32, `ebpf lsm` at 3 / 15, `ebpf tc` at 3 / 8, `xdp` at 3 / 82, `ebpf tutorial` at 2 / 65, and `bpftime` at 1 / 28.
+
+The GA4 organic landing-page export continues to show tutorials and CUDA/GPU material among the strongest known landing pages. Its largest row remains `(not set)` at 157 sessions with an engagement rate of about 5.7%, while the homepage has 34 sessions at about 61.8%, `/tutorials/1-helloworld/` has 33 at about 63.6%, the Chinese hello-world route has 23 at about 78.3%, and `/bpftime/` has 4 at 100% in this slice. The export still has zero configured key events in these rows and is not sufficient for site-wide conversion or outbound-action claims. The `(not set)` row remains a measurement-quality question that requires richer GA4 dimensions before any implementation change is justified.
+
+## Repository and live-site evidence
+
+Public GitHub activity remains consistent with the site's runtime/eBPF focus but is not treated as a traffic conversion metric. On `2026-08-09`, `eunomia-bpf/bpftime` merged a runtime fix that keeps preload logging off host stdio. The site repository also received unrelated community dashboard and digest work before this run. These are current engineering signals, not evidence by themselves that a search topic should be promoted.
+
+The current public site still exposes the main Eunomia landing page, bilingual navigation, Daily Report navigation, eBPF tutorials, bpftime, project pages, and the TCX tutorial. Search results continue to surface legacy `/en/` variants as previously observed. The repository intentionally generates canonical redirect stubs for those paths, and today's evidence does not establish a new canonical, redirect, hreflang, structured-data, or crawl defect attributable to them.
+
+No unrelated technical SEO implementation change is justified today. The directly coupled SEO work is the normal addition of the new bilingual report to the Daily Report indexes and its generated canonical/hreflang/structured page output. The PR and exact production deployment must verify those generated signals before closeout.
+
+## Rolling Daily Report mix before topic selection
+
+Before today's publication, the public Daily Report archive contains three reports:
+
+- eBPF-centered: **1 of 3** (`/research/userspace-ebpf-runtime-contract/`)
+- pure Agent-centered: **2 of 3** (`/research/agent-trace-evidence-budget/`, `/research/parallel-agent-effect-serializability/`)
+- adjacent systems: **0 of 3**
+
+The small archive is outside the long-run target of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10. The next report therefore needs to be eBPF-centered unless the active-series candidate fails the quality gates.
+
+## Topic selection and research gate
+
+Active series: **eBPF Runtime, Extensibility, and Composition**.
+
+Selected question: **How should multiple independently developed eBPF programs share one hook safely?**
+
+The first candidate framing, "build a dispatcher or chainer for multiple eBPF programs," was rejected as too weak. libxdp already provides an XDP dispatcher with run priorities and chain-call actions, TCX provides link-based multi-program ordering and revision-aware changes, and the published program for the upcoming SIGCOMM 2026 BPFChain tutorial explicitly covers chaining, ordering conflicts, return-value overrides, shared-map races, and monitoring.
+
+The narrower report passes the gap and novelty gate because it asks what semantic contract remains after those mechanisms exist. Primary evidence shows that different Linux hooks already implement different composition rules: `BPF_SK_LOOKUP` combines verdicts with selected sockets, cgroup sockopt propagates context mutations, HID-BPF shares a mutable data buffer, libxdp exposes dispatcher continuation policy, and TCX exposes explicit ordering and chain revisions. vBPF addresses multi-tenant late binding and state isolation; KRAKENGUARD analyzes fine-grained permissions and cross-program interference; Yaksha-Prashna analyzes bytecode conformance and dependencies. The residual mechanism is a machine-checkable attachment contract for effects, mutation visibility, outcome resolution, shared-state ownership, and versioned whole-hook composition.
+
+Today's report is therefore classified **eBPF-centered**. After publication the rolling archive becomes **2 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 4**. That is still short of the eventual eBPF share and still at the pure-Agent cap for a small archive, so the next run should remain in the active eBPF series. The preferred next question is transactional upgrade of a stateful eBPF application across programs, links, maps, and controllers.
+
+## Delivery scope
+
+One fresh branch, `daily/2026-08-09-ebpf-hook-composition`, carries the complete daily change:
+
+- this source-attributed operating record;
+- one new English report at `/research/ebpf-hook-composition-contract/`;
+- its Chinese counterpart at `/zh/research/ebpf-hook-composition-contract/`;
+- both Daily Report index updates;
+- `status.md` refresh;
+- active-series continuity update.
+
+`plan.md` does not require a new action because the existing plan already calls for eBPF-first daily reports, accumulation of analytics history, investigation of GA4 `(not set)` only with richer evidence, and monitoring rather than speculative repair of legacy `/en/` indexing. `block.md` also remains current: Drive analytics are readable and Cloudflare remains intentionally disabled pending a supported read-only path.
+
+## Uncertainty and next evidence
+
+The largest operational uncertainty is data freshness. The next weekly Drive export should show whether `2026-08-03` onward changes the current query/page distribution and whether the report series begins to receive measurable discovery. A richer GA4 export with acquisition and outbound-navigation dimensions is needed before attributing repository or paper movement to a landing page. Additional Search Console weekly windows are needed before any 7-day or 28-day trend claim is valid.
+
+For the report thesis, the most discriminating next evidence is an empirical corpus of real multi-program BPF deployments. If deterministic ordering plus isolation already eliminates most semantic conflicts, a cross-hook composition contract may be unnecessary. If conflicts repeatedly involve return precedence, transformed inputs, shared-state ownership, and coordinated update, the proposed composition layer becomes more strongly justified.
+
+Production verification, exact merge commit, deployment result, public English/Chinese page checks, and any remaining uncertainty belong in the single merged-PR closeout comment required by `DAILY_TASK.md`.

--- a/.github/seo-data/daily/2026-08-09.md
+++ b/.github/seo-data/daily/2026-08-09.md
@@ -1,6 +1,12 @@
-# Daily analysis — 2026-08-09
+# SEO operations — 2026-08-09
 
-## Coverage
+## Scope
+
+This run followed the repository-authoritative daily operation: analyze every enabled data source first, audit technical SEO and GEO signals, calculate the rolling Daily Report mix, research inside the active series, and publish exactly one new bilingual report. No unrelated technical SEO implementation change is included because today's evidence did not establish a new defect.
+
+The active series is **eBPF Runtime, Extensibility, and Composition**. The selected report asks how independently developed eBPF programs should share one hook safely when ordering, mutable context, shared state, competing outcomes, and independent upgrades all interact.
+
+## Data window
 
 This run used every source currently enabled by `.github/seo-data/site.md`.
 
@@ -17,7 +23,9 @@ The configured finalization lag is three days, so data through `2026-08-06` is n
 
 Only one complete weekly Google window is available. A latest-7-days versus previous-7-days comparison and a latest-28-days versus prior comparable period cannot yet be computed from the enabled exports without inventing history. Keep accumulating weekly exports before making period-over-period claims.
 
-## Search and traffic evidence
+## Evidence collected
+
+### Search and traffic evidence
 
 Because no new weekly export has arrived since the previous run, the verified Search Console baseline is unchanged rather than newly declining or growing.
 
@@ -27,53 +35,56 @@ The strongest known landing/search surfaces remain practical eBPF and accelerato
 
 The GA4 organic landing-page export continues to show tutorials and CUDA/GPU material among the strongest known landing pages. Its largest row remains `(not set)` at 157 sessions with an engagement rate of about 5.7%, while the homepage has 34 sessions at about 61.8%, `/tutorials/1-helloworld/` has 33 at about 63.6%, the Chinese hello-world route has 23 at about 78.3%, and `/bpftime/` has 4 at 100% in this slice. The export still has zero configured key events in these rows and is not sufficient for site-wide conversion or outbound-action claims. The `(not set)` row remains a measurement-quality question that requires richer GA4 dimensions before any implementation change is justified.
 
-## Repository and live-site evidence
+### Repository and live-site evidence
 
 Public GitHub activity remains consistent with the site's runtime/eBPF focus but is not treated as a traffic conversion metric. On `2026-08-09`, `eunomia-bpf/bpftime` merged a runtime fix that keeps preload logging off host stdio. The site repository also received unrelated community dashboard and digest work before this run. These are current engineering signals, not evidence by themselves that a search topic should be promoted.
 
 The current public site still exposes the main Eunomia landing page, bilingual navigation, Daily Report navigation, eBPF tutorials, bpftime, project pages, and the TCX tutorial. Search results continue to surface legacy `/en/` variants as previously observed. The repository intentionally generates canonical redirect stubs for those paths, and today's evidence does not establish a new canonical, redirect, hreflang, structured-data, or crawl defect attributable to them.
 
-No unrelated technical SEO implementation change is justified today. The directly coupled SEO work is the normal addition of the new bilingual report to the Daily Report indexes and its generated canonical/hreflang/structured page output. The PR and exact production deployment must verify those generated signals before closeout.
+### Rolling Daily Report mix and research evidence
 
-## Rolling Daily Report mix before topic selection
-
-Before today's publication, the public Daily Report archive contains three reports:
-
-- eBPF-centered: **1 of 3** (`/research/userspace-ebpf-runtime-contract/`)
-- pure Agent-centered: **2 of 3** (`/research/agent-trace-evidence-budget/`, `/research/parallel-agent-effect-serializability/`)
-- adjacent systems: **0 of 3**
-
-The small archive is outside the long-run target of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10. The next report therefore needs to be eBPF-centered unless the active-series candidate fails the quality gates.
-
-## Topic selection and research gate
-
-Active series: **eBPF Runtime, Extensibility, and Composition**.
-
-Selected question: **How should multiple independently developed eBPF programs share one hook safely?**
+Before today's publication, the public Daily Report archive contains three reports: **1 of 3 eBPF-centered**, **2 of 3 pure Agent-centered**, and **0 of 3 adjacent systems**. The small archive is outside the long-run target of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10, so the next report needs to be eBPF-centered unless the active-series candidate fails the quality gates.
 
 The first candidate framing, "build a dispatcher or chainer for multiple eBPF programs," was rejected as too weak. libxdp already provides an XDP dispatcher with run priorities and chain-call actions, TCX provides link-based multi-program ordering and revision-aware changes, and the published program for the upcoming SIGCOMM 2026 BPFChain tutorial explicitly covers chaining, ordering conflicts, return-value overrides, shared-map races, and monitoring.
 
-The narrower report passes the gap and novelty gate because it asks what semantic contract remains after those mechanisms exist. Primary evidence shows that different Linux hooks already implement different composition rules: `BPF_SK_LOOKUP` combines verdicts with selected sockets, cgroup sockopt propagates context mutations, HID-BPF shares a mutable data buffer, libxdp exposes dispatcher continuation policy, and TCX exposes explicit ordering and chain revisions. vBPF addresses multi-tenant late binding and state isolation; KRAKENGUARD analyzes fine-grained permissions and cross-program interference; Yaksha-Prashna analyzes bytecode conformance and dependencies. The residual mechanism is a machine-checkable attachment contract for effects, mutation visibility, outcome resolution, shared-state ownership, and versioned whole-hook composition.
+The narrower question passes the gap and novelty gate because it asks what semantic contract remains after those mechanisms exist. Primary evidence shows that different Linux hooks already implement different composition rules: `BPF_SK_LOOKUP` combines verdicts with selected sockets, cgroup sockopt propagates context mutations, HID-BPF shares a mutable data buffer, libxdp exposes dispatcher continuation policy, and TCX exposes explicit ordering and chain revisions. vBPF addresses multi-tenant late binding and state isolation; KRAKENGUARD analyzes fine-grained permissions and cross-program interference; Yaksha-Prashna analyzes bytecode conformance and dependencies. The residual mechanism is a machine-checkable attachment contract for effects, mutation visibility, outcome resolution, shared-state ownership, and versioned whole-hook composition.
 
-Today's report is therefore classified **eBPF-centered**. After publication the rolling archive becomes **2 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 4**. That is still short of the eventual eBPF share and still at the pure-Agent cap for a small archive, so the next run should remain in the active eBPF series. The preferred next question is transactional upgrade of a stateful eBPF application across programs, links, maps, and controllers.
+## Work performed
 
-## Delivery scope
+One new bilingual Daily Report was added:
 
-One fresh branch, `daily/2026-08-09-ebpf-hook-composition`, carries the complete daily change:
+- English: `/research/ebpf-hook-composition-contract/`
+- Chinese: `/zh/research/ebpf-hook-composition-contract/`
 
-- this source-attributed operating record;
-- one new English report at `/research/ebpf-hook-composition-contract/`;
-- its Chinese counterpart at `/zh/research/ebpf-hook-composition-contract/`;
-- both Daily Report index updates;
-- `status.md` refresh;
-- active-series continuity update.
+Both Daily Report indexes were updated, `status.md` was refreshed, and `content-series.md` records that the first two questions in the active series are now covered and that transactional stateful eBPF upgrade is the preferred next question.
 
-`plan.md` does not require a new action because the existing plan already calls for eBPF-first daily reports, accumulation of analytics history, investigation of GA4 `(not set)` only with richer evidence, and monitoring rather than speculative repair of legacy `/en/` indexing. `block.md` also remains current: Drive analytics are readable and Cloudflare remains intentionally disabled pending a supported read-only path.
+Today's report is classified **eBPF-centered**. After publication the rolling archive becomes **2 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 4**. That is still short of the eventual eBPF share and still at the pure-Agent cap for a small archive, so the next run should remain in the active eBPF series.
 
-## Uncertainty and next evidence
+The technical SEO audit did not justify an unrelated implementation change. The directly coupled SEO work is the normal addition of the bilingual report to the Daily Report indexes and its generated canonical, hreflang, Open Graph, Article metadata, and internal-link output. `plan.md` needs no new action because its existing follow-ups already cover analytics history, GA4 `(not set)`, legacy `/en/` monitoring, SEO-skill migration, and Cloudflare. `block.md` also remains current.
+
+## Validation and self-review
+
+The report was checked against the current Daily Report skill and its required reader path: a concrete shared-hook scenario, primary-source mechanism comparison, a non-trivial gap, three developed directions with explicit Gap / Mechanism / Delta / Artifact / Evaluation / Academic value / Production value / Failure condition fields, and a reader-facing conclusion boundary describing evidence that would change the thesis.
+
+The research self-review specifically rejects "another dispatcher" as the novelty claim and distinguishes the proposed contract from libxdp/TCX chaining, vBPF virtualization, KRAKENGUARD isolation analysis, Yaksha-Prashna bytecode dependency analysis, and the announced BPFChain tutorial. The SIGCOMM 2026 material is described as an upcoming published program as of the `2026-08-09` source cutoff, not as a completed event.
+
+Repository CI remains authoritative for build and generated-output validation. The PR must pass the pinned SEO-data validator, Daily Report/content checks, static build, link checks, and other expected workflows on its final head before squash merge. The exact production squash commit must then pass `Deploy Static App` and public bilingual page verification before closeout.
+
+## Delivery
+
+The complete daily change is carried by one branch and one non-draft pull request:
+
+- branch: `daily/2026-08-09-ebpf-hook-composition`
+- pull request: `#149`
+
+The pull request contains this operating record, exactly one new bilingual report, both report-index updates, the status refresh, and the series-continuity update. No second closeout PR will be created.
+
+Production verification, exact merge commit, deployment result, public English/Chinese page checks, data coverage, series/topic classification, and any remaining uncertainty belong in the single merged-PR closeout comment required by `DAILY_TASK.md`.
+
+## Decisions and follow-ups
 
 The largest operational uncertainty is data freshness. The next weekly Drive export should show whether `2026-08-03` onward changes the current query/page distribution and whether the report series begins to receive measurable discovery. A richer GA4 export with acquisition and outbound-navigation dimensions is needed before attributing repository or paper movement to a landing page. Additional Search Console weekly windows are needed before any 7-day or 28-day trend claim is valid.
 
 For the report thesis, the most discriminating next evidence is an empirical corpus of real multi-program BPF deployments. If deterministic ordering plus isolation already eliminates most semantic conflicts, a cross-hook composition contract may be unnecessary. If conflicts repeatedly involve return precedence, transformed inputs, shared-state ownership, and coordinated update, the proposed composition layer becomes more strongly justified.
 
-Production verification, exact merge commit, deployment result, public English/Chinese page checks, and any remaining uncertainty belong in the single merged-PR closeout comment required by `DAILY_TASK.md`.
+The preferred next Daily Report question is whether a stateful eBPF application can be upgraded transactionally across programs, links, maps, pinned state, userspace controllers, and rollback after partial failure.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -9,93 +9,59 @@
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
 - Last completed daily run: `2026-08-08`
 - Last verified data window: `2026-07-27` through `2026-08-02`
-- Latest daily record: `2026-08-08`
+- Latest daily record: `2026-08-09`
 - Last public-change pull request: recorded in the `2026-08-08` daily record and merged-PR closeout comment
-- Last verified production deployment from a daily run: recorded in the merged-PR closeout comment
+- Last verified production deployment from a daily run: recorded in the merged `2026-08-08` pull-request closeout comment
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
+
+The `2026-08-09` daily record and content are in the current daily change. Per `DAILY_TASK.md`, exact merge/deployment/public verification is recorded in the merged-PR closeout comment, and the next daily run promotes those verified closeout facts into this summary.
 
 ## Current Daily Report mix
 
-The public archive contains three Daily Reports after the `2026-08-08` run:
+The archive contains four Daily Reports with the `2026-08-09` publication:
 
-- eBPF-centered: **1 of 3**
+- eBPF-centered: **2 of 4**
+  - `/research/ebpf-hook-composition-contract/`
   - `/research/userspace-ebpf-runtime-contract/`
-- pure Agent-centered: **2 of 3**
+- pure Agent-centered: **2 of 4**
   - `/research/agent-trace-evidence-budget/`
   - `/research/parallel-agent-effect-serializability/`
-- adjacent systems: **0 of 3**
+- adjacent systems: **0 of 4**
 
-The archive is still outside the long-run target. New reports should continue to
-strongly favor eBPF. The active series is **eBPF Runtime, Extensibility, and
-Composition**. The rolling target is 5–7 eBPF-centered reports per 10 published
-reports and at most 1–2 pure Agent reports per 10.
+The archive is still outside the long-run target. New reports should continue to strongly favor eBPF. The active series is **eBPF Runtime, Extensibility, and Composition**. The rolling target is 5–7 eBPF-centered reports per 10 published reports and at most 1–2 pure Agent reports per 10.
 
 ## Current signals
 
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly Drive export available and verified
-- Google Search Console: six dimension exports for one weekly window available and verified
+- Google Analytics 4: weekly Drive export available and verified, but the latest configured export lags the current finalizable date
+- Google Search Console: six dimension exports for one weekly window available and verified, but the latest configured export lags the current finalizable date
 - Cloudflare: not configured
 
-The verified Drive folder currently covers one complete Search Console and GA4
-weekly date window, `2026-07-27` through `2026-08-02`. Search Console has date,
-search-appearance, device, country, page, and query dimensions; GA4 has an organic
-landing-page export. The configured source cadence is weekly, so `2026-08-03`
-through `2026-08-05` are not yet represented even though those dates are beyond
-the configured three-day finalization lag. Previous-period and 28-day comparisons
-remain unavailable until more weekly windows accumulate.
+The verified Drive folder still covers one complete Search Console and GA4 weekly date window, `2026-07-27` through `2026-08-02`. Search Console has date, search-appearance, device, country, page, and query dimensions; GA4 has an organic landing-page export. With the configured three-day finalization lag, data through `2026-08-06` is now old enough to be finalizable, so `2026-08-03` through `2026-08-06` are currently unrepresented in the enabled Google exports. Previous-period and 28-day comparisons remain unavailable until more weekly windows accumulate.
 
-For `2026-07-27` through `2026-08-02`, Search Console reports 486 clicks and
-55,021 impressions, for a weighted CTR of 0.883% and an impression-weighted
-average position of approximately 8.21. Desktop accounts for about 92.9% of
-impressions in the current window. Search appearance includes translated-result
-traffic, and country rows show broad international discovery, which reinforces
-the value of maintaining first-class English and Chinese variants.
+For `2026-07-27` through `2026-08-02`, Search Console reports 486 clicks and 55,021 impressions, for a weighted CTR of 0.883% and an impression-weighted average position of approximately 8.21. Desktop accounts for about 92.9% of impressions in the current window. Search appearance includes translated-result traffic, and country rows show broad international discovery, which reinforces the value of maintaining first-class English and Chinese variants.
 
-The GA4 organic landing-page export shows tutorials and CUDA/GPU material among
-the strongest known landing pages. Its largest row is `(not set)` with low
-engagement, which remains a measurement-quality problem. The current export is
-not sufficient to make site-wide conversion or outbound-action claims.
+The GA4 organic landing-page export shows tutorials and CUDA/GPU material among the strongest known landing pages. Its largest row is `(not set)` with low engagement, which remains a measurement-quality problem. The current export is not sufficient to make site-wide conversion or outbound-action claims.
 
 ## Current technical baseline
 
-The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
-structured data, legacy redirect stubs, and HTTP audit artifacts. Production
-deploys through the `Deploy Static App` workflow.
+The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through the `Deploy Static App` workflow.
 
-The `2026-08-08` technical audit did not establish a new crawl, canonical,
-hreflang, structured-data, redirect, or performance defect that justified a
-separate implementation change. Public search still exposes legacy `/en/` URLs,
-but the current build intentionally emits canonical redirect stubs for those
-paths; this remains an observation to monitor rather than a proven new defect.
+The `2026-08-09` technical audit did not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, or performance defect that justified an unrelated implementation change. Public search still exposes legacy `/en/` URLs, but the current build intentionally emits canonical redirect stubs for those paths; this remains an observation to monitor rather than a proven new defect. The only coupled SEO work in the daily change is the normal bilingual Daily Report index and generated page metadata for the new report.
 
-The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Newer upstream commits restructure
-the skill package and remove interfaces that the current consuming contract
-still names, including `change-seo-site` and `scripts/validate_seo_data.py`.
-Advancing the pointer therefore requires a coordinated consumer migration rather
-than an isolated submodule bump.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` currently points at `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`, but that newer layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer therefore still requires a coordinated consumer migration rather than an isolated submodule bump.
 
 ## Current focus
 
-1. Continue the **eBPF Runtime, Extensibility, and Composition** Daily Report
-   series. The preferred next question is how multiple independent eBPF
-   extensions should share one hook safely.
-2. Publish one new eBPF-centered Daily Report per scheduled run until the rolling
-   mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer
-   exceed the 1–2 per 10 cap.
-3. Use the verified weekly GA4 and Search Console exports in every run; never mark
-   them unavailable while the configured folder remains readable.
+1. Continue the **eBPF Runtime, Extensibility, and Composition** Daily Report series. After the hook-composition report, the preferred next question is whether a stateful eBPF application can be upgraded transactionally across programs, links, maps, pinned state, userspace controllers, and rollback.
+2. Continue publishing eBPF-centered Daily Reports until the rolling mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer exceed the 1–2 per 10 cap.
+3. Use the verified weekly GA4 and Search Console exports in every run; explicitly mark their lag relative to the current finalizable date instead of treating missing days as zero.
 4. Accumulate enough weekly history for previous-period and 28-day comparisons.
-5. Investigate the GA4 `(not set)` landing-page row with a richer export before
-   making a measurement or content change.
-6. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows
-   canonical redirect stubs are causing measurable harm.
-7. Migrate the consuming SEO contract to the newer `seo-skill` layout before
-   updating the submodule pointer.
+5. Investigate the GA4 `(not set)` landing-page row with a richer export before making a measurement or content change.
+6. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows canonical redirect stubs are causing measurable harm.
+7. Migrate the consuming SEO contract to the newer `seo-skill` layout before updating the submodule pointer.
 8. Add Cloudflare evidence when a supported read-only path exists.
 
-This file is the current verified summary. Detailed history belongs in
-`.github/seo-data/daily/` and the merged daily pull requests.
+This file is the current verified summary. Detailed history belongs in `.github/seo-data/daily/` and the merged daily pull requests.

--- a/docs/research/ebpf-hook-composition-contract.md
+++ b/docs/research/ebpf-hook-composition-contract.md
@@ -1,0 +1,227 @@
+---
+date: 2026-08-09
+title: "eBPF Hook Composition: Sharing One Hook Safely"
+description: "eBPF hook composition needs more than execution order. This report compares kernel chains, libxdp, isolation work, and a testable composition contract."
+tags:
+  - Daily Report
+  - eBPF
+  - Runtime Systems
+  - Composition
+  - Linux
+research_question: "What semantics should a runtime expose when multiple independently developed eBPF programs share one hook, mutate common state, return competing outcomes, and evolve independently?"
+source_cutoff: 2026-08-09
+status: daily-report
+---
+
+# eBPF Hook Composition: Sharing One Hook Safely
+
+Imagine one ingress path shared by three independently managed eBPF programs. A security program can drop traffic. A telemetry program wants to observe every packet. A traffic-control program rewrites metadata before forwarding. All three are individually valid, all three can attach, and all three may be correct in isolation. The hard question begins after that: if they share one hook, what does the combined system mean?
+
+This is the **eBPF hook composition** problem. Execution order matters, but order alone does not answer whether a drop is final, whether later programs see original or modified data, whether two programs can safely write the same map, or whether replacing one member can expose an unsafe intermediate chain. Linux already has several useful multi-program attachment models, yet those models encode different answers to these questions.
+
+<!-- more -->
+
+The conclusion of this report is that **safe multi-program eBPF needs a composition contract, not only a dispatcher**. Such a contract should make four things explicit: what each program can affect, how intermediate effects are exposed, how outcomes are combined, and which generation of the whole composition is active. Existing work on dispatchers, isolation, static analysis, and virtualization provides important pieces. The missing layer is a machine-checkable protocol that binds those pieces to attachment and update semantics.
+
+This report continues the [Daily Report on first-class userspace eBPF runtimes](https://eunomia.dev/research/userspace-ebpf-runtime-contract/). That report argued that an eBPF runtime needs explicit attachment, capability, state, and lifetime semantics above the ISA. Once several extensions share one attachment point, the same requirement becomes a composition problem.
+
+## eBPF hook composition already exists, but not as one contract
+
+Linux does not have one universal rule for "run several BPF programs here." Different hook families deliberately expose different composition semantics because their underlying operations are different.
+
+The [`BPF_SK_LOOKUP` documentation](https://docs.kernel.org/bpf/prog_sk_lookup.html) is a good example. Multiple programs can attach to the same network namespace and execute in attachment order. But the final result is not simply the return value of the last program. A program may select a socket with `bpf_sk_assign()`. If several programs select sockets and return `SK_PASS`, the last valid selection wins. A `SK_DROP` only determines the result when no program returned `SK_PASS` with a valid socket. The hook therefore has an explicit outcome algebra involving both verdicts and an accumulated selected object.
+
+[`BPF_PROG_TYPE_CGROUP_SOCKOPT`](https://docs.kernel.org/bpf/prog_cgroup_sockopt.html) exposes a different model. In a cgroup hierarchy, programs execute from the child upward to its ancestors. A later program sees modifications made to the shared `bpf_sockopt` context by an earlier program. A return value of `0` rejects the operation, while `1` continues. Here composition includes both ordered context transformation and a gate on continuation.
+
+[HID-BPF](https://docs.kernel.org/hid/hid-bpf.html) makes the mutation issue even clearer. Several programs can attach to one device for most HID-BPF attachment types. Programs execute one after another on the same data buffer, and later programs see the modified data rather than the original input. A negative return discards the event. The API supports inserting a program at the front with `BPF_F_BEFORE`, but that flag does not tell an independently developed program whether it is semantically safe to consume another program's rewritten buffer.
+
+The networking ecosystem has built additional composition machinery above kernel primitives. [`libxdp`](https://github.com/xdp-project/xdp-tools/blob/master/lib/libxdp/README.org) can load multiple XDP programs on one interface through a dispatcher. Component programs have run priorities and chain-call actions. A program's return code can either continue to the next component or terminate the chain. This is much better than accidental replacement, but it still assumes that the programs agree on the meaning of shared packet mutations, maps, and return behavior.
+
+Modern TCX goes further on lifecycle and ordering. The [Eunomia TCX tutorial](https://eunomia.dev/tutorials/50-tcx/) demonstrates BPF link ownership, relative placement with `BPF_F_BEFORE` and `BPF_F_AFTER`, `BPF_F_REPLACE`, chain revision tracking, and return codes such as `TCX_NEXT`, `TCX_PASS`, and `TCX_DROP`. TCX shows that explicit relative ordering and revision-aware attachment can be part of a production interface instead of loader convention.
+
+These mechanisms are all reasonable for their hooks. Their differences are the important evidence.
+
+| Mechanism | Ordering | What later programs observe | How outcomes combine | Shared state / update semantics |
+| --- | --- | --- | --- | --- |
+| `BPF_SK_LOOKUP` | attachment order | selected socket can be carried forward | last valid selection can win; drop is conditional on no valid selection | hook-specific |
+| cgroup sockopt | child to parent | earlier context mutations | return controls rejection/continuation | cgroup/socket local storage available |
+| HID-BPF | list order, optional front insertion | same mutable data buffer | negative error discards event | link lifetime; shared mutation is visible |
+| libxdp | run priority | packet after previous components | chain-call actions decide continuation | dispatcher-managed component set |
+| TCX | relative before/after ordering | packet and `__sk_buff` state | explicit terminal and non-terminal return codes | BPF links, replacement, revision-aware changes |
+
+There is no contradiction here. A socket selector, a packet classifier, a HID event transformer, and a socket-option filter should not necessarily share one return-value rule. The problem is that the rule is mostly implicit in the hook API rather than represented as a composition contract that tools can reason about.
+
+## Ordering is only one axis of eBPF hook composition
+
+A common response to multi-program conflicts is to add priorities or an explicit chain. That solves one real problem: deterministic order. It does not solve four other kinds of interaction.
+
+### The hook needs an outcome algebra
+
+Consider a security filter followed by a telemetry program. If the security filter returns a deny verdict, should telemetry still execute so it can record the denied event? If it executes, may its return value accidentally override the deny? Now replace telemetry with a socket-selection program. "First wins" and "last wins" are both plausible but have very different meaning.
+
+Linux already answers these questions on a per-hook basis. `BPF_SK_LOOKUP` accumulates a selected socket with documented precedence rules. TCX distinguishes `TCX_NEXT` from terminal outcomes. libxdp lets component metadata declare which XDP actions should continue. These are small algebras, not just integer return values.
+
+A general composition interface should therefore identify the hook's outcome categories and the resolver that combines them. A loader should be able to distinguish "terminal deny," "continue," "select resource," "redirect," and "transform then continue" rather than treating every program as a function that returns an opaque integer.
+
+### Mutation visibility needs to be intentional
+
+HID-BPF explicitly documents that every program works on the same data buffer and later programs do not have the original data unless they preserve it themselves. Cgroup sockopt similarly propagates context modifications to later programs.
+
+This is powerful because it enables pipelines. It is also a hidden dependency. A parser written against the original packet or report can silently become wrong when an earlier extension rewrites a field. Conversely, forcing every program to see an immutable snapshot would prevent useful staged transformations and add copying cost.
+
+The composition contract therefore needs a visibility choice. A program may require the original view, the previous program's output, or a named derived view. If the runtime cannot provide the requested view, attachment should fail before production traffic reaches the chain.
+
+### Shared maps are a concurrency contract, not only a data structure
+
+Linux allows maps to be shared deliberately. The [`BPF_MAP_TYPE_CGROUP_STORAGE` documentation](https://docs.kernel.org/bpf/map_cgroup_storage.html) notes that since Linux 5.9 storage can be shared by multiple programs and that there is no implicit synchronization when programs on different CPUs access it. The user must provide synchronization where necessary.
+
+That is appropriate at the primitive level. For independently managed extensions, however, "both programs can open this map" is not enough information. One program may assume single-writer counters, another may reset entries, and a third may treat an entry as a lease. The verifier can prove memory safety without proving that those state-machine assumptions compose.
+
+A composition contract should at least distinguish private state, shared read-only state, shared state with one writer, and shared multi-writer state with an explicit synchronization protocol. Richer state invariants can remain optional, but ownership cannot be invisible.
+
+### Updating one member is a whole-chain event
+
+Link-based attachment makes individual program lifetime manageable. Relative ordering makes insertion predictable. Revision checking, as exposed by TCX, helps detect concurrent modifications. The remaining issue is semantic atomicity.
+
+Suppose a security program changes from version A to version B and the new version expects a companion metadata producer to run first. Replacing only the security program can create a period where B executes against the old composition. Even if each individual `BPF_LINK_CREATE` or replace operation is atomic, the desired multi-program configuration may require several linked changes.
+
+This is why composition state needs a generation. The runtime should be able to validate the complete proposed chain, construct it off the hot path where possible, and commit a new generation only if the currently active generation still matches the expected revision.
+
+## Recent work solves important pieces, not the whole composition protocol
+
+The multi-program problem is active research rather than an empty space.
+
+[vBPF, presented at OSDI 2026](https://www.usenix.org/conference/osdi26/presentation/zhang-jing), targets multi-tenant eBPF contention. It late-binds logical programs to physical hooks, attributes events to tenants, uses an O(1) dispatcher, and adds compiler-assisted state isolation. This is strong evidence that simple linear native attachment is insufficient when independent tenants share infrastructure. Its core problem is virtualization and tenant isolation, not a general contract for the semantic interaction of programs that intentionally operate on the same event.
+
+[KRAKENGUARD, presented at NSDI 2026](https://www.usenix.org/conference/nsdi26/presentation/patel), uses symbolic execution in a trusted userspace manager to enforce policies over helper use, memory access, return values, and cross-program interference. Its XDP-as-a-Service use case demonstrates that load-time analysis can reject unsafe combinations before they share a host interface. This is directly useful for composition. It still leaves the attachment layer to decide what the allowed composition is supposed to mean.
+
+[Yaksha-Prashna](https://arxiv.org/abs/2602.11232) analyzes eBPF bytecode network functions for conformance and dependencies on other bytecodes. That matters because a future composition system should infer effects when source annotations are unavailable. It also means that "statically analyze two eBPF programs for conflicts" is no longer a sufficient research thesis by itself. The open question is how such analysis becomes enforceable runtime state.
+
+The scheduled [BPFChain tutorial at ACM SIGCOMM 2026](https://conferences.sigcomm.org/sigcomm/2026/ttbpfchain/) is another useful signal. Its published program explicitly calls out execution-order conflicts, return-value overrides, shared-map races, a trampoline chainer, and chain monitoring. As of this report's August 9 source cutoff, SIGCOMM 2026 is still upcoming, so this is evidence from the announced tutorial program rather than a completed event. It nevertheless makes one point clear: a new dispatcher alone is not a novel answer to multi-program eBPF.
+
+The residual problem sits between these efforts. We have mechanisms to chain programs, isolate tenants, infer effects, and manage individual links. We do not yet have a widely used object that says, in machine-readable form, **which effects are allowed to compose, which result resolver applies, which state is shared, and which complete generation is active**.
+
+## A composition contract should make effects and dependencies explicit
+
+A useful contract does not need to replace existing hook APIs. It can sit above them and compile down to TCX, libxdp, cgroup attachment, kernel links, or userspace runtimes such as [bpftime](https://github.com/eunomia-bpf/bpftime).
+
+A minimal per-program manifest could describe:
+
+- the hook and attach target it expects;
+- context fields or packet regions it may read and write;
+- helper classes and externally visible side effects it may invoke;
+- maps it reads or writes and the ownership mode of each map;
+- whether it requires the original event, the previous program's result, or a named transformed view;
+- relative ordering constraints such as `after: parser` or `before: terminal-policy`;
+- result categories it may produce and whether any are terminal;
+- failure behavior and an optional execution budget.
+
+The hook adapter would add the native outcome algebra. For XDP it might map XDP actions into terminal and continuing categories. For TCX it can use the existing `TCX_NEXT` versus terminal behavior. For `BPF_SK_LOOKUP` it must model both the verdict and the selected socket. For HID-BPF it must model the shared mutable buffer and event-discard rule.
+
+Some manifest facts can be authored. Others should be inferred from bytecode, BTF, map references, helper calls, or program analysis. The important distinction is that analysis is evidence for the contract, not the contract itself. The loader should compare declared and inferred effects, report contradictions, and reject a composition when it cannot establish the requested guarantees.
+
+## Where current work is still weak
+
+### Hook-specific semantics are difficult to compare or reuse
+
+Kernel documentation defines semantics precisely within individual hook families, but an operator managing dozens of BPF components still has to understand each family manually. There is no common vocabulary for "terminal result," "selected object," "shared mutation," or "original-view requirement" that a deployment tool can validate across hook types.
+
+The missing evidence is a corpus of real multi-program deployments showing which semantic dimensions recur across XDP, TCX, cgroup, tracing, HID, and userspace backends. If every hook needs entirely bespoke rules, a common contract may collapse into documentation metadata. If a small set of effect and outcome patterns covers most deployments, the abstraction is useful.
+
+### Isolation analysis is not yet the attachment protocol
+
+KRAKENGUARD can reason about helper use, memory accesses, return values, and interference. Yaksha-Prashna can expose conformance and bytecode dependencies. Those capabilities are stronger than simple declaration files.
+
+What remains weak is the path from analysis result to live composition. An analyzer may determine that program B reads a field written by program A, but the attachment system still needs to decide whether that dependency requires `A before B`, whether B may run after A returns a terminal result, and whether an update can temporarily violate the dependency.
+
+This separation suggests a systems boundary: analysis should produce evidence; a composition protocol should turn that evidence into enforceable attachment and generation rules.
+
+### Revision-aware links do not automatically provide transactional composition
+
+TCX is a strong counterexample to the claim that BPF attachment lacks ordering or revision control. It has relative ordering, replacement, links, and expected revisions. The research gap is narrower: how should a *set* of programs, state contracts, and result-resolution policy change as one semantic unit?
+
+A useful experiment must inject failures between several coordinated updates. If ordinary TCX or another existing mechanism can already preserve every required invariant without a new bundle abstraction, then a versioned composition generation is unnecessary.
+
+### Shared-state correctness remains mostly outside verifier scope
+
+The verifier can establish many safety properties about one program. Map types and locks provide mechanisms for concurrent access. Fine-grained isolation systems can restrict which state a program may touch.
+
+None of those automatically proves that two independently designed state machines agree on ownership, reset behavior, epochs, or update ordering. The composition problem therefore extends beyond memory safety into protocol compatibility. The practical question is how much of that protocol can be captured without recreating a general-purpose formal specification language.
+
+## Promising directions with academic and production value
+
+### A typed composition manifest backed by effect inference
+
+**Gap.** Deployment systems can order programs, and analysis systems can discover some program effects, but the two are not connected by a portable attachment contract.
+
+**Mechanism.** Define a compact manifest with typed reads, writes, map ownership, outcome categories, visibility requirements, and partial-order constraints. Use BTF, ELF metadata, helper-call inspection, and optional symbolic or abstract interpretation to infer an effect summary from the compiled program. The loader checks declared effects against inferred effects and solves the partial order before attaching anything.
+
+**Delta.** This is not another dispatcher and not another standalone analyzer. libxdp or TCX can remain the execution mechanism; KRAKENGUARD- or Yaksha-Prashna-style analysis can remain the evidence producer. The new artifact is the machine-checkable contract between analysis and attachment.
+
+**Artifact.** A schema plus a libbpf-based loader with adapters for TCX and libxdp first, followed by cgroup hooks and a userspace adapter for bpftime. A small compiler plugin could emit optional source-derived effect metadata.
+
+**Evaluation.** Build a corpus of independently developed observability, security, and networking programs. Form valid and invalid pairs and triples. Measure whether the system detects write/write conflicts, missing ordering dependencies, map-ownership mismatches, and undeclared side effects. Report false rejection and false acceptance rates separately. Measure attach-time analysis cost and steady-state overhead, which should be close to the native backend after the composition has been validated.
+
+**Academic value.** The central question is whether an effect system for eBPF composition can be expressive enough for real programs while remaining decidable and backend-independent.
+
+**Production value.** Operators get a pre-deployment answer to "can these two independently shipped programs safely coexist on this hook?" instead of learning through traffic loss or policy bypass.
+
+**Failure condition.** The idea fails if annotations dominate developer effort, inference produces too many false conflicts, or most useful programs require hook-specific escape hatches that erase the common type system.
+
+### Hook adapters with explicit outcome algebras
+
+**Gap.** Every multi-program hook has return values, but those return values do not have one composition meaning. Flattening them into generic priorities can silently change security or routing behavior.
+
+**Mechanism.** Give each hook adapter a typed result model. A small common vocabulary could include `continue`, `deny`, `select`, `redirect`, `transform`, and `terminal`, while the adapter keeps hook-specific payloads such as a selected socket. A composition plan declares which resolver applies. The planner rejects combinations where two terminal or stateful results are ambiguous unless the operator supplies an explicit resolver.
+
+**Delta.** Existing chain mechanisms determine which program runs next. This mechanism makes the *meaning of the combined result* explicit and testable. It should compile to native return conventions rather than introduce a second packet-processing runtime when the kernel already has suitable semantics.
+
+**Artifact.** Hook adapters for `BPF_SK_LOOKUP`, TCX, XDP/libxdp, cgroup sockopt, and HID-BPF, plus a test harness that runs the same abstract composition cases against native kernel behavior.
+
+**Evaluation.** Generate permutations of policy, telemetry, transformation, selection, and redirect programs. Compare the declared outcome against the observed kernel outcome under each permutation. Include malicious and accidental return-value overrides. Measure adapter overhead and, more importantly, whether the model catches semantic ambiguity before attach.
+
+**Academic value.** The research problem is to find a small algebra that preserves enough hook-specific behavior to be useful without pretending that all BPF hooks are identical.
+
+**Production value.** Security and networking teams can inspect why one result wins and can reject a deployment where an observability or routing component would accidentally weaken policy.
+
+**Failure condition.** If preserving native semantics requires a completely unique algebra per hook with no reusable properties, the abstraction should remain hook-local instead of becoming a cross-hook layer.
+
+### Versioned composition generations
+
+**Gap.** Individual BPF links can be replaced safely, and TCX exposes revision-aware chain changes, but a semantic composition may include several programs, ordering constraints, state contracts, and one result resolver that must evolve together.
+
+**Mechanism.** Represent the active composition as a generation object. Build the next generation off-path, validate all members and dependencies, resolve ordering, prepare compatible maps or state views, then commit using compare-and-swap against the expected current generation. If preparation or validation fails, the old generation remains active. If the backend cannot swap a complete chain atomically, the adapter must expose that limitation rather than claiming transactional behavior.
+
+**Delta.** This proposal does not solve arbitrary stateful eBPF application upgrade, which is the next question in this Daily Report series. Its scope is narrower: make the *membership and semantics of one shared hook* a coherent versioned object.
+
+**Artifact.** A userspace composition manager with a TCX prototype first because TCX already exposes ordering and revision concepts, then a libxdp dispatcher adapter. Record generation IDs, member program/link IDs, effect contracts, and resolver choice in an inspectable control-plane object.
+
+**Evaluation.** Repeatedly add, remove, reorder, and replace programs while traffic or events exercise the hook. Inject process crashes and failures between every preparation step. Define safety invariants such as "deny policy is never absent," "parser version and consumer version match," and "no old writer runs with new map layout." Measure any interruption window, rollback time, throughput impact, and the number of intermediate invalid compositions observed.
+
+**Academic value.** The question is whether transactional configuration can be layered over heterogeneous BPF attachment mechanisms without kernel changes, and where kernel support becomes necessary.
+
+**Production value.** Fleet operators can roll out independent eBPF components without turning every chain update into a hand-coordinated maintenance operation.
+
+**Failure condition.** If current link and revision primitives already provide the required multi-object atomicity with a thin userspace wrapper, then this should remain an engineering library rather than a new systems abstraction.
+
+## The practical architecture is a planner over existing mechanisms
+
+The strongest design is probably not a universal mega-dispatcher. It is a planner and contract layer that reuses the best native primitive for each hook.
+
+For TCX, the planner can use native links, relative ordering, and revisions. For XDP, it can compile a validated plan into a libxdp dispatcher. For cgroup hooks, it can respect hierarchy and hook-specific return semantics. For HID-BPF, it can reject a program that requires the original event if an earlier transformer destroys that view. In userspace runtimes such as bpftime, the same contract can drive a local dispatcher and capability model even though the physical attachment mechanism is different.
+
+This architecture also gives observability a stable unit. Instead of merely listing program IDs, tooling can report a composition generation, its declared dependencies, which program terminated an event, which shared-state contract is active, and whether the running chain still matches the validated plan.
+
+That matters because composition failures often look like ordinary application failures. A packet disappears, a syscall is rejected, or an input event changes shape. Without a first-class composition identity, an operator has to reconstruct the chain from several independent loaders and infer which interaction caused the behavior.
+
+## What would change this conclusion?
+
+Three kinds of evidence would weaken the case for a new eBPF hook composition contract.
+
+First, an existing production mechanism could already provide a cross-hook, machine-readable model of program effects, outcome resolution, shared-state ownership, ordering dependencies, and versioned whole-chain updates. In that case the right work is adoption and conformance testing, not another abstraction.
+
+Second, a broad empirical study could show that independently managed eBPF programs almost never have semantic conflicts once deterministic ordering and memory isolation are provided. That would suggest the remaining contract adds complexity for rare failures.
+
+Third, a prototype may show that effect inference is too imprecise or that transactional composition requires so much copying, pausing, or backend-specific code that operators are better served by explicit per-hook managers.
+
+The evidence available today points the other way. Linux already exposes multiple distinct composition semantics; libxdp and TCX make multi-program chains operationally practical; vBPF and KRAKENGUARD show that multi-tenant coexistence needs more than the classic verifier; Yaksha-Prashna shows that bytecode dependencies can be analyzed; and the announced BPFChain material treats multi-program conflict as a production discipline. The next missing step is to connect those pieces into one testable statement of what a shared hook is allowed to mean.

--- a/docs/research/ebpf-hook-composition-contract.zh.md
+++ b/docs/research/ebpf-hook-composition-contract.zh.md
@@ -1,0 +1,216 @@
+---
+date: 2026-08-09
+title: "多个 eBPF 程序如何安全共享同一个 Hook？"
+description: "多个独立 eBPF 程序共享同一 hook 时，执行顺序只是第一步。本文比较 Linux 多程序链、libxdp、vBPF 与 KRAKENGUARD，分析返回值、状态共享、权限、更新和故障语义，并提出可验证、可版本化的组合契约，让独立程序在加载前声明影响范围并安全更新整条链。"
+tags:
+  - Daily Report
+  - eBPF
+  - Runtime Systems
+  - Composition
+  - Linux
+research_question: "多个独立开发的 eBPF 程序共享同一 hook、修改共同状态、产生竞争结果并各自升级时，运行时应该暴露哪些可验证的组合语义？"
+source_cutoff: 2026-08-09
+status: daily-report
+---
+
+# 多个 eBPF 程序如何安全共享同一个 Hook？
+
+设想同一个 ingress 路径上同时挂着三个由不同团队维护的 eBPF 程序。安全程序可以丢包，遥测程序希望看到每一个包，流量控制程序会修改元数据再继续转发。三个程序单独看都通过 verifier，也都能正常 attach。真正困难的问题出现在它们同时工作之后：这三个程序组成的系统到底应该是什么语义？
+
+这就是 **eBPF hook 组合** 问题。执行顺序当然重要，但顺序本身无法回答这些问题：一次 `drop` 是否必须终止后续执行，后面的程序看到的是原始数据还是已经修改的数据，两个程序能不能安全写同一个 map，以及替换其中一个程序时是否可能短暂出现一个不安全的中间状态。
+
+<!-- more -->
+
+本文的判断是：**多程序 eBPF 要做到可独立部署而且安全共存，需要的是组合契约，而不只是 dispatcher。** 这个契约至少要把四件事写清楚：每个程序能产生什么影响，中间结果如何传递，多个返回结果如何合并，以及当前生效的是整套组合的哪个版本。dispatcher、隔离、静态分析、虚拟化和 BPF link 都已经提供了重要机制，但还缺少一个把这些机制绑定到 attach 与更新语义上的机器可检查接口。
+
+这也是上一篇[用户态 eBPF 运行时报告](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/)的直接延续。上一篇讨论的是单个扩展进入不同运行时之后，attach、能力、状态和生命周期如何显式化。多个扩展共享同一个 attach point 后，这些问题会进一步变成组合问题。
+
+## Linux 已经支持多程序组合，但每个 Hook 的规则并不一样
+
+Linux 并不存在一条通用规则来定义“多个 BPF 程序一起运行”。不同 hook 的底层操作不同，所以它们有意采用不同的组合语义。
+
+[`BPF_SK_LOOKUP` 文档](https://docs.kernel.org/bpf/prog_sk_lookup.html)是一个很直接的例子。多个程序可以挂到同一个 network namespace，并按 attach 顺序执行。但最后结果并不是简单取最后一个程序的 return value。程序可以通过 `bpf_sk_assign()` 选择 socket。如果多个程序都选择了 socket 并返回 `SK_PASS`，最后一次有效选择生效；如果某个程序返回 `SK_DROP`，只有在没有任何程序通过 `SK_PASS` 提供有效 socket 时才会导致 lookup 失败。这里实际存在的是“verdict 加累积选中对象”的结果合并规则。
+
+[`BPF_PROG_TYPE_CGROUP_SOCKOPT`](https://docs.kernel.org/bpf/prog_cgroup_sockopt.html)又是另一套模型。在 cgroup 层级中，程序会从子 cgroup 向父 cgroup 执行。前一个程序对 `bpf_sockopt` context 的修改会被后面的程序看到。返回 `0` 表示拒绝操作，返回 `1` 表示继续执行下一段 BPF。这里的组合既包含有序的数据变换，也包含是否继续的控制结果。
+
+[HID-BPF](https://docs.kernel.org/hid/hid-bpf.html)把共享修改的问题写得更明确。除少数 attachment type 外，同一个设备可以挂多个程序。它们依次操作同一块数据 buffer，后一个程序看到的是已经修改的数据，而不是原始输入。返回负数会丢弃整个事件。接口允许用 `BPF_F_BEFORE` 把程序插到最前面，但这个 flag 并不能告诉一个独立开发的程序：它是否真的能正确处理前面程序重写过的数据。
+
+网络生态还在 kernel primitive 之上增加了自己的组合机制。[`libxdp`](https://github.com/xdp-project/xdp-tools/blob/master/lib/libxdp/README.org)通过 dispatcher 让多个 XDP 程序共享一个 interface。每个 component 有运行优先级和 chain-call action。一个程序的 return code 可以决定继续执行下一个程序，或者直接终止链。这比互相覆盖 attach 好很多，但它仍然默认各个程序已经对 packet 修改、map 使用和结果语义达成一致。
+
+新的 TCX 在生命周期和顺序上更进一步。[Eunomia 的 TCX 教程](https://eunomia.dev/zh/tutorials/50-tcx/)展示了 BPF link 所有权、`BPF_F_BEFORE` / `BPF_F_AFTER` 相对排序、`BPF_F_REPLACE`、chain revision，以及 `TCX_NEXT`、`TCX_PASS`、`TCX_DROP` 这类明确的返回语义。TCX 说明相对顺序和 revision-aware attach 完全可以成为正式接口，而不是 loader 之间的约定。
+
+这些设计没有谁是“错”的。socket 选择、packet 分类、HID 数据变换和 socket option 过滤，本来就不应该强行使用同一套结果合并规则。真正值得注意的是，它们的差异大多隐藏在各自 hook 的 API 和文档里，没有被表示成可以让部署工具统一检查的组合契约。
+
+| 机制 | 执行顺序 | 后续程序看到什么 | 结果如何合并 | 状态与更新 |
+| --- | --- | --- | --- | --- |
+| `BPF_SK_LOOKUP` | attach 顺序 | 可能继承已选择的 socket | 最后的有效 socket 选择可能覆盖之前选择，drop 还受是否存在有效选择影响 | hook 专用规则 |
+| cgroup sockopt | 子 cgroup 到父 cgroup | 前面程序修改后的 context | return 控制拒绝或继续 | 可使用 cgroup/socket local storage |
+| HID-BPF | list 顺序，可插到最前 | 同一个可修改 buffer | 负数终止并丢弃事件 | link 生命周期，共享修改可见 |
+| libxdp | run priority | 前面 component 处理后的 packet | chain-call action 决定继续还是终止 | dispatcher 管理 component set |
+| TCX | before/after 相对顺序 | packet 与 `__sk_buff` 状态 | `TCX_NEXT` 与终止类结果明确区分 | BPF link、replace、revision-aware 变更 |
+
+## 执行顺序只是 eBPF Hook 组合的一条轴
+
+面对多程序冲突，一个常见做法是增加 priority 或显式 chain。这确实解决了 deterministic ordering，但至少还有四类交互没有被解决。
+
+### Hook 自己需要明确的结果合并规则
+
+假设安全过滤器后面是遥测程序。安全过滤器决定拒绝一次操作后，遥测还要不要运行，以便记录被拒绝的事件？如果继续运行，它的 return value 是否可能把拒绝结果覆盖掉？再把遥测换成 socket selector，“第一个结果赢”和“最后一个结果赢”都讲得通，但安全含义完全不同。
+
+Linux 已经针对不同 hook 回答了这些问题。`BPF_SK_LOOKUP` 有 socket selection 的优先规则；TCX 用 `TCX_NEXT` 把继续执行和终止结果分开；libxdp 允许 component metadata 声明哪些 XDP action 应继续执行。它们本质上都是小型的“结果代数”，而不只是整数返回值。
+
+因此，一个通用组合层不应该把 return value 当作 opaque integer。它至少需要知道 `continue`、`deny`、`select`、`redirect`、`transform`、`terminal` 等结果类别，再由 hook adapter 映射到原生语义。
+
+### 数据修改对后续程序是否可见，必须成为显式选择
+
+HID-BPF 明确规定多个程序操作同一 buffer，后面的程序只能自然看到被前面改过的数据。cgroup sockopt 同样把 context 修改传给后面的程序。
+
+这很有用，因为它可以构成 pipeline。但它同时创建了隐藏依赖。一个 parser 也许只对原始 packet 正确，前面插入一个 rewriter 后就会悄悄产生错误。反过来，如果强制每个程序都看 immutable snapshot，又会破坏很多有价值的 staged transformation，并引入复制成本。
+
+所以组合契约需要表达程序究竟要求哪一种视图：原始输入、上一个程序的输出，或者某个有名字的派生视图。如果运行时无法提供要求的视图，应该在 attach 之前失败，而不是让线上流量帮我们发现问题。
+
+### 共享 Map 是并发协议，不只是共享数据结构
+
+Linux 当然允许多个程序有意共享 map。[`BPF_MAP_TYPE_CGROUP_STORAGE` 文档](https://docs.kernel.org/bpf/map_cgroup_storage.html)指出，从 Linux 5.9 开始 storage 可以被多个程序共享，而且多个 CPU 上的访问没有隐含同步，使用者需要自己处理同步。
+
+这在 primitive 层面是合理的。但对独立部署的扩展来说，“两个程序都能打开这个 map”远远不够。一个程序可能假设自己是唯一 writer，另一个程序可能会 reset entry，第三个程序又把同一 entry 当成 lease。verifier 能证明 memory safety，却不会证明这些状态机假设能组合。
+
+至少需要区分 private state、shared read-only、single-writer shared state、以及带明确同步协议的 multi-writer state。更复杂的 invariant 可以留给上层，但 ownership 不能继续隐含。
+
+### 替换一个程序，实际上可能是整条链的版本切换
+
+BPF link 让单个程序的 lifetime 更容易管理，相对顺序让插入位置更确定，TCX 的 revision checking 还能发现并发修改。剩下的问题是 semantic atomicity。
+
+例如安全程序从 A 版本升级到 B 版本，而 B 依赖一个新版 metadata producer 先运行。如果只原子地 replace 安全程序，B 仍然可能短暂运行在旧 composition 上。即使每一次 `BPF_LINK_CREATE` 或 replace 都是原子的，真正需要上线的配置也可能要求多项变化一起生效。
+
+因此，组合本身需要 generation。运行时应该先验证完整的新链，在 hot path 之外尽可能准备好成员和状态，然后在当前 generation 仍然符合 expected revision 时一次提交。
+
+## 最近的工作已经解决不少问题，但还没有统一成组合协议
+
+多程序 eBPF 并不是一个没人研究的空白方向。
+
+[OSDI 2026 的 vBPF](https://www.usenix.org/conference/osdi26/presentation/zhang-jing)解决 multi-tenant eBPF contention。它把 logical program 到 physical hook 的 binding 延迟到运行时，用 Sniffer 做 tenant attribution，用 O(1) Dispatcher 选择程序，并通过 compiler-assisted 方法隔离状态。这说明多个 tenant 共享基础设施时，简单 linear attach 不够。它主要解决 virtualization 和 tenant isolation，而不是那些本来就要共同处理一个事件的程序应该怎样组合语义。
+
+[NSDI 2026 的 KRAKENGUARD](https://www.usenix.org/conference/nsdi26/presentation/patel)使用 trusted userspace manager 和 symbolic execution，在 load time 检查 helper、memory access、return value 和 cross-program interference。它的 XDP-as-a-Service case 表明，组合在真正 attach 前可以接受相当深入的安全分析。这对组合层很有价值，但 attachment system 仍然要决定“允许的组合到底应该是什么语义”。
+
+[Yaksha-Prashna](https://arxiv.org/abs/2602.11232)直接分析 eBPF bytecode network function 的规范一致性和它对其他 bytecode 的依赖。这一点很重要，因为未来的组合系统不能假设总能拿到源码 annotation。同时它也意味着，单纯提出“静态分析两个 eBPF 程序是否冲突”已经不足以构成新的系统方向。还需要回答分析结果怎样变成可 enforce 的运行时状态。
+
+[ACM SIGCOMM 2026 已公布的 BPFChain tutorial](https://conferences.sigcomm.org/sigcomm/2026/ttbpfchain/)也是一个很直接的信号。它的 program 已经把 execution-order conflict、return-value override、shared-map race、trampoline chainer 和 chain monitoring 列为重点。本文 source cutoff 是 8 月 9 日，而 SIGCOMM 2026 将在 8 月 17 日之后举行，所以这里引用的是已公布的教程计划，而不是把未来活动写成已经完成。它至少说明一件事：再做一个 dispatcher 或 chainer 本身已经不是足够的新意。
+
+剩余的问题在这些工作之间。我们已经有 chain、有 tenant isolation、有 effect analysis、有 individual link lifecycle，但还缺一个被广泛使用的对象，能够机器可读地说明：**哪些影响可以组合，结果使用什么 resolver，共享哪些状态，以及整套组合的哪个 generation 正在运行。**
+
+## 组合契约需要把影响范围和依赖关系显式化
+
+这个契约不需要取代现有 hook API。它可以位于它们上方，再编译成 TCX、libxdp、cgroup attach、kernel link，或者 [bpftime](https://github.com/eunomia-bpf/bpftime) 这样的用户态运行时。
+
+最小的 per-program manifest 可以描述：程序期望的 hook 和 target；它可能读取或写入哪些 context field 或 packet region；它能调用哪些 helper class 和外部 side effect；它读写哪些 map，以及每个 map 的 ownership mode；它要求原始事件、前一程序输出还是某个派生视图；它与其他组件的 `before` / `after` 约束；它可能产生哪些结果类别，以及哪些结果是 terminal；还有 failure behavior 与可选 execution budget。
+
+hook adapter 再补上原生结果语义。XDP adapter 可以把 XDP action 映射成继续与终止类别；TCX 直接利用 `TCX_NEXT` 等已有语义；`BPF_SK_LOOKUP` 则必须同时表示 verdict 和 selected socket；HID-BPF 需要表示共同 buffer 与 event-discard 规则。
+
+manifest 中有些事实可以由开发者声明，有些应该从 bytecode、BTF、map reference、helper call 或 program analysis 中推断。关键区别在于，静态分析只是组合契约的证据来源，不是契约本身。loader 应该比较声明与推断效果，在两者矛盾时报告问题，并在无法建立所要求保证时拒绝 attach。
+
+## 现有研究还缺什么
+
+### 不同 Hook 的组合语义仍然难以比较和复用
+
+kernel documentation 在单个 hook 内往往已经定义得很精确，但维护大量 BPF component 的 operator 仍然需要手工理解每一种 family。现在缺少一个共同词汇去表达“terminal result”“selected object”“shared mutation”“original-view requirement”等概念，让部署工具能跨 hook 检查。
+
+真正需要的下一步证据，是一组真实 multi-program deployment 的 corpus，观察 XDP、TCX、cgroup、tracing、HID 和 userspace backend 到底重复出现哪些语义维度。如果每一个 hook 都需要完全特制的规则，那么通用 contract 只会退化成 documentation metadata。如果少量 effect 和 outcome pattern 能覆盖大多数部署，抽象才站得住。
+
+### 隔离分析还没有成为 Attach 协议
+
+KRAKENGUARD 能分析 helper、memory、return 和 interference，Yaksha-Prashna 能分析 conformance 与 bytecode dependency。这些能力已经比简单的 declaration file 强得多。
+
+问题在于分析结果怎样进入 live composition。分析器可以知道 B 读取 A 写入的字段，但 attach system 还要决定这是否意味着 `A before B`，A 给出 terminal result 后 B 是否仍然应该运行，以及更新过程中能不能短暂违反这个 dependency。
+
+因此可以把边界划得很清楚：analysis 产生 evidence，composition protocol 把 evidence 变成可 enforce 的 attach 和 generation rule。
+
+### Revision-aware Link 还不等于整个组合的事务
+
+TCX 是一个很重要的反例。它说明 BPF 并不缺排序、link ownership 或 revision control。真正较窄的 gap 是：一组程序、状态 contract 和 result resolver 怎样作为一个 semantic unit 一起变化。
+
+好的实验必须在多个 coordinated update 之间注入 failure。如果普通 TCX 或其他现有机制加一层很薄的 userspace wrapper 就能守住所有 invariant，那么所谓 versioned composition generation 就不值得成为新的系统抽象。
+
+### 共享状态正确性仍然大多在 Verifier 之外
+
+verifier 可以证明单程序的很多安全属性，map type 与 lock 提供并发访问机制，fine-grained isolation 还能限制程序接触哪些状态。
+
+但这些机制都不会自动证明两个独立状态机对 ownership、reset、epoch 或 update order 有相同假设。因此组合问题会从 memory safety 延伸到 protocol compatibility。真正的研究难点是：究竟能捕获多少这类 protocol，而不把接口膨胀成一套通用 formal specification language。
+
+## 兼具学术价值与生产价值的方向
+
+### 用 Effect Inference 支撑的类型化组合 Manifest
+
+**Gap。** 部署系统能排序程序，分析系统能发现部分 effect，但两者之间缺少 portable attachment contract。
+
+**Mechanism。** 定义一个紧凑 schema，描述 read/write effect、map ownership、outcome category、visibility requirement 与 partial-order constraint。再利用 BTF、ELF metadata、helper-call inspection，以及可选的 symbolic 或 abstract interpretation，从编译后的程序推断 effect summary。loader 在 attach 前对比声明与推断结果，并解出合法的 partial order。
+
+**Delta。** 这不是另一个 dispatcher，也不是另一个独立 analyzer。libxdp 或 TCX 继续负责实际执行，KRAKENGUARD 或 Yaksha-Prashna 一类分析继续提供证据。新 artifact 是 analysis 和 attachment 之间的机器可检查 contract。
+
+**Artifact。** 一份公开 schema，一个基于 libbpf 的 loader，优先实现 TCX 和 libxdp adapter，再扩展到 cgroup hook 与 bpftime。可选 compiler plugin 可以生成 source-derived effect metadata。
+
+**Evaluation。** 收集独立开发的 observability、security、networking 程序，构造有效和无效的 pair / triple。分别测 write/write conflict、缺失 ordering dependency、map ownership mismatch、undeclared side effect 的检测率，同时报告 false rejection 与 false acceptance。attach-time analysis cost 与 steady-state overhead 要分开测，后者在验证结束后应该尽量接近 native backend。
+
+**Academic value。** 可以研究一个 eBPF composition effect system 是否既能表达真实程序，又保持可判定并且不绑定单一 backend。
+
+**Production value。** operator 能在部署前回答“两个由不同团队发布的程序能不能安全共享这个 hook”，而不是等到丢流量或 policy bypass 后再排查。
+
+**Failure condition。** 如果 annotation 成本过高、推断制造大量 false conflict，或者多数真实程序都必须依赖 hook-specific escape hatch，这个 common type system 就没有价值。
+
+### 为不同 Hook 建立显式的 Outcome Algebra Adapter
+
+**Gap。** 多程序 hook 都有 return value，但这些返回值没有统一的组合含义。把它们压成 generic priority 很容易改变安全或路由语义。
+
+**Mechanism。** 每个 hook adapter 都提供类型化结果模型。共同 vocabulary 可以包括 `continue`、`deny`、`select`、`redirect`、`transform`、`terminal`，而 adapter 保留 selected socket 之类 hook-specific payload。composition plan 指定 resolver。如果两个 terminal 或 stateful result 的组合存在歧义，planner 在没有显式 resolver 时直接拒绝。
+
+**Delta。** 现有 chain mechanism 主要决定下一个程序要不要运行。这里关注的是“多个程序共同产生的结果究竟是什么意思”，并让这个含义可检查、可测试。只要 kernel 已经有足够 primitive，就应该编译到原生 return convention，而不是再发明一个 packet-processing runtime。
+
+**Artifact。** 为 `BPF_SK_LOOKUP`、TCX、XDP/libxdp、cgroup sockopt 和 HID-BPF 做 adapter，并提供一个 test harness，把同一组 abstract composition case 映射到真实 kernel behavior。
+
+**Evaluation。** 构造 policy、telemetry、transformation、selection、redirect 程序的不同排列，比较 declared outcome 与 kernel observed outcome。加入恶意或偶然的 return-value override。除了 adapter overhead，更重要的是 attach 前能发现多少 semantic ambiguity。
+
+**Academic value。** 研究问题是能否找到一个足够小的 algebra，在不假装所有 BPF hook 相同的前提下复用主要组合性质。
+
+**Production value。** security 和 networking 团队可以清楚看到为什么某个结果最终生效，并在 observability 或 routing component 可能削弱 policy 时提前拒绝部署。
+
+**Failure condition。** 如果每个 hook 都必须有完全独立的 algebra，几乎没有可复用性质，那么这个抽象应该留在 hook-local 层，而不是强行做 cross-hook interface。
+
+### 给整个 Hook 组合建立 Versioned Generation
+
+**Gap。** 单个 BPF link 可以安全 replace，TCX 也已经支持 revision-aware chain change，但一个真正的 semantic composition 可能包含多个程序、ordering constraint、state contract 和一个 result resolver，它们需要一起演化。
+
+**Mechanism。** 把 active composition 表示成 generation object。先 off-path 构造下一代，验证所有成员与 dependency，解出顺序，准备兼容 map 或 state view，然后对 expected current generation 做 compare-and-swap commit。任何准备或验证失败都保持旧 generation 继续运行。如果 backend 根本无法原子切换完整 chain，adapter 必须暴露这个限制，而不能伪装成 transactional behavior。
+
+**Delta。** 这个方向并不试图解决任意 stateful eBPF application 的完整升级问题，那是本系列下一篇更大的问题。这里范围更窄，只让“同一个共享 hook 上有哪些成员，以及它们采用什么组合语义”成为一个 coherent versioned object。
+
+**Artifact。** 一个 userspace composition manager。先以 TCX 为 prototype，因为 TCX 已经暴露 ordering 与 revision，再做 libxdp dispatcher adapter。control-plane object 记录 generation ID、member program/link ID、effect contract 与 resolver choice，并允许 operator inspect。
+
+**Evaluation。** 在持续流量或事件下反复 add、remove、reorder、replace program，并在每一个 preparation step 注入 process crash 和故障。定义“deny policy 从未缺席”“parser 与 consumer version 永远匹配”“old writer 不会写 new map layout”之类 safety invariant。测 interruption window、rollback time、throughput impact，以及是否出现任何 intermediate invalid composition。
+
+**Academic value。** 可以回答 transactional configuration 是否能在不改 kernel 的情况下覆盖 heterogeneous BPF attachment mechanism，以及哪个边界最终必须得到 kernel support。
+
+**Production value。** fleet operator 可以独立 rollout 多个 eBPF component，而不用把每次 chain update 都变成人工协调的 maintenance operation。
+
+**Failure condition。** 如果已有 link 与 revision primitive 加很薄的 userspace wrapper 就能提供所需 multi-object atomicity，那么它应该只是工程 library，而不是新的系统抽象。
+
+## 更实际的架构是复用原生机制的 Planner，而不是万能 Dispatcher
+
+最有可能落地的设计并不是一个 universal mega-dispatcher，而是一层 planner 和 contract，针对每个 hook 复用最合适的 native primitive。
+
+对 TCX，可以直接使用 native link、relative ordering 和 revision；对 XDP，可以把验证后的 plan 编译成 libxdp dispatcher；对 cgroup hook，保留 hierarchy 与各自 return semantics；对 HID-BPF，如果前面的 transformer 会破坏原始数据，而后面程序声明自己必须看到 original event，planner 就拒绝这个组合。对 bpftime 这样的 userspace runtime，同一 contract 也可以驱动本地 dispatcher 与 capability model，即使物理 attach mechanism 完全不同。
+
+这样做还会给 observability 一个稳定单位。工具不再只能列出 program ID，而可以报告当前 composition generation、dependency、哪个程序终止了事件、当前共享状态采用什么 contract，以及 live chain 是否仍然等于验证过的 plan。
+
+这很重要，因为组合故障在表面上经常只是普通 application failure。packet 消失、syscall 被拒绝、input event 形状变化，都不一定直接指向 BPF。如果没有 first-class composition identity，operator 只能从多个 loader 的状态里重新拼出整条 chain，再猜是哪一段交互造成了结果。
+
+## 哪些结果会改变这个判断？
+
+有三类证据会明显削弱“需要新的 eBPF hook 组合契约”这个判断。
+
+第一，如果已有生产机制实际上已经提供了跨 hook 的 machine-readable effect、outcome resolution、shared-state ownership、ordering dependency 和 versioned whole-chain update，那么更值得做的是 adoption 和 conformance test，而不是再发明一层抽象。
+
+第二，如果大规模 empirical study 证明，只要有 deterministic ordering 和 memory isolation，独立 eBPF 程序几乎不会再出现 semantic conflict，那么额外 contract 可能只是在为少数故障增加复杂度。
+
+第三，如果 prototype 证明 effect inference 太不精确，或者 transactional composition 为了获得一致性需要大量 copying、pause 或 backend-specific code，最终 operator 还不如继续使用每个 hook 专用的 manager，那么这个 cross-hook 方案也应该被放弃。
+
+目前的证据更支持相反方向。Linux 已经暴露多种不同的组合语义，libxdp 和 TCX 让 multi-program chain 成为现实，vBPF 与 KRAKENGUARD 说明多 tenant 共存不能只依赖传统 verifier，Yaksha-Prashna 说明 bytecode dependency 可以被分析，已公布的 BPFChain 内容则把 multi-program conflict 明确当作 production discipline。下一步真正缺的不是再加一条 chain，而是把这些机制连接成一个可测试的声明：共享同一个 hook 的多个程序，究竟被允许组成什么样的系统。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [eBPF Hook Composition: Sharing One Hook Safely](https://eunomia.dev/research/ebpf-hook-composition-contract/)
+
+Linux, libxdp, and TCX already let multiple eBPF programs share execution points, but ordering alone does not define how mutations, shared state, competing outcomes, and updates compose. This report compares existing multi-program semantics and research on isolation and bytecode dependencies, then proposes typed composition manifests, explicit outcome algebras, and versioned hook generations.
+
 ### [What Is Missing Before Userspace eBPF Becomes a Real Runtime?](https://eunomia.dev/research/userspace-ebpf-runtime-contract/)
 
 A BPF VM can execute the instruction set without defining how programs attach, which capabilities they receive, who owns state, or how extensions are revoked and accounted for. This report compares Linux eBPF, uBPF, bpftime, and eBPF for Windows, then proposes a machine-readable runtime contract, capability-aware attach handles, and per-extension resource accounting.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [多个 eBPF 程序如何安全共享同一个 Hook？](https://eunomia.dev/zh/research/ebpf-hook-composition-contract/)
+
+Linux、libxdp 与 TCX 已经能让多个 eBPF 程序共享执行点，但排序本身无法定义数据修改、共享状态、竞争结果和更新应该怎样组合。本文比较现有多程序语义以及近期隔离和 bytecode dependency 工作，并提出类型化组合 manifest、显式 outcome algebra 与 versioned hook generation。
+
 ### [用户态 eBPF 要成为真正的运行时，还缺什么？](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/)
 
 一个 BPF VM 可以执行指令，却未必定义程序如何挂载、拥有哪些能力、状态由谁持有，以及扩展如何撤销和做资源归属。本文比较 Linux eBPF、uBPF、bpftime 与 eBPF for Windows，并提出机器可读的运行时契约、绑定能力的 attach handle 和 per-extension 资源账本。


### PR DESCRIPTION
## Summary

- add the 2026-08-09 bilingual Daily Report on safe multi-program eBPF hook composition
- record current Search Console, GA4, GitHub, live-site, and research evidence, including the analytics coverage gap through the current finalizable date
- advance the active eBPF Runtime, Extensibility, and Composition series and refresh the rolling topic mix
- update both Daily Report indexes; no unrelated technical SEO change is included because today's audit did not establish a new defect

## Report thesis

Ordering and dispatch are necessary but insufficient when independently managed eBPF programs share one hook. The report compares hook-specific Linux semantics, libxdp/TCX, vBPF, KRAKENGUARD, Yaksha-Prashna, and the announced BPFChain tutorial, then develops a machine-checkable composition contract around effects, outcome resolution, state ownership, and versioned hook generations.

## Data coverage

The enabled weekly GA4 and Search Console exports still cover 2026-07-27 through 2026-08-02. With the configured three-day finalization lag, 2026-08-03 through 2026-08-06 are currently unrepresented; the daily record treats that as missing coverage, not zero traffic. Only one complete weekly window exists, so prior-7-day and 28-day comparisons remain unavailable.

## Validation

This PR is intended to run the repository's authoritative static, Daily Report, SEO-data, link, build, and deployment-related checks. Final merge is gated on a clean diff and expected CI. Production verification and the exact squash commit will be recorded in the single merged-PR closeout comment required by `DAILY_TASK.md`.