### PR TITLE
Daily: publish transactional stateful eBPF upgrade report

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -17,13 +17,20 @@ already configured and enabled; it is not a blocker.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder
-contains six Search Console exports and one GA4 organic landing-page export for
-`2026-07-27` through `2026-08-02`. Only one complete weekly window is currently
-available, so previous-week and 28-day comparisons remain unavailable until
-additional exports appear. The GA4 export is also limited to organic landing-page
-rows and does not by itself provide complete acquisition, conversion, or outbound
-behavior coverage.
+Google Drive access is verified and is not a blocker. The configured folder now
+contains two adjacent weekly Search Console and GA4 export sets: `2026-07-27`
+through `2026-08-02` and `2026-08-03` through `2026-08-09`. The newest Search
+Console date export currently has rows through `2026-08-08`; under the configured
+three-day finalization lag, those rows are usable on `2026-08-11`.
+
+A complete latest-7-days versus previous-7-days comparison is still unavailable.
+The latest complete finalized seven-day GSC window is `2026-08-02` through
+`2026-08-08`, while its preceding window begins on `2026-07-26`, one day before
+the available history. The 28-day comparison also remains unavailable. The
+newest GA4 landing-page export includes `2026-08-09` and has no date dimension,
+so it cannot be cleanly restricted to the finalized period. GA4 is also limited
+to organic landing-page rows and does not by itself provide complete acquisition,
+conversion, or outbound behavior coverage.
 
 These constraints never justify skipping the daily operation. Each run must use
 the available Google exports, live-site evidence, public GitHub evidence, and

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -86,9 +86,19 @@ upgrade, safety, performance, and deployment boundaries.
 2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
    multi-program problem beyond dispatch and ordering to effect visibility,
    outcome resolution, shared-state ownership, and versioned hook composition.
-3. Preferred next question: transactional upgrade of stateful eBPF applications
-   across programs, links, maps, pinned state, userspace controllers, and
-   rollback after partial failure.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
+   object-level replacement from application-level upgrade and developed an
+   explicit prepare / migrate / commit / retire generation protocol for programs,
+   links, maps, pinned state, controller recovery, and rollback.
+4. Preferred next question: what an asynchronous profiler built around modern
+   eBPF would need to reconstruct causality across syscalls, io_uring, work
+   queues, runtime tasks, and application-defined resources without unacceptable
+   overhead or sampling bias.
+
+The series now has three substantial reports. A public series hub may be useful
+once the next report confirms that the sequence has enough reader value to merit
+an additional navigation surface; do not create a thin hub solely to satisfy the
+three-report threshold.
 
 ### Preferred sequence
 

--- a/.github/seo-data/daily/2026-08-11.md
+++ b/.github/seo-data/daily/2026-08-11.md
@@ -85,7 +85,7 @@ Repository CI remains authoritative for generated output. The final PR head must
 The complete daily change is carried by one fresh branch and one non-draft pull request:
 
 - branch: `daily/2026-08-11-stateful-ebpf-upgrade`
-- pull request: pending creation in this run
+- pull request: `#151`
 
 This branch starts from the current default branch and contains exactly one new bilingual report plus its directly coupled index, status, series, plan, site-data, blocker, and daily operating-record changes. No second closeout pull request will be created. Exact merge, deployment, public verification, analytics coverage, topic classification, and remaining uncertainty will be recorded in the single merged-PR closeout comment required by `DAILY_TASK.md`.
 

--- a/.github/seo-data/daily/2026-08-11.md
+++ b/.github/seo-data/daily/2026-08-11.md
@@ -1,0 +1,98 @@
+# SEO operations — 2026-08-11
+
+## Scope
+
+This run followed `DAILY_TASK.md` from the current default branch in repository order: analyze every enabled data source, audit technical SEO/GEO behavior, calculate the rolling Daily Report mix, research inside the active series, and publish exactly one new bilingual Daily Report. No unrelated technical SEO implementation change is included because the audit did not establish a new defect with evidence strong enough to justify one.
+
+The active series remains **eBPF Runtime, Extensibility, and Composition**. The selected report asks whether a stateful eBPF application can upgrade as one logical generation when programs, links, maps, pinned state, and a userspace controller must change together.
+
+PR `#150` prepared this research on `2026-08-10` but was closed without merge or deployment after `main` advanced. It therefore does not count as a completed publication. This run starts from the current `main`, preserves the still-valid report body, refreshes the operating evidence for `2026-08-11`, and delivers the unpublished report through one fresh daily branch and PR. The article's `source_cutoff` remains `2026-08-10` because the research body was completed on that date; this run rechecked the load-bearing primary sources rather than pretending the body was newly sourced on a later date.
+
+## Data window
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | Drive export sets for `2026-07-27` to `2026-08-02` and `2026-08-03` to `2026-08-09`; date, query, page, country, device, and search-appearance dimensions; current date rows through `2026-08-08` | available; rows through `2026-08-08` are usable under the three-day finalization lag |
+| Google Analytics 4 | Drive organic landing-page exports for `2026-07-27` to `2026-08-02` and `2026-08-03` to `2026-08-09` | available; newest export includes `2026-08-09` and has no date dimension, so finalized-period analysis is partial |
+| Public GitHub | current `eunomia-bpf/eunomia.dev`, `eunomia-bpf/bpftime`, and pinned/upstream SEO-skill state checked on `2026-08-11` | available |
+| Live site | current public homepage/navigation checked on `2026-08-11`; exact generated report output is required again during PR/deployment verification | available |
+| Public web / primary research sources | Linux kernel documentation, libbpf maintainer discussion, and public Cilium issue evidence rechecked through `2026-08-11` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
+
+With the configured three-day finalization lag on `2026-08-11`, Search Console rows through `2026-08-08` are now usable. The latest complete finalized seven-day GSC window is `2026-08-02` through `2026-08-08`, but its preceding seven-day comparison would require `2026-07-26`, which is not present in the available exports. Therefore the required latest-7-days versus previous-7-days comparison remains unavailable without inventing one missing day. The 28-day comparison is also unavailable.
+
+To extract a valid movement signal from the overlapping history, this record compares equal six-day finalized slices: `2026-08-03` through `2026-08-08` versus `2026-07-28` through `2026-08-02`. This is explicitly an interim comparable slice, not a substitute for the repository-required complete 7-day comparison.
+
+## Evidence collected
+
+### Search and traffic evidence
+
+For `2026-08-03` through `2026-08-08`, Search Console reports **478 clicks** and **69,053 impressions**, a weighted CTR of **0.692%**, and an impression-weighted average position of approximately **9.42**. The comparable `2026-07-28` through `2026-08-02` slice reports **409 clicks**, **46,327 impressions**, **0.883%** CTR, and position **8.18**. Clicks increased about **16.9%** and impressions about **49.1%**, while CTR declined by about **0.191 percentage points** and average position became about **1.24 positions worse**.
+
+The movement is strongly non-uniform. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at average position **13.30** and CTR **0.343%**. That day therefore explains a large part of the impression expansion and aggregate CTR/position dilution. The current page and query exports are weekly aggregates rather than date-by-page or date-by-query matrices, so the evidence cannot safely attribute the spike to one page or query family. A date-by-page or date-by-query export remains the next discriminating evidence.
+
+The latest device export remains desktop-heavy: desktop contributes 64,355 of 69,053 impressions, about **93.2%**. Translated-result search appearance is still present. Current page rows include the homepage at 26 clicks / 1,077 impressions, the Chinese GPU-architecture tutorial at 19 / 242, Hello World at 12 / 492, `GPTtrace` at 11 / 419, TCX at 9 / 317, and XDP at 8 / 849. Query aggregates include `eunomia`, `ebpf examples`, `actplane`, `ebpf 教程`, `xdp`, `ebpf`, `ebpf tutorial`, `bpftime`, and `ebpf hook(s)`. These rows support continued eBPF/runtime ownership and bilingual maintenance, but raw query rows remain outside Git and are not treated as a mandate to chase every query.
+
+The newest GA4 landing-page export covers `2026-08-03` through `2026-08-09` without a date dimension, so it is directional rather than a clean finalized-period comparison. `(not set)` remains the largest row at **116 sessions** with about **6.0%** engagement; the homepage has **43 sessions** at about **53.5%** engagement; the Chinese GPU-architecture page has **28 sessions** at about **64.3%** engagement; `GPTtrace` has **18 sessions** at about **66.7%** engagement; and the Chinese Hello World tutorial has **18 sessions** at about **72.2%** engagement. The export contains no usable configured key-event signal for site-wide conversion claims. `(not set)` remains a measurement-quality question rather than evidence for a speculative content or SEO change.
+
+### Previous-run closeout promoted into current state
+
+The `2026-08-09` merged-PR closeout is complete and was checked before today's change. PR `#149` squash-merged as `db383576aab403c63c4192bc8b52d75f300f58ce`. Its final `Validate SEO Operations` and `Deploy Static App` checks succeeded. Production `Deploy Static App` run `31322000113` completed successfully for that exact squash commit, and the exact deployed export contained the English and Chinese hook-composition report pages with their required content, reciprocal navigation, canonical URLs, `hreflang`, Open Graph metadata, and Article JSON-LD. These facts are promoted into `status.md` today.
+
+### Repository and live-site evidence
+
+Public GitHub activity remains aligned with runtime/eBPF work but is not treated as a traffic conversion metric. `eunomia-bpf/bpftime` merged runtime work on `2026-08-10` for selectable Frida fuzzy backtracing and for a documented preload host-process contract. Recent runtime fixes also cover host stdio isolation, syscall callback containment, stack semantics, and runtime configuration. These are current engineering signals that reinforce the active series, not proof that today's exact research question has search demand.
+
+The current public homepage serves the eBPF/runtime-oriented navigation and exposes the Daily Report entry point. The newest GA4 slice still contains some legacy `/en/` traffic. The repository intentionally generates canonical redirect stubs for those paths, and today's evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance regression that warrants an unrelated site change.
+
+The pinned SEO-skill submodule remains `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` currently points at `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`, but the consuming repository still names interfaces removed from the newer layout. Per the current repository contract, the submodule is not bumped in isolation; it requires a coordinated consumer migration.
+
+### Rolling Daily Report mix and research evidence
+
+Before today's publication, the completed public archive contains four reports: **2 eBPF-centered / 2 pure Agent / 0 adjacent systems**. The eBPF share is still below the desired long-run range in the small archive, and the two pure-Agent reports already occupy the available Agent budget. Today's report therefore needs to remain eBPF-centered unless the candidate fails quality review.
+
+The weak framing, "how to atomically replace an eBPF program," is rejected because Linux already exposes `BPF_LINK_UPDATE` for replacing the program behind one link. A second weak framing, "how to reuse a pinned map during code upgrade," is also rejected because libbpf already supports map reuse and maintainers describe it as a normal code-upgrade path.
+
+The narrower question passes the gap and novelty gate: what transaction semantics are needed only when several persistent BPF objects jointly define one correctness invariant. Rechecked primary evidence shows that libbpf already separates open/load/attach phases, pinned objects survive controller lifetime, map-of-maps provides state indirection, and existing maps can be reused during ordinary code upgrades. Cilium issue evidence shows that real datapath regeneration coordinates policy state, program loading, attachment, revert/finalization, and that partial failure can leave policy state inconsistent. The report therefore does not claim that existing object-level updates are missing or unsafe; it asks how those primitives can be composed into a **prepare / migrate / commit / retire** application-generation protocol.
+
+The report's novelty is also bounded by explicit countercases. A stateless one-link tracer can use `BPF_LINK_UPDATE`; stable state can be reused; an application that tolerates a maintenance window can stop, migrate, and restart. The research contribution is only justified if coupled multi-hook invariants, semantic state migration, or crash recovery make those simpler paths insufficient.
+
+## Work performed
+
+Exactly one previously unpublished bilingual Daily Report is included in today's delivery:
+
+- English: `/research/stateful-ebpf-transactional-upgrade/`
+- Chinese: `/zh/research/stateful-ebpf-transactional-upgrade/`
+
+Both Daily Report indexes are updated. `content-series.md` records the third report in the active series and advances the preferred next question to asynchronous/causal profiling with modern eBPF. `status.md` is refreshed with the verified `2026-08-09` closeout and today's data coverage. `site.md` and `block.md` are refreshed because the second weekly export set changes the durable analytics-history state. `plan.md` advances durable priorities and records the next evidence needed for the `2026-08-05` impression spike.
+
+Today's report is classified **eBPF-centered**. After publication the rolling archive becomes **3 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 5**. The eBPF share becomes 60%, inside the long-run 5–7/10 target proportion, while pure Agent remains above the eventual 1–2/10 proportion for a five-report archive. Continue to favor eBPF and adjacent systems before another pure-Agent report.
+
+The active series now has three substantial reports. A public series hub may become useful, but this run does not create a thin hub solely because the numerical threshold was reached.
+
+## Validation and self-review
+
+The report was rechecked against the current Daily Report contract. It starts from a concrete multi-hook policy upgrade, distinguishes per-object primitives from application-level guarantees, uses primary kernel and production evidence, states explicit counterexamples where a transaction layer is unnecessary, and develops three directions with Gap / Mechanism / Delta / Artifact / Evaluation / Academic value / Production value / Failure condition fields. The Chinese page uses reader-facing Chinese gap, ideas, and conclusion headings rather than mechanically copying English labels.
+
+The conclusion boundary is falsifiable: a production corpus showing that coupled multi-hook upgrades and semantic map migrations are rare, or experiments showing that sequential link updates plus ordinary reconciliation never expose harmful mixed generations, would weaken the case. The report also avoids starting from a proposed new kernel syscall; kernel support is treated as something to justify only after a userspace generation protocol exposes a concrete missing primitive.
+
+Repository CI remains authoritative for generated output. The final PR head must pass all required and expected checks. After CI is green, the complete diff and generated output must receive a clean self-review before squash merge. The exact squash commit must then pass the production `Deploy Static App` workflow and the deployed English/Chinese routes must be verified before closeout.
+
+## Delivery
+
+The complete daily change is carried by one fresh branch and one non-draft pull request:
+
+- branch: `daily/2026-08-11-stateful-ebpf-upgrade`
+- pull request: pending creation in this run
+
+This branch starts from the current default branch and contains exactly one new bilingual report plus its directly coupled index, status, series, plan, site-data, blocker, and daily operating-record changes. No second closeout pull request will be created. Exact merge, deployment, public verification, analytics coverage, topic classification, and remaining uncertainty will be recorded in the single merged-PR closeout comment required by `DAILY_TASK.md`.
+
+## Decisions and follow-ups
+
+The second weekly export materially improves analytics coverage but still does not unlock the repository's required complete 7-day versus previous-7-day comparison because the preceding period begins one day before the available history. The current GSC movement is also dominated by the `2026-08-05` impression spike; a date-by-page or date-by-query export would distinguish broad discovery growth from a narrow SERP/query event. A richer or date-dimensioned GA4 export is still required before acting on `(not set)` or making conversion claims. Cloudflare remains disabled by configuration.
+
+For the report thesis, the highest-value next evidence is an empirical corpus of real BPF application upgrades: how often several hooks must move together, how often pinned map schemas evolve semantically, which projects already implement prepare/revert/finalize state machines, and whether a common generation model captures them without hook-specific special cases.
+
+The preferred next Daily Report question is what an asynchronous profiler built around modern eBPF would need to reconstruct causal edges across syscalls, io_uring, work queues, runtime tasks, and application-defined resources with bounded overhead and measurable sampling bias.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,16 +71,23 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Complete the first scheduled daily operation using the root repository
-   contract and verify that one new eBPF-centered Daily Report reaches production.
-2. Keep upcoming reports strongly eBPF-centered until the current two pure-Agent
-   reports no longer dominate the rolling archive; maintain the long-term 5–7/10
-   eBPF and 1–2/10 pure-Agent mix.
-3. Use the verified Search Console and GA4 Drive exports in every run and build
-   enough weekly history for previous-period and 28-day comparisons.
-4. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as technical SEO
+1. Continue the **eBPF Runtime, Extensibility, and Composition** series. After the
+   stateful-upgrade report, prefer the asynchronous/causal profiling question
+   across syscalls, io_uring, work queues, runtime tasks, and application-defined
+   resources.
+2. Keep upcoming reports strongly eBPF-centered until the two existing pure-Agent
+   reports are diluted into the long-term 5–7/10 eBPF and 1–2/10 pure-Agent mix.
+3. Use both verified weekly Search Console and GA4 Drive export sets in every run.
+   Keep accumulating history until a complete previous-7-day and 28-day comparison
+   can be made without inventing missing dates.
+4. Obtain or generate date-by-page or date-by-query Search Console evidence before
+   attributing the `2026-08-05` impression spike to a specific page or query family.
+5. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as technical SEO
    evidence rather than letting those issues distort content selection.
-5. Add Cloudflare coverage when a supported read-only route is available.
-6. Use search behavior, GitHub activity, primary research, kernel changes, and
+6. Add Cloudflare coverage when a supported read-only route is available.
+7. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside the approved eBPF and adjacent
    systems series.
+8. Migrate the consuming SEO contract before moving the pinned `seo-skills`
+   submodule to a newer upstream layout that removed interfaces this repository
+   still calls.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,7 +32,7 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified export window: `2026-07-27` through `2026-08-02`
+- Verified export window: `2026-07-27` through `2026-08-09`; the newest Search Console date export currently has rows through `2026-08-08`
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
 The Drive folder is discovered by its configured name. Do not store its folder ID,
@@ -50,10 +50,16 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-Search Console and GA4 exports now support source-native weekly analysis. The
-current folder contains one complete weekly window, so longer comparisons remain
-unavailable until more history is present. Public repository and live-site data
-supplement these exports but do not replace their source-native meanings.
+Search Console and GA4 exports now provide two adjacent weekly export sets,
+`2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. As of
+`2026-08-11`, Search Console rows through `2026-08-08` are usable under the
+three-day finalization lag. A complete latest-7-days versus previous-7-days
+comparison is still unavailable because the required preceding period begins on
+`2026-07-26`, one day before the available history. The 28-day comparison is
+also unavailable. The newest GA4 landing-page export has no date dimension and
+includes `2026-08-09`, so it remains partial for finalized-period comparison.
+Public repository and live-site data supplement these exports but do not replace
+their source-native meanings.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,61 +7,69 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-08`
-- Last verified data window: `2026-07-27` through `2026-08-02`
-- Latest daily record: `2026-08-09`
-- Last public-change pull request: recorded in the `2026-08-08` daily record and merged-PR closeout comment
-- Last verified production deployment from a daily run: recorded in the merged `2026-08-08` pull-request closeout comment
+- Last completed daily run: `2026-08-09`
+- Last verified data window: Search Console rows through `2026-08-08`; GA4 weekly export through `2026-08-09` is partial for finalized analysis
+- Latest daily record: `2026-08-11`
+- Last public-change pull request: `#149`, verified in its merged-PR closeout comment
+- Last verified production deployment from a daily run: `Deploy Static App` run `31322000113` for squash commit `db383576aab403c63c4192bc8b52d75f300f58ce`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The `2026-08-09` daily record and content are in the current daily change. Per `DAILY_TASK.md`, exact merge/deployment/public verification is recorded in the merged-PR closeout comment, and the next daily run promotes those verified closeout facts into this summary.
+The `2026-08-11` daily record and stateful-upgrade report are in the current daily change. The prior `2026-08-10` attempt was closed without merge or deployment after `main` advanced; it is not counted as a completed daily publication. Per `DAILY_TASK.md`, exact merge/deployment/public verification for the current change belongs in the single merged-PR closeout comment, and the next run will promote those verified facts into this summary.
 
 ## Current Daily Report mix
 
-The archive contains four Daily Reports with the `2026-08-09` publication:
+The current change adds the fifth Daily Report:
 
-- eBPF-centered: **2 of 4**
+- eBPF-centered: **3 of 5**
+  - `/research/stateful-ebpf-transactional-upgrade/`
   - `/research/ebpf-hook-composition-contract/`
   - `/research/userspace-ebpf-runtime-contract/`
-- pure Agent-centered: **2 of 4**
+- pure Agent-centered: **2 of 5**
   - `/research/agent-trace-evidence-budget/`
   - `/research/parallel-agent-effect-serializability/`
-- adjacent systems: **0 of 4**
+- adjacent systems: **0 of 5**
 
-The archive is still outside the long-run target. New reports should continue to strongly favor eBPF. The active series is **eBPF Runtime, Extensibility, and Composition**. The rolling target is 5–7 eBPF-centered reports per 10 published reports and at most 1–2 pure Agent reports per 10.
+The eBPF share is now 60%, which is inside the long-run 5–7/10 target proportion, while the two pure-Agent reports still occupy too much of the current five-report archive relative to the eventual 1–2/10 cap. Continue to favor eBPF and adjacent systems before another pure-Agent report. The active series remains **eBPF Runtime, Extensibility, and Composition**.
 
 ## Current signals
 
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly Drive export available and verified, but the latest configured export lags the current finalizable date
-- Google Search Console: six dimension exports for one weekly window available and verified, but the latest configured export lags the current finalizable date
+- Google Analytics 4: two weekly Drive organic landing-page exports available; the newest export includes a non-finalized date and has no date dimension
+- Google Search Console: two adjacent weekly sets of date, search-appearance, device, country, page, and query exports available; current date rows extend through `2026-08-08`
 - Cloudflare: not configured
 
-The verified Drive folder still covers one complete Search Console and GA4 weekly date window, `2026-07-27` through `2026-08-02`. Search Console has date, search-appearance, device, country, page, and query dimensions; GA4 has an organic landing-page export. With the configured three-day finalization lag, data through `2026-08-06` is now old enough to be finalizable, so `2026-08-03` through `2026-08-06` are currently unrepresented in the enabled Google exports. Previous-period and 28-day comparisons remain unavailable until more weekly windows accumulate.
+The configured Drive folder now contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. With the configured three-day finalization lag on `2026-08-11`, Search Console rows through `2026-08-08` are usable. The latest complete finalized seven-day GSC window is therefore `2026-08-02` through `2026-08-08`, but its preceding comparison would require `2026-07-26`, which is absent. The required 7-day versus previous-7-day comparison and the 28-day comparison remain unavailable rather than being inferred.
 
-For `2026-07-27` through `2026-08-02`, Search Console reports 486 clicks and 55,021 impressions, for a weighted CTR of 0.883% and an impression-weighted average position of approximately 8.21. Desktop accounts for about 92.9% of impressions in the current window. Search appearance includes translated-result traffic, and country rows show broad international discovery, which reinforces the value of maintaining first-class English and Chinese variants.
+A valid common-duration finalized six-day comparison is available. Search Console reports **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. That is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. The current weekly page/query aggregates cannot attribute that spike to one page or query family without a date-by-page or date-by-query export.
 
-The GA4 organic landing-page export shows tutorials and CUDA/GPU material among the strongest known landing pages. Its largest row is `(not set)` with low engagement, which remains a measurement-quality problem. The current export is not sufficient to make site-wide conversion or outbound-action claims.
+The latest device export remains desktop-heavy at about **93.2%** of impressions. Translated-result search appearance is still present. Current page/query aggregates continue to show discovery around eBPF tutorials, XDP, CUDA/GPU material, project names, and long-tail systems questions. Raw query rows remain outside Git.
+
+The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` without a date dimension, so it is directional rather than a clean finalized-period comparison. `(not set)` remains the largest row at **116 sessions** with about **6.0%** engagement; the homepage has **43 sessions** at about **53.5%** engagement; the Chinese GPU-architecture page has **28 sessions** at about **64.3%** engagement; `GPTtrace` has **18 sessions** at about **66.7%** engagement; and the Chinese Hello World tutorial has **18 sessions** at about **72.2%** engagement. The export has no usable configured outcome signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative site change.
+
+## Previous-run closeout
+
+The `2026-08-09` operation is fully closed out. PR `#149` squash-merged as `db383576aab403c63c4192bc8b52d75f300f58ce`. Its final `Validate SEO Operations` and `Deploy Static App` checks succeeded. Production `Deploy Static App` run `31322000113` completed successfully for that exact squash commit, and the deployed artifact contained the English and Chinese hook-composition pages with the required content, canonical URLs, reciprocal language alternates, Open Graph metadata, and Article JSON-LD.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through the `Deploy Static App` workflow.
 
-The `2026-08-09` technical audit did not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, or performance defect that justified an unrelated implementation change. Public search still exposes legacy `/en/` URLs, but the current build intentionally emits canonical redirect stubs for those paths; this remains an observation to monitor rather than a proven new defect. The only coupled SEO work in the daily change is the normal bilingual Daily Report index and generated page metadata for the new report.
+The `2026-08-11` technical audit does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance defect that justifies an unrelated implementation change. The public homepage currently exposes the Daily Report entry point and the expected eBPF/runtime navigation. The newest GA4 slice still contains some legacy `/en/` traffic, but the repository intentionally emits canonical redirect stubs for those paths; this remains a monitoring item rather than a proven defect.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` currently points at `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`, but that newer layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer therefore still requires a coordinated consumer migration rather than an isolated submodule bump.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` currently points at `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`, but that newer layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer still requires a coordinated consumer migration rather than an isolated submodule bump.
 
 ## Current focus
 
-1. Continue the **eBPF Runtime, Extensibility, and Composition** Daily Report series. After the hook-composition report, the preferred next question is whether a stateful eBPF application can be upgraded transactionally across programs, links, maps, pinned state, userspace controllers, and rollback.
-2. Continue publishing eBPF-centered Daily Reports until the rolling mix moves toward 5–7 eBPF reports per 10 and pure Agent reports no longer exceed the 1–2 per 10 cap.
-3. Use the verified weekly GA4 and Search Console exports in every run; explicitly mark their lag relative to the current finalizable date instead of treating missing days as zero.
-4. Accumulate enough weekly history for previous-period and 28-day comparisons.
-5. Investigate the GA4 `(not set)` landing-page row with a richer export before making a measurement or content change.
-6. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows canonical redirect stubs are causing measurable harm.
-7. Migrate the consuming SEO contract to the newer `seo-skill` layout before updating the submodule pointer.
-8. Add Cloudflare evidence when a supported read-only path exists.
+1. Complete and verify the current stateful eBPF transactional-upgrade Daily Report from the latest `main`.
+2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: what an asynchronous profiler built around modern eBPF needs to reconstruct causality across syscalls, io_uring, work queues, runtime tasks, and application-defined resources without unacceptable overhead or sampling bias.
+3. Continue favoring eBPF and adjacent systems until the rolling archive is comfortably inside the long-run 5–7/10 eBPF and 1–2/10 pure-Agent mix.
+4. Use both weekly GA4 and Search Console export sets in every run; keep required 7-day and 28-day comparisons marked unavailable until complete source history exists.
+5. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.
+6. Investigate GA4 `(not set)` with richer dimensions before making a measurement or content change.
+7. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows canonical redirect stubs are causing measurable harm.
+8. Migrate the consuming SEO contract before updating the skill submodule pointer.
+9. Add Cloudflare evidence when a supported read-only path exists.
 
 This file is the current verified summary. Detailed history belongs in `.github/seo-data/daily/` and the merged daily pull requests.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can a Stateful eBPF Application Upgrade Atomically?](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/)
+
+One BPF link can replace one program cleanly, but real stateful applications also span maps, pinned objects, multiple hooks, and userspace controllers. This report separates simple state reuse from semantic state migration and develops generation-gated activation, BTF-aware migration, and crash-consistent recovery as testable upgrade mechanisms.
+
 ### [eBPF Hook Composition: Sharing One Hook Safely](https://eunomia.dev/research/ebpf-hook-composition-contract/)
 
 Linux, libxdp, and TCX already let multiple eBPF programs share execution points, but ordering alone does not define how mutations, shared state, competing outcomes, and updates compose. This report compares existing multi-program semantics and research on isolation and bytecode dependencies, then proposes typed composition manifests, explicit outcome algebras, and versioned hook generations.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [有状态 eBPF 应用能不能原子升级？](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/)
+
+单个 BPF link 可以干净地替换一个程序，但真实有状态应用还跨越 maps、pinned objects、多个 hooks 和用户态控制器。本文区分简单 state reuse 与 semantic state migration，并把 generation-gated activation、BTF-aware migration 和 crash-consistent recovery 发展成可验证的升级机制。
+
 ### [多个 eBPF 程序如何安全共享同一个 Hook？](https://eunomia.dev/zh/research/ebpf-hook-composition-contract/)
 
 Linux、libxdp 与 TCX 已经能让多个 eBPF 程序共享执行点，但排序本身无法定义数据修改、共享状态、竞争结果和更新应该怎样组合。本文比较现有多程序语义以及近期隔离和 bytecode dependency 工作，并提出类型化组合 manifest、显式 outcome algebra 与 versioned hook generation。

--- a/docs/research/stateful-ebpf-transactional-upgrade.md
+++ b/docs/research/stateful-ebpf-transactional-upgrade.md
@@ -1,0 +1,260 @@
+---
+date: 2026-08-10
+title: "Can a Stateful eBPF Application Upgrade Atomically?"
+description: "One BPF link can be replaced atomically, but stateful apps span programs, maps, pins, and controllers. This report examines upgrade and rollback semantics."
+tags:
+  - Daily Report
+  - eBPF
+  - Runtime Systems
+  - State Migration
+  - Linux
+research_question: "What transaction semantics are needed to upgrade a stateful eBPF application across programs, links, maps, pinned objects, and its userspace controller without exposing a partially upgraded configuration?"
+source_cutoff: 2026-08-10
+status: daily-report
+---
+
+# Can a Stateful eBPF Application Upgrade Atomically?
+
+Suppose a production policy application has two eBPF programs, one attached to ingress traffic and another attached to a cgroup hook. Both read a pinned policy map. A userspace controller keeps that map synchronized with external policy. Version 2 changes the program logic and also changes the map value layout.
+
+Replacing either program is straightforward. Linux exposes `BPF_LINK_UPDATE`, so one BPF link can switch from an old program to a new one without a detach-and-reattach gap. The hard part is the rest of the application. If the controller migrates the map first, version 1 may observe version 2 state. If it replaces the programs first, version 2 may read the old layout. If one replacement succeeds and the second fails, the host can run a combination that was never tested. A controller crash between these steps makes the correct rollback target even less obvious.
+
+<!-- more -->
+
+This is the boundary between **program replacement** and **stateful eBPF application upgrade**. The kernel already gives us useful atomic operations on individual objects. libbpf separates load from attachment so state can be prepared before programs run. Pins make object lifetime independent of one controller process. Map indirection can switch one map reference. Production systems such as Cilium already maintain their own regeneration, migration, revert, and finalization logic.
+
+The evidence points to a narrower missing mechanism: **there is no common application-level commit protocol that binds those object-level operations into one upgrade generation**. A useful transaction layer should let an operator prepare a complete new generation, migrate or reuse state under explicit rules, validate cross-object invariants, expose one logical commit point, retain the old generation long enough to drain or roll back, and recover after the controller dies midway.
+
+This report continues the [userspace eBPF runtime contract](https://eunomia.dev/research/userspace-ebpf-runtime-contract/) and [hook-composition contract](https://eunomia.dev/research/ebpf-hook-composition-contract/). Those reports argued that an eBPF runtime needs explicit lifetime and composition semantics above bytecode execution. Stateful upgrade is where lifetime, composition, and persistent state meet.
+
+## The kernel already makes several individual transitions safe
+
+A transactional upgrade proposal is only useful if it starts from what Linux already provides rather than rebuilding existing primitives.
+
+### A BPF link can replace one program without an attachment gap
+
+The Linux `bpf()` syscall documentation defines `BPF_LINK_UPDATE` as updating the eBPF program associated with a specified link to a new program. At the libbpf layer, the corresponding update operation is used when an application wants to replace the program behind a link instead of destroying and recreating the link.
+
+That solves an important lifecycle problem. A tracer can replace one attached program without deliberately creating an interval where nothing is attached. A policy program can preserve the attachment object's lifetime and ownership while changing the code it executes.
+
+But the operation names one link and one new program. It does not say that two links, three maps, a pinned object namespace, and a userspace controller all changed as one unit. Object-level replacement is therefore a building block, not yet an application transaction.
+
+### libbpf deliberately separates load and attach
+
+The kernel's libbpf overview describes a BPF application as one or more programs, maps, and global variables. Its lifecycle has distinct open, load, attachment, and teardown phases. During load, maps are created and programs are verified and loaded, but the programs have not yet executed. The documentation explicitly notes that this gives userspace a chance to establish initial map state without racing with program execution.
+
+That separation is almost a prepare phase. Version 2 can be opened, relocated, loaded, and populated while version 1 still serves traffic. The missing decision is what makes the prepared collection become the active application, especially when several hook points must move together.
+
+### Pinned objects survive controller process lifetime
+
+The BPF syscall documentation also makes object lifetime reference-based. Maps and programs can be shared between processes, and BPF objects can be pinned in bpffs. An object is deallocated only after file descriptors, pins, and attachment references are gone.
+
+This is useful for upgrades because the controller does not need to own every object's lifetime through one process. It is also why crash recovery becomes a real design problem. After a controller restarts, both the old and partially prepared new objects may still exist. A correct upgrader must determine which generation is active and which objects are safe to garbage-collect rather than assuming process exit restored a clean state.
+
+### Map indirection can stage a new state object
+
+Linux map-of-maps support allows an outer map to hold references to inner maps. Userspace can update an outer-map entry, while BPF programs perform lookups through the outer map. This provides a useful form of indirection: userspace can build a new inner map off the data path, populate it, and then replace the outer reference for future lookups.
+
+This still operates at one map entry and one indirection relationship. It does not simultaneously update program links. It also does not solve arbitrary schema evolution: the outer map constrains the inner-map type and layout, and multi-level nesting is not supported. The primitive is valuable precisely because it shows the shape of a possible commit point while also exposing its boundary.
+
+## Reusing state and replacing state are different upgrade modes
+
+A large class of eBPF upgrades is simpler than the opening scenario. If version 2 uses exactly the same map schema and state semantics, the safest operation may be to reuse the existing map rather than migrate it.
+
+A libbpf maintainer described this as a typical code-upgrade workflow in the libbpf-rs project: open the new object, reuse the file descriptor of the existing pinned map before load, then load the new programs so they reference the old state. That is a strong counterexample to any claim that every eBPF upgrade needs a transaction layer. For a single program with stable state, map reuse plus one link update may be enough.
+
+The problem appears when compatibility is semantic rather than merely structural.
+
+Consider a hash map whose value changes from:
+
+```c
+struct policy_v1 {
+    __u32 verdict;
+    __u32 flags;
+};
+```
+
+to:
+
+```c
+struct policy_v2 {
+    __u32 verdict;
+    __u32 flags;
+    __u64 epoch;
+};
+```
+
+The object loader can notice a size mismatch. It cannot infer whether `epoch` can be initialized to zero, derived from another source, or requires a coordinated controller action. Even equal-sized structs can be semantically incompatible if a field changes from a counter to a lease expiration time or if one version changes who is allowed to reset an entry.
+
+Cilium provides production evidence for this distinction. In an older issue involving pinned map property mismatches, the loader logged that incompatible maps were being removed to permit the property upgrade and explicitly expected map data loss. The important point is not that this behavior is wrong. It is that schema incompatibility forces a lifecycle decision that is outside the verifier's normal memory-safety question.
+
+A stateful upgrade protocol therefore needs at least three declared modes:
+
+1. **Reuse** when old and new programs intentionally share the same state semantics.
+2. **Transform** when state must move through a versioned conversion before cutover.
+3. **Replace** when old state is disposable or can be reconstructed independently.
+
+Treating all three as "load the new object" hides the decision that determines correctness.
+
+## Partial failure is not hypothetical in production BPF control planes
+
+The strongest reason to care about upgrade transactions is not aesthetic API consistency. It is that multi-step datapath regeneration already contains failure paths that can expose the wrong state.
+
+A Cilium issue from 2025 documented endpoint regeneration retries that could leave an endpoint associated with an empty policy map, causing policy-denied traffic. The investigation is especially useful because maintainers traced the failure through concrete regeneration phases: policy state, BPF collection loading, attachment, policy-map synchronization, and deferred revert behavior. One maintainer summarized the desired ordering as creating the policy map, populating it, wiring it into the program, loading the program, and only then attaching it. Another traced how an early return could execute revert logic before later synchronization restored the expected map contents.
+
+Cilium is not evidence that Linux BPF updates are generally unsafe. It is evidence that **a real BPF application has side effects whose ordering and rollback semantics extend beyond one syscall**. The project already has a revert stack and finalization actions because successful regeneration is not a single operation.
+
+This is also a useful novelty check. "Add rollback to an eBPF loader" is too weak as a research direction; production loaders already do it. The more specific question is whether these bespoke state machines can be reduced to a portable generation protocol with properties we can test across applications.
+
+## What should an application-level eBPF transaction guarantee?
+
+Calling an upgrade "atomic" can easily overpromise. A kernel cannot rewind packets already processed by version 1, and two independent events may execute on different CPUs while a commit occurs. The useful guarantee is narrower.
+
+For a declared application generation `G`, an upgrader should define these properties:
+
+- **Prepared completeness.** Every program, map, link target, and controller-side dependency required by `G+1` exists and passes validation before it can become active.
+- **State compatibility.** Each state object is explicitly reused, transformed, or replaced, with a declared version and migration rule.
+- **Single logical commit.** The system has one authoritative generation decision. Observers should not infer activation from whichever individual link happened to update first.
+- **No unsupported mixed generation.** If the application declares that two components must move together, the runtime must not intentionally expose a steady state containing one old and one new component.
+- **Recoverable ownership.** After controller failure, persistent metadata is sufficient to distinguish active, prepared, retiring, and orphaned objects.
+- **Bounded retirement.** The old generation is retained until the runtime can establish that rollback is no longer required and in-flight work that depends on it has drained according to the hook's semantics.
+
+These are application-level properties. Linux already gives us lower-level reference counting, RCU-backed datapath mechanisms in many map types, verifier checks, link lifetime, and per-object updates. A transaction layer should compose those mechanisms rather than pretend to replace them.
+
+## A generation protocol can make the lifecycle explicit
+
+One practical model is a four-phase lifecycle: **prepare, migrate, commit, retire**.
+
+During **prepare**, the controller opens and loads version 2 without attaching it to production hooks. It creates versioned state objects or binds compatible existing maps. It records the expected old generation and all object identities in a transaction record.
+
+During **migrate**, the controller copies or reconstructs state into the new generation. If live updates continue, the protocol must choose a synchronization strategy: pause writes briefly, capture a snapshot plus delta, dual-write through a controller, or let old and new programs share a compatibility map. The choice is workload-specific and should be measurable rather than hidden in the loader.
+
+During **commit**, the runtime changes the authoritative active generation. On hook families that can afford a stable dispatcher, each dispatcher can read a shared generation selector and route to the prepared program set. That reduces a multi-link application cutover to one control-plane generation decision, at the cost of an extra indirection on the hot path. Where no suitable stable dispatch path exists, a stronger kernel primitive or a weaker documented guarantee may be required.
+
+During **retire**, the old generation stays pinned or otherwise referenced until the runtime knows it is safe to remove. A grace period may be enough for a stateless hook. Stateful applications may need acknowledgements from the userspace controller, completion of outstanding asynchronous work, or evidence that no state references point to the old maps.
+
+This is not necessarily a universal kernel ABI. It is first a model that allows us to compare implementations and say precisely where a backend cannot provide the requested guarantee.
+
+## Where current work is still weak
+
+### There is no portable object that describes an upgrade generation
+
+The interfaces inspected here expose programs, maps, links, pins, and object files. Production systems add their own regeneration context and rollback state. What is missing is a portable manifest that says which objects constitute one application generation, which old objects they supersede, and which compatibility relationships must hold at commit.
+
+Without that object, a crash-recovering controller has to reconstruct intent from pin names, process state, loader-specific conventions, or external databases. The consequence is operational ambiguity: leaked objects are annoying, but deleting the wrong "old" map can be a correctness failure.
+
+A decisive test is whether several existing loaders can express their upgrade state machines with the same small set of generation states and dependency edges. If each requires unrelated lifecycle semantics, a common transaction manifest is the wrong abstraction.
+
+### Map schema compatibility is still mostly structural
+
+Loader checks can compare map type, key size, value size, flags, and other properties. BTF provides rich type information. Neither by itself says whether a semantic migration is correct.
+
+The missing element is a migration contract that connects an old BTF/schema version to a transformation and an invariant. The consequence is that sophisticated projects hand-code migration behavior while generic loaders can only reuse, reject, or recreate state.
+
+A useful experiment should include schema changes that preserve byte size but change meaning. If a BTF-aware migration checker only catches changes that ordinary loader property checks already reject, it adds little value.
+
+### Per-link atomic replacement does not define multi-hook commit semantics
+
+`BPF_LINK_UPDATE` is a strong primitive for one link. The gap appears only when an application has a cross-hook invariant such as "ingress classifier and cgroup policy must use the same policy epoch."
+
+The missing element is either a common generation gate or a kernel-level multi-object commit primitive. The consequence of sequential updates is a bounded but real mixed-generation interval. Whether that interval matters depends on the workload.
+
+The right test is not microbenchmarking update syscalls alone. Inject traffic and faults while repeatedly upgrading coupled hooks, then measure whether any event is processed under a forbidden generation combination. If no realistic workload can observe a harmful mixed state, the extra transaction machinery is unnecessary.
+
+### Crash recovery is underspecified for persistent BPF object graphs
+
+Pins deliberately outlive one controller process. That is a feature, but it means a partially prepared generation can survive the process that created it.
+
+The missing element is a durable transaction journal with idempotent recovery rules. The consequence is that cleanup and rollback become application-specific after a crash at exactly the time when in-memory intent is gone.
+
+The test is straightforward: kill the controller after every side effect in the upgrade state machine, restart it, and check whether it always converges to either the old committed generation or the new committed generation without deleting live state.
+
+## Promising directions with academic and production value
+
+### A generation-gated upgrade runtime for libbpf applications
+
+**Gap.** Existing primitives can prepare programs and replace individual links, but a multi-hook application lacks one logical activation decision.
+
+**Mechanism.** Keep a small, stable dispatch program at each supported hook. The dispatcher reads an application-wide generation selector and routes to the program slot for that generation. New programs and maps are loaded into a versioned namespace while the old generation runs. After validation and state preparation, the controller performs one generation-selector update. The old generation remains reachable until a retirement condition is satisfied. For map state, a parallel versioned indirection can select the state object associated with the same generation where the map type permits it.
+
+This design must not hide its portability boundary. Tail calls and dispatcher techniques differ by program type and hook. The runtime should advertise which hook families support a true generation gate, which require sequential `BPF_LINK_UPDATE`, and which cannot meet the requested cross-hook guarantee without kernel support.
+
+**Delta.** The delta from libxdp-style dispatch or ordinary program arrays is the lifecycle protocol, not the existence of a dispatcher. The new property is that program routing, state version, recovery metadata, and retirement all refer to one application generation.
+
+**Artifact.** A libbpf-based controller and manifest format, initially supporting XDP/TC and one tracing or cgroup family, plus an adapter for [bpftime](https://eunomia.dev/bpftime/) to test the same generation protocol in userspace.
+
+**Evaluation.** Use stateless and stateful networking, policy, and observability applications with 1, 2, 4, and 8 coordinated hooks. Repeatedly upgrade under packet/event load. Inject failure before and after every prepare, migration, selector, and retirement step. Measure forbidden mixed-generation observations, lost events or packets, cutover latency, steady-state dispatcher overhead, retained memory during rollback windows, and recovery time. Compare against sequential link updates, stop-and-restart, and application-specific hand-coded orchestration.
+
+**Academic value.** The research question is whether one generation selector plus explicit retirement can provide a useful cross-object consistency property over heterogeneous BPF hook lifecycles, and where the abstraction breaks.
+
+**Production value.** Platform teams get a reusable update state machine rather than embedding one in every BPF controller. The same manifest can drive health checks, rollback, and garbage collection.
+
+**Failure condition.** If realistic applications rarely have cross-hook invariants, or if the dispatcher overhead and hook-coverage limitations exceed the cost of a short sequential update window, this runtime should not replace simpler link updates.
+
+### BTF-aware state migration with explicit invariants
+
+**Gap.** Reusing a compatible pinned map is efficient, but structural compatibility does not cover semantic schema evolution.
+
+**Mechanism.** Assign every persistent state object a schema version derived from BTF plus application metadata. Before load, compare the old and new schemas and classify changes as reusable, mechanically transformable, or requiring an application-supplied converter. For transformations, populate a shadow map, validate invariants such as key preservation, monotonic counters, or policy-epoch consistency, then bind the new generation to that map. Under write-heavy workloads, add a snapshot-plus-delta protocol or a short quiescence window and make its cost explicit.
+
+**Delta.** This is narrower than a general serialization system. It targets BPF map schemas and the exact transition between loaded generations. It also goes beyond existing property checks by testing semantic invariants and by making migration success a prerequisite for activation.
+
+**Artifact.** A BTF schema differ, migration-plan generator, converter API, and fault-injection harness integrated with the generation runtime. Publish a corpus of real map-schema changes from open-source BPF projects after removing project-specific secrets or operational data.
+
+**Evaluation.** Include key/value additions, field renames, widening and narrowing, equal-sized semantic changes, map-type changes, per-CPU state, LRU maps, and maps too large to copy cheaply. Compare full copy, lazy migration, snapshot-plus-delta, and explicit reset. Measure migration throughput, pause time, memory amplification, update loss, invariant violations, and developer effort. The key correctness metric is whether the system rejects unsafe automatic migrations rather than maximizing the number it accepts.
+
+**Academic value.** This asks which semantic properties of long-lived eBPF state can be inferred from types and which require explicit application invariants, a boundary not addressed by verifier memory safety.
+
+**Production value.** Operators can distinguish a safe zero-downtime upgrade from one that requires planned state loss or a maintenance window before deployment begins.
+
+**Failure condition.** If most production map changes are either exactly reusable or intentionally disposable, a migration framework is unnecessary overhead. A corpus study should establish the frequency before a large implementation effort.
+
+### A crash-consistent journal for pinned BPF object graphs
+
+**Gap.** Pins preserve objects across controller restarts, but the controller's in-memory upgrade intent can disappear while both generations remain alive.
+
+**Mechanism.** Store a small durable transaction record that names the expected old generation, prepared new generation, object identities, state-migration status, commit decision, and retirement status. Every phase is idempotent. Recovery follows a deterministic rule: before commit, discard or resume the prepared generation; after commit, restore the new controller view and finish retirement; if the active generation cannot be established, fail closed and preserve both object sets for diagnosis instead of guessing.
+
+The journal can live outside bpffs if the deployment already has durable control-plane storage. The important property is that pinned object references and transaction metadata are reconciled explicitly.
+
+**Delta.** Production projects already have revert stacks and finalizers. The contribution would be a minimal, portable recovery state machine with a tested crash-consistency property rather than another project-specific rollback callback collection.
+
+**Artifact.** A transaction library, recovery checker, and deterministic fault injector that kills the controller after each externally visible operation. Expose the object graph through `bpftool`-compatible IDs and pins so failures can be inspected with normal tooling.
+
+**Evaluation.** Run thousands of randomized upgrades while killing the controller at each transition, including repeated crashes during recovery. Verify that every run converges to a valid committed generation, does not delete the active map, and eventually collects unreachable objects. Compare with a simple desired-state reconciler that has no explicit journal.
+
+**Academic value.** The question is whether reference-counted kernel objects plus a small userspace journal are sufficient for crash-consistent application upgrades, or whether stronger kernel transaction support is required.
+
+**Production value.** This targets the failure mode that is hardest to debug operationally: an agent restart leaves a datapath running, but nobody knows whether its persistent state belongs to the old or new software generation.
+
+**Failure condition.** If an idempotent desired-state reconciler can recover every tested object graph with the same correctness and less metadata, the journal is redundant and the simpler reconciler should win.
+
+## A kernel multi-object transaction should be a result, not the starting assumption
+
+It is tempting to propose a new syscall that takes a list of links and maps and atomically publishes all replacements. That could eventually be useful, particularly for hook families where a stable dispatcher is impossible or too expensive.
+
+But it is premature as the first implementation. The kernel would need to define what happens when different hook types use different synchronization and lifetime rules, how map state migration participates, how expected revisions prevent concurrent controllers from committing stale state, and how failure is reported without leaving references half-installed. A syscall can make a pointer swap atomic without making the application's state transformation correct.
+
+A better research path is to first implement the transaction model in userspace on top of existing primitives, collect the cases where it cannot provide the required guarantee, and then use those cases to justify the smallest kernel primitive. The resulting kernel proposal might be a multi-link expected-generation commit, a reusable generation handle, or something narrower than a general BPF transaction syscall.
+
+## What would change this conclusion?
+
+The strongest alternative is the simple one: most eBPF applications may not need transactional upgrade at all. A stateless tracer with one link can use `BPF_LINK_UPDATE`. A program with a stable map schema can reuse the existing map. An application that can tolerate a brief maintenance window can stop, migrate, and restart with much less machinery.
+
+Three results would materially weaken the argument for an application transaction layer.
+
+First, a corpus of production BPF deployments could show that coupled multi-hook upgrades and semantic map migrations are rare. Second, fault-injection experiments could show that sequential link updates plus ordinary desired-state reconciliation never expose harmful mixed generations in realistic workloads. Third, generation dispatch could impose enough steady-state cost or hook-specific complexity that operators prefer a short explicit disruption.
+
+The opposite evidence would strengthen the case: repeated real incidents involving partially applied program/state updates, several projects independently implementing similar prepare/revert/finalize state machines, or experiments showing that a single generation protocol removes observable policy and state inconsistencies at low cost.
+
+The useful boundary is therefore not "eBPF needs database transactions." It is more specific: **when several persistent BPF objects jointly define one correctness invariant, the upgrade mechanism needs a commit concept at the same scope as that invariant**. Linux already gives us most of the object-level pieces. The open systems question is how small the layer above them can be.
+
+## References
+
+- [Linux kernel: eBPF syscall reference](https://docs.kernel.org/userspace-api/ebpf/syscall.html)
+- [Linux kernel: libbpf overview and BPF application lifecycle](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html)
+- [Linux kernel: map of maps](https://docs.kernel.org/bpf/map_of_maps.html)
+- [libbpf-rs discussion: reusing an existing map during BPF code upgrades](https://github.com/libbpf/libbpf-rs/issues/52)
+- [Cilium issue #38998: empty policy map after endpoint regeneration failure](https://github.com/cilium/cilium/issues/38998)
+- [Cilium issue #19091: pinned map property mismatch and expected data loss](https://github.com/cilium/cilium/issues/19091)
+- [bpftime: userspace eBPF runtime](https://github.com/eunomia-bpf/bpftime)

--- a/docs/research/stateful-ebpf-transactional-upgrade.zh.md
+++ b/docs/research/stateful-ebpf-transactional-upgrade.zh.md
@@ -1,0 +1,258 @@
+---
+date: 2026-08-10
+title: "有状态 eBPF 应用能不能原子升级？"
+description: "单个 BPF link 可以原子替换程序，但有状态应用还跨越 maps、pins 与用户态控制器。本文分析如何实现可提交、回滚和崩溃恢复的整体升级。"
+tags:
+  - Daily Report
+  - eBPF
+  - Runtime Systems
+  - State Migration
+  - Linux
+research_question: "一个有状态 eBPF 应用跨越多个程序、link、map、pinned object 和用户态控制器时，需要什么事务语义，才能避免升级过程中暴露半新半旧的配置？"
+source_cutoff: 2026-08-10
+status: daily-report
+---
+
+# 有状态 eBPF 应用能不能原子升级？
+
+假设一个生产环境里的策略应用由两个 eBPF 程序组成：一个挂在 ingress，另一个挂在 cgroup hook。两边都读取同一个 pinned policy map，用户态控制器持续把外部策略同步进去。现在 version 2 不只改了程序逻辑，还改了 map value 的布局。
+
+单独替换某个程序并不难。Linux 有 `BPF_LINK_UPDATE`，一个 BPF link 可以从旧程序切换到新程序，而不需要先 detach 再 attach。真正麻烦的是应用剩下的部分：如果先迁移 map，version 1 可能读到 version 2 的状态；如果先换程序，version 2 可能读旧 schema；如果第一个 link 更新成功、第二个失败，机器会运行一个从未测试过的混合版本；如果控制器恰好在中间崩溃，连“应该回滚到哪里”都不再显然。
+
+<!-- more -->
+
+这就是**替换一个 BPF program**和**升级一个有状态 eBPF application**之间的边界。Linux 已经提供不少有用的对象级原子操作。libbpf 把 load 和 attach 分开，因此程序开始执行前可以准备 state。bpffs pin 让对象生命周期不依赖某一个控制器进程。map indirection 可以把一个逻辑 map 指向新的 inner map。Cilium 这类生产系统也已经自己实现 regeneration、migration、revert 和 finalization。
+
+因此缺的并不是“再做一个能换程序的 API”。从今天检查的内核接口和生产案例来看，更具体的空白是：**缺少一个通用的应用级 commit protocol，把这些对象级操作绑定成同一个 upgrade generation**。一个有用的事务层应该允许控制器先完整准备下一代，显式声明 state 是复用、迁移还是重建，验证跨对象 invariant，再通过一个逻辑 commit point 激活新版本，同时保留旧 generation 直到可以安全 drain 或 rollback，并且在控制器半路死亡之后能够恢复。
+
+这篇报告继续前两篇 Daily Report：[用户态 eBPF runtime contract](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/) 和 [eBPF hook composition contract](https://eunomia.dev/zh/research/ebpf-hook-composition-contract/)。前两篇分别讨论 lifetime、capability 和多程序 composition。stateful upgrade 正好是 lifetime、composition 与 persistent state 汇合的地方。
+
+## Linux 已经能安全完成不少单对象切换
+
+要讨论 transactional upgrade，第一步不是重做 Linux 已经有的东西，而是把现有 primitive 的边界说清楚。
+
+### 一个 BPF link 可以无 detach gap 地替换程序
+
+Linux `bpf()` syscall 文档定义了 `BPF_LINK_UPDATE`：把指定 `link_fd` 关联的 eBPF program 更新为 `new_prog_fd`。在 libbpf 这一层，对应接口允许应用直接替换 link 背后的程序，而不是销毁 link 再重新创建。
+
+这解决了很实际的生命周期问题。tracer 更新一个程序时，不需要故意制造“这一小段时间没有任何程序挂着”的窗口。policy program 也可以保持 attachment object 的 owner 和 lifetime，只改变它执行的代码。
+
+但这个操作只描述**一个 link 和一个 new program**。它没有说两个 links、三个 maps、一组 pinned objects 和 userspace controller 如何一起变化。因此它是 transaction 的 building block，不是 application transaction 本身。
+
+### libbpf 本来就把 load 和 attach 分成两个阶段
+
+Linux 的 libbpf overview 把 BPF application 定义成一个或多个 programs、maps 和 global variables，并把生命周期分成 open、load、attachment、tear down。load 阶段会创建 map、完成 relocation、验证并把 program load 进 kernel，但此时 program 还没有开始执行。文档明确指出，这允许 userspace 在没有 program execution race 的情况下先设置初始 map state。
+
+这已经很接近 transaction 里的 prepare phase。version 2 可以先 open、load、populate，而 version 1 继续服务。真正缺的是：当多个 hook 需要一起变化时，什么动作代表“prepared collection 现在正式成为 active application”。
+
+### pinned object 故意跨越 controller process lifetime
+
+BPF syscall 文档使用 reference-based lifetime。map 和 program 可以在进程之间共享，BPF object 也可以 pin 到 bpffs；只有 file descriptor、pin、attachment 等 reference 都消失之后，对象才会被释放。
+
+这对升级很有用，因为 controller 不需要靠一个进程一直活着来维持所有对象。但它也让 crash recovery 变成真实问题：controller 重启后，旧 generation 和只准备了一半的新 generation 可能都还在。正确的 upgrader 必须判断谁是 active、谁是 prepared、谁可以 GC，而不是假设进程退出以后系统就自动回到干净状态。
+
+### map indirection 可以先准备新 state object 再切引用
+
+Linux 的 map-of-maps 允许 outer map 持有 inner map reference。userspace 可以更新 outer map entry，BPF program 通过 outer map lookup 获得 inner map。这提供了一个很实用的 indirection：新 inner map 可以先离线创建和填充，再让未来的 lookup 转过去。
+
+但这依然只解决一个 map entry 的 reference update，而且 outer map 对 inner map type/layout 有约束，不支持多层 nesting。更重要的是，它不会同时替换 program links。这个 primitive 有价值，恰恰因为它展示了“单点 publish”可能是什么样，也把边界暴露出来了。
+
+## 复用 state 和迁移 state 是两种不同的升级
+
+很多 eBPF 升级其实比开头那个例子简单。如果 version 2 使用完全相同的 map schema，而且 state semantics 没变，最安全的方案可能不是 migration，而是直接复用旧 map。
+
+libbpf-rs 的一个讨论里，libbpf maintainer 把这种做法描述为典型 code-upgrade workflow：先 open 新 object，在 load 之前把新的 map object 绑定到旧 pinned map 的 FD，然后 load 新 programs。这样新代码继续使用旧 state。这个例子很重要，因为它直接否定了“所有 eBPF 升级都需要 transaction layer”这种过宽的结论。对单程序、稳定 state 的情况，map reuse 加一次 link update 往往已经够了。
+
+问题出现在“compatibility 不是结构兼容，而是语义兼容”的时候。
+
+例如 map value 从：
+
+```c
+struct policy_v1 {
+    __u32 verdict;
+    __u32 flags;
+};
+```
+
+变成：
+
+```c
+struct policy_v2 {
+    __u32 verdict;
+    __u32 flags;
+    __u64 epoch;
+};
+```
+
+loader 可以发现 size mismatch，却无法自动知道 `epoch` 应不应该初始化成 0、从别的 source 计算，还是必须等 controller 完成某个同步。甚至两个 struct byte size 完全一样，也可能语义不兼容，例如某个字段从普通 counter 变成 lease expiration，或者 reset ownership 发生变化。
+
+Cilium 的生产 issue 给出了这种区别的直接证据。一个旧 issue 里，pinned map property 与新程序不兼容时，loader 会删除旧 map 以允许 property upgrade，并明确提示预期会有 data loss。重点不是这种行为“错了”，而是 schema incompatibility 迫使系统做一个生命周期决定，而这个决定不属于 verifier 的普通 memory-safety 问题。
+
+所以 stateful upgrade 至少应该明确区分三种模式：
+
+1. **Reuse**：旧新程序确实共享同一套 state semantics。
+2. **Transform**：state 必须经过 versioned conversion 才能切换。
+3. **Replace**：旧 state 可以丢弃，或者能从别处独立重建。
+
+把三者都隐藏在“load 新 object”后面，会把决定 correctness 的核心步骤藏起来。
+
+## 部分失败在生产 BPF 控制面里不是理论问题
+
+做 upgrade transaction 的理由，不是为了 API 看起来更整齐，而是 multi-step datapath regeneration 本身就有能暴露错误状态的 failure path。
+
+Cilium 在 2025 年的一个 issue 记录了 endpoint regeneration retry 之后 policy map 变空，最终导致流量被 policy denied 的问题。这个案例尤其有价值，因为维护者沿着具体阶段定位问题：policy state、BPF collection load、attachment、policy-map sync，以及 deferred revert behavior。一个 maintainer 把期望顺序概括为：创建 policy map，先填好 policy，再把 map 注入 program，load program，最后 attach。另一个 maintainer 则追踪到 early return 如何在后续同步之前触发 revert path，把 map 恢复到了错误的空 state。
+
+这不是“Linux BPF update 普遍不安全”的证据。它说明的是：**真实 BPF application 的 side effect 顺序与 rollback 语义已经超出了单个 syscall**。Cilium 之所以存在 revert stack 和 finalizer，就是因为一次成功 regeneration 本来就不是一个操作。
+
+这也给 novelty gate 一个很好的反例。“给 eBPF loader 加 rollback”太弱，因为生产 loader 早就在做。更值得研究的问题是：这些 bespoke state machine 能不能被压缩成一个 portable generation protocol，并且在不同 application 上验证一致的 property。
+
+## 应用级 eBPF 事务到底应该保证什么？
+
+把 upgrade 叫“atomic”很容易说过头。kernel 不可能撤回 version 1 已经处理完的 packet，两个独立 event 也可能在 commit 的前后分别执行。真正有用的 guarantee 应该更窄。
+
+对一个声明出来的 application generation `G`，upgrader 至少应该定义：
+
+- **Prepared completeness**：`G+1` 需要的 program、map、link target 和 controller dependency 在激活前全部存在并通过 validation。
+- **State compatibility**：每个 persistent state object 都明确声明 reuse、transform 或 replace，并带 version 和 migration rule。
+- **Single logical commit**：系统有唯一权威的 active-generation decision，不能靠“哪个 link 先更新完”来猜版本是否已经生效。
+- **No unsupported mixed generation**：如果 application 声明两个 component 必须一起变化，就不能把一个 old、一个 new 的组合长期暴露给 datapath。
+- **Recoverable ownership**：controller crash 以后，durable metadata 足以区分 active、prepared、retiring 和 orphaned objects。
+- **Bounded retirement**：old generation 在 rollback window 和 in-flight work 安全结束之前仍然保持 reference。
+
+这些都是 application-level property。Linux 底层仍然负责 reference count、verifier、link lifetime，以及各种 map/hook 自己的 synchronization。transaction layer 的工作应该是组合这些 primitive，而不是假装自己重新实现内核。
+
+## 一个 generation protocol 可以把生命周期变得明确
+
+比较实用的模型是四个 phase：**prepare、migrate、commit、retire**。
+
+在 **prepare** 阶段，controller open/load version 2，但不把它接到 production hook。它创建 versioned state，或者绑定经过验证的 existing map，同时记录 expected old generation 和所有 object identity。
+
+在 **migrate** 阶段，controller 把 state copy、transform 或 reconstruct 到新 generation。如果 old state 仍持续更新，就必须显式选择同步策略：短暂 pause write、snapshot + delta、controller dual-write，或者 old/new 共同使用 compatibility map。不同 workload 可能有不同答案，关键是把答案暴露出来并且测量成本，而不是藏在 loader 里。
+
+在 **commit** 阶段，runtime 改变权威的 active generation。对于可以长期保留 stable dispatcher 的 hook，可以让每个 dispatcher 读取同一个 application-wide generation selector，再跳到该 generation 对应的 program slot。这样多 link cutover 在逻辑上压缩成一个 generation decision，代价是 hot path 多一层 indirection。对于不适合这种 dispatch 的 hook，则必须明确降低 guarantee，或者最终需要更强的 kernel primitive。
+
+在 **retire** 阶段，old generation 继续被 pin 或持有 reference，直到 runtime 能确认不再需要 rollback。stateless hook 可能一个 grace period 就够了；stateful application 则可能需要 controller acknowledgement、异步 work 完成，或者确认没有 state reference 仍指向 old map。
+
+这个 protocol 一开始不需要成为 universal kernel ABI。它首先应该是一个能比较 implementation 的 model：哪个 backend 能提供完整 guarantee，哪个只能提供弱一些的 guarantee，都要说清楚。
+
+## 现有研究还缺什么
+
+### 现在没有 portable object 描述“一个 upgrade generation 包含什么”
+
+今天检查的接口主要暴露 programs、maps、links、pins 和 object files。生产系统则自己维护 regeneration context 与 rollback state。缺的东西是一个 portable manifest，声明哪些 object 属于同一代 application、它们替代哪些旧 object，以及 commit 前必须满足哪些 compatibility relationship。
+
+没有这个对象时，crash recovery 只能从 pin name、process state、loader convention 或外部数据库里猜 intent。leaked object 只是资源问题，但删错一个“看起来已经旧了”的 map 就会变成 correctness 问题。
+
+最直接的验证方式，是拿几个已有 loader 的 upgrade state machine，看它们是否能用一套很小的 generation states 和 dependency edges 表达。如果每个 loader 都需要完全不同的语义，那 common manifest 就不是对的 abstraction。
+
+### map schema compatibility 目前主要还是结构检查
+
+loader 可以比较 map type、key/value size、flags 等 property，BTF 也能提供丰富 type information。但这些信息本身不能证明 semantic migration 正确。
+
+缺的是把 old schema、new schema、transformation 和 invariant 连接起来的 migration contract。否则 generic loader 最多只能 reuse、reject 或 recreate，复杂 project 继续 hand-code migration。
+
+值得做的实验必须包含“byte size 一样但 meaning 变化”的 schema change。如果 BTF-aware checker 只会抓 ordinary property check 已经能发现的问题，它没有多少增量价值。
+
+### per-link atomic replacement 不等于 multi-hook commit
+
+`BPF_LINK_UPDATE` 对一个 link 已经是很强的 primitive。gap 只有在 application 真的存在 cross-hook invariant 时才出现，例如“ingress classifier 与 cgroup policy 必须使用同一个 policy epoch”。
+
+缺的是 common generation gate，或者更底层的 multi-object commit primitive。sequential update 会产生一个很短但真实的 mixed-generation window。这个窗口是否重要必须靠 workload 判断。
+
+正确的实验不是只量 update syscall latency，而是升级期间持续注入 traffic/event 和 failure，看是否有 event 被一个禁止的 generation combination 处理。如果现实 workload 根本观察不到有害 mixed state，那么额外 transaction machinery 就没有必要。
+
+### persistent BPF object graph 的 crash recovery 语义还不够明确
+
+pin 的目的就是让 object 跨过 controller restart，但这意味着 partially prepared generation 也可能跟着活下来。
+
+缺的是 durable transaction journal 和 idempotent recovery rule。否则最需要 rollback 的时候，恰好也是 in-memory intent 消失的时候。
+
+这个问题很好测：在 upgrade state machine 每个 side effect 之后 kill controller，再 restart，检查系统是否总能收敛到 old committed generation 或 new committed generation，而不会删除 live state。
+
+## 兼具学术价值与生产价值的方向
+
+### 给 libbpf application 做 generation-gated upgrade runtime
+
+**Gap.** 现有 primitive 能 prepare program，也能逐个替换 link，但 multi-hook application 没有一个逻辑 activation decision。
+
+**Mechanism.** 在支持的 hook 上长期保留一个很小的 stable dispatcher。dispatcher 读取 application-wide generation selector，再跳到该 generation 对应的 program slot。new programs 和 maps 先 load 到 versioned namespace，旧 generation 继续运行。state 准备和 validation 完成后，controller 只更新 generation selector。old generation 一直保留到 retirement condition 满足。对于 map state，可以在 map type 允许的情况下使用与 generation 对齐的 versioned indirection。
+
+这个设计必须明确 portability boundary。tail call 与 dispatcher 在不同 program type/hook 上能力不同，所以 runtime 应该公开：哪些 hook 能得到真正 generation gate，哪些只能 sequential `BPF_LINK_UPDATE`，哪些没有 kernel support 就无法达到 requested guarantee。
+
+**Delta.** 和普通 libxdp dispatcher 或 program array 的区别不在“有 dispatcher”，而在 lifecycle protocol。program routing、state version、recovery metadata、retirement 都引用同一个 application generation。
+
+**Artifact.** 一个 libbpf-based controller + manifest，先支持 XDP/TC，再支持一个 tracing 或 cgroup family；同时给 [bpftime](https://eunomia.dev/zh/bpftime/) 做 adapter，用同一个 generation protocol 测 userspace backend。
+
+**Evaluation.** 用 stateless/stateful networking、policy、observability application，分别组合 1、2、4、8 个 coordinated hooks，在持续 packet/event load 下反复升级。每个 prepare、migration、selector、retirement step 前后都 fault inject。测 forbidden mixed-generation observation、lost event/packet、cutover latency、dispatcher steady-state overhead、rollback window 内 memory amplification 与 recovery time。baseline 包括 sequential link update、stop-and-restart 和 application-specific orchestration。
+
+**Academic value.** 核心问题是：一个 generation selector 加明确 retirement，能不能在不同 BPF hook lifetime 上提供足够有用的 cross-object consistency，以及 abstraction 在哪里失效。
+
+**Production value.** 平台团队可以复用同一个 update state machine，而不是每个 BPF controller 都重新实现 prepare/revert/finalize。manifest 还能直接驱动 health check、rollback 与 GC。
+
+**Failure condition.** 如果真实 application 很少存在 cross-hook invariant，或者 dispatcher overhead 与 hook coverage 限制比短暂 sequential-update window 更贵，就不应该用这个 runtime 取代简单 link update。
+
+### BTF-aware state migration，加显式 invariant
+
+**Gap.** compatible pinned map 可以高效 reuse，但 structural compatibility 不足以覆盖 semantic schema evolution。
+
+**Mechanism.** 每个 persistent state object 都带一个由 BTF + application metadata 定义的 schema version。load 前比较 old/new schema，把变化分类成 reusable、mechanically transformable、需要 application converter。需要 transform 时先填充 shadow map，再验证 key preservation、monotonic counter、policy epoch consistency 等 invariant，最后才让新 generation 绑定该 map。write-heavy workload 则明确选择 snapshot-plus-delta 或短暂 quiescence，并把 pause/copy cost 量出来。
+
+**Delta.** 这不是 general serialization system，而是专门处理 BPF map schema 与 generation transition。它也超出普通 map property check：migration 成功和 invariant validation 会变成 activation 的前置条件。
+
+**Artifact.** BTF schema differ、migration-plan generator、converter API 与 fault-injection harness，再从开源 BPF project 收集一组真实 schema change corpus，只保留 public-safe 的结构信息。
+
+**Evaluation.** 覆盖 field add/rename、widen/narrow、等长 semantic change、map-type change、per-CPU state、LRU map，以及大到无法便宜 copy 的 map。比较 full copy、lazy migration、snapshot-plus-delta、explicit reset，测 migration throughput、pause time、memory amplification、update loss、invariant violation 和 developer effort。最重要的 correctness metric 不是“自动迁移越多越好”，而是 unsafe migration 能不能被拒绝。
+
+**Academic value.** 它研究 long-lived eBPF state 哪些 semantic property 能从 type 推断、哪些必须由 application 明确声明，这个边界不是 verifier memory safety 能回答的。
+
+**Production value.** operator 在 deploy 前就能知道这是 safe zero-downtime upgrade，还是必须接受 planned state loss / maintenance window。
+
+**Failure condition.** 如果 corpus 显示绝大多数生产 map change 要么 exact reuse、要么本来就可以丢弃，那么做复杂 migration framework 没有必要。
+
+### 给 pinned BPF object graph 做 crash-consistent journal
+
+**Gap.** pin 会让 object 跨 controller restart 存活，但 controller memory 里的 upgrade intent 可能消失，此时 old/new generation 同时存在。
+
+**Mechanism.** 保存一个很小的 durable transaction record：expected old generation、prepared new generation、object identity、migration status、commit decision、retirement status。每个 phase 必须 idempotent。recovery 按确定规则执行：commit 前可以丢弃或继续 prepared generation；commit 后恢复 new controller view 并完成 retirement；如果 active generation 无法确定，则 fail closed 并保留两组 object 供诊断，不允许猜。
+
+journal 不一定放在 bpffs。如果 deployment 已经有 durable control-plane storage，用现有 storage 也可以。关键是 pinned object reference 和 transaction metadata 必须显式 reconcile。
+
+**Delta.** Cilium 这类 production project 已经有 revert stack 和 finalizer。这里的贡献必须是一个最小 portable recovery state machine，加可以验证的 crash-consistency property，而不是另一套 project-specific callback。
+
+**Artifact.** transaction library、recovery checker 与 deterministic fault injector，在每个 externally visible operation 之后 kill controller，并通过 `bpftool` compatible ID/pin 暴露 object graph 方便检查。
+
+**Evaluation.** 随机跑数千次 upgrade，在每个 transition kill controller，包括 recovery 过程中再次 crash。验证每次都收敛到 valid committed generation，不会删 active map，并最终收集 unreachable objects。baseline 是没有 explicit journal 的简单 desired-state reconciler。
+
+**Academic value.** 研究 reference-counted kernel objects + 小型 userspace journal 是否足够提供 crash-consistent application upgrade，还是必须引入更强 kernel transaction support。
+
+**Production value.** 它针对最难排查的一类 operational failure：agent restart 以后 datapath 还在跑，但没人知道 persistent state 到底属于旧软件还是新软件。
+
+**Failure condition.** 如果 idempotent desired-state reconciler 在同样 object graph 上能以更少 metadata 达到同样 correctness，那么 journal 是多余的，应该选更简单的 reconciler。
+
+## 不应该一开始就假设必须新增 kernel multi-object transaction
+
+很容易想到一个新的 syscall：传入多个 links、maps，一次原子 publish 全部 replacement。这在一些 stable dispatcher 不可行或开销太高的 hook 上，未来可能确实有价值。
+
+但它不应该成为第一版方案。kernel 必须先回答不同 hook type 的 synchronization/lifetime 怎么组合、state migration 如何参加 transaction、expected revision 如何阻止 concurrent controller 提交 stale state，以及 failure 如何返回而不留下半安装 reference。一个 syscall 可以让 pointer swap 原子化，却不能自动让 application state transformation 正确。
+
+更合理的 research path 是先用现有 primitive 在 userspace 实现 transaction model，收集哪些 case 无法满足 guarantee，再用这些 case 去 justify 最小 kernel primitive。最后真正需要的可能是 multi-link expected-generation commit、reusable generation handle，或者比“通用 BPF transaction syscall”窄得多的东西。
+
+## 哪些结果会改变这个判断？
+
+最强的反方其实很简单：大部分 eBPF application 可能根本不需要 transactional upgrade。stateless tracer 只有一个 link，直接 `BPF_LINK_UPDATE`。map schema 稳定，就继续 reuse。能够接受短 maintenance window 的 application，可以 stop、migrate、restart，系统复杂度低很多。
+
+三类结果会明显削弱本文结论。第一，production BPF deployment corpus 显示 coupled multi-hook upgrade 和 semantic map migration 非常罕见。第二，fault injection 说明 sequential link update + 普通 desired-state reconciliation 在现实 workload 中从不暴露有害 mixed generation。第三，generation dispatch 的 steady-state cost 或 hook-specific complexity 高到 operator 宁愿接受一个明确的小停顿。
+
+相反，如果多个 project 都独立实现相似的 prepare/revert/finalize state machine，真实 incident 反复来自 program/state partial update，或者实验显示一个 generation protocol 可以低成本消除 policy/state inconsistency，那么 application-level transaction 的必要性就会变强。
+
+因此本文不是在说“eBPF 需要数据库事务”。更准确的边界是：**当多个 persistent BPF object 共同定义一个 correctness invariant 时，upgrade mechanism 的 commit scope 也必须和这个 invariant 一样大**。Linux 已经给了我们大部分对象级 primitive。真正值得继续做的系统问题，是上面这一层究竟能有多小。
+
+## 参考资料
+
+- [Linux kernel: eBPF syscall reference](https://docs.kernel.org/userspace-api/ebpf/syscall.html)
+- [Linux kernel: libbpf overview and BPF application lifecycle](https://docs.kernel.org/bpf/libbpf/libbpf_overview.html)
+- [Linux kernel: map of maps](https://docs.kernel.org/bpf/map_of_maps.html)
+- [libbpf-rs discussion: reusing an existing map during BPF code upgrades](https://github.com/libbpf/libbpf-rs/issues/52)
+- [Cilium issue #38998: empty policy map after endpoint regeneration failure](https://github.com/cilium/cilium/issues/38998)
+- [Cilium issue #19091: pinned map property mismatch and expected data loss](https://github.com/cilium/cilium/issues/19091)
+- [bpftime: userspace eBPF runtime](https://github.com/eunomia-bpf/bpftime)


### PR DESCRIPTION
## Summary

- publish exactly one new bilingual Daily Report on transactional stateful eBPF application upgrades
- replay the unpublished report from the current `main` after closed PR #150 was superseded without merge/deployment
- refresh Google data coverage for the second adjacent weekly export set and the 2026-08-11 finalization boundary
- promote the verified PR #149 closeout into current repository state
- advance the active eBPF Runtime, Extensibility, and Composition series and durable follow-ups
- make no unrelated technical SEO implementation change because the current audit did not establish one

## Data / editorial state

- complete required 7-day vs previous-7-day and 28-day comparisons remain unavailable because available GSC history starts on 2026-07-27; the latest complete finalized seven-day window begins 2026-08-02 and its preceding window needs 2026-07-26
- valid equal six-day finalized slice: 2026-08-03..08 vs 2026-07-28..08-02 = 478 vs 409 clicks and 69,053 vs 46,327 impressions; CTR 0.692% vs 0.883%; position 9.42 vs 8.18
- 2026-08-05 contributes 24,516 impressions, so date-by-page/query evidence is needed before attribution
- rolling archive after this report: 3/5 eBPF-centered, 2/5 pure Agent, 0/5 adjacent systems

## Validation contract

Final PR-head CI, complete diff/generated-output self-review, squash merge, exact-commit production deployment, public EN/ZH verification, and one merged-PR closeout comment are required by `DAILY_TASK.md` before this run is complete.