### PR TITLE
Refine Eunomia around agent-native eBPF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,17 @@ eunomia-bpf, AgentSight, ActPlane, bpftime, papers, tutorials, and talks as the
 core public evidence assets. Optimize platform posts for native account trust,
 discussion, and community reach rather than website ranking alone.
 
+The public site identity is community-first. Eunomia.dev is the home of an
+open-source systems community building agent-native eBPF runtime infrastructure.
+Keep eBPF as the technical anchor; AI agents are a primary workload and can also
+be direct users of the infrastructure. Eunomia Labs, Inc. may be named
+transparently as a steward, supporter, and commercial builder around the
+open-source work, but do not rewrite eunomia.dev as a conventional company or
+sales website. Preserve the prominence of projects, docs, tutorials, research,
+and community work. Product-specific pricing and conversion should live on
+product surfaces unless the user explicitly requests otherwise, and do not add
+sales-first navigation or CTAs without an explicit request.
+
 ## Required Workflow
 
 For open-source code, documentation, synchronization, CI, release-readiness, or

--- a/app/components/AboutLandingPage.tsx
+++ b/app/components/AboutLandingPage.tsx
@@ -52,9 +52,9 @@ export function AboutLandingPage({ locale, links, projects }: AboutLandingPagePr
     locale === "zh"
       ? {
           eyebrow: "About",
-          title: "Eunomia 是围绕 eBPF、runtime extension 和 AI agent infra 的开源系统工程项目",
+          title: "Eunomia 是构建 eBPF 运行时基础设施的开源系统社区",
           description:
-            "这里汇总 Eunomia 的项目体系，并组织非 eBPF 教程、研究和实验性项目。",
+            "社区围绕 agent-native eBPF runtime、runtime extension、AI agent observability 与 policy、GPU tracing、教程和系统研究开展开源工作。",
           tutorials: "非 eBPF 教程",
           tutorialsDescription:
             "CUDA、CUPTI 和 NVBit 内容适合作为 GPU programming、profiling 和 instrumentation 的学习入口。",
@@ -68,13 +68,13 @@ export function AboutLandingPage({ locale, links, projects }: AboutLandingPagePr
           resourcesDescription: "兼容性、基准测试、路线图和其他仍在维护的资料入口。",
           community: "社区入口",
           communityDescription:
-            "GitHub、discussion 和公开文档仍然是主要协作渠道；商业支持放在 Products。"
+            "GitHub、discussion 和公开文档仍然是主要协作渠道；Eunomia Labs, Inc. 支持这些开源项目的开发、生产采用与商业合作。"
         }
       : {
           eyebrow: "About",
-          title: "Eunomia is an open-source systems engineering effort around eBPF, runtime extension, and AI agent infrastructure",
+          title: "Eunomia is an open-source systems community building eBPF runtime infrastructure",
           description:
-            "This page summarizes the broader Eunomia project and organizes non-eBPF tutorials, research, and experiments.",
+            "The community works on agent-native eBPF runtimes, runtime extension, AI agent observability and policy, GPU tracing, tutorials, and systems research.",
           tutorials: "Tutorials beyond eBPF",
           tutorialsDescription:
             "CUDA, CUPTI, and NVBit content serve as learning paths for GPU programming, profiling, and instrumentation.",
@@ -88,7 +88,7 @@ export function AboutLandingPage({ locale, links, projects }: AboutLandingPagePr
           resourcesDescription: "Compatibility notes, benchmarks, roadmaps, and other maintained project resources.",
           community: "Community",
           communityDescription:
-            "GitHub, discussions, and public documentation remain the main collaboration paths. Commercial support lives under Products."
+            "GitHub, discussions, and public documentation remain the main collaboration paths. Eunomia Labs, Inc. supports development, production adoption, and commercial work around these open-source projects."
         };
 
   return (

--- a/app/components/ProductPages.tsx
+++ b/app/components/ProductPages.tsx
@@ -378,9 +378,9 @@ export function ProductsLandingPage({ locale, links, projects }: ProductPageProp
           agent:
             "旗舰：AgentSight 观察和解释执行过程，ActPlane 在系统边界执行策略，Akeep 保存可检查、可恢复的原生会话历史。",
           bpftime:
-            "底层引擎与护城河：高性能 userspace eBPF runtime，同时支撑低开销 tracing、GPU paths 和定制 runtime extension。",
+            "底层运行时引擎：高性能 userspace eBPF runtime，同时支撑低开销 tracing、GPU paths 和定制 runtime extension。",
           services:
-            "过桥性质的 design-partner 合作：固定范围咨询、POC、生产加固、性能调优，以及 eBPF / agent infra 的定制集成。",
+            "Design-partner 与工程支持：固定范围咨询、POC、生产加固、性能调优，以及 eBPF / agent infra 的定制集成。",
           buyersTitle: "适合的团队",
           buyersDescription:
             "面向在生产里运行 AI agent，并需要把开源系统工程落地的 AI infra、platform 团队。",
@@ -415,9 +415,9 @@ export function ProductsLandingPage({ locale, links, projects }: ProductPageProp
           agent:
             "Flagship: AgentSight observes and explains execution, ActPlane enforces policy at system boundaries, and Akeep preserves inspectable, recoverable native session history.",
           bpftime:
-            "The engine and moat: a high-performance userspace eBPF runtime that also powers low-overhead tracing, GPU paths, and custom runtime extension.",
+            "The runtime engine: a high-performance userspace eBPF runtime that also powers low-overhead tracing, GPU paths, and custom runtime extension.",
           services:
-            "Bridge-style design-partner work: fixed-scope consulting, POCs, production hardening, performance tuning, and custom eBPF / agent infra integration.",
+            "Design-partner and engineering support: fixed-scope consulting, POCs, production hardening, performance tuning, and custom eBPF / agent infra integration.",
           buyersTitle: "Who it helps",
           buyersDescription:
             "Built for AI infrastructure and platform teams running AI agents in production that need open-source systems engineering to land.",

--- a/app/lib/ui-copy.ts
+++ b/app/lib/ui-copy.ts
@@ -106,7 +106,7 @@ export const siteFooterCopyByLocale = {
     explore: "Explore",
     projects: "Projects",
     community: "Community",
-    copyright: "Eunomia Labs, Inc. operates the site and supports the open-source systems research, eBPF tooling, and runnable documentation published here.",
+    copyright: "Eunomia is an open-source systems community building agent-native eBPF runtime infrastructure. Eunomia Labs, Inc. supports development and commercial work around the projects published here.",
     legacyBlog: "Legacy blog",
     sourceCode: "Site Source"
   },
@@ -114,7 +114,7 @@ export const siteFooterCopyByLocale = {
     explore: "浏览",
     projects: "项目",
     community: "社区",
-    copyright: "本网站由 Eunomia Labs, Inc. 运营，并支持这里发布的开源系统研究、eBPF 工具和可运行文档。",
+    copyright: "Eunomia 是构建 agent-native eBPF 运行时基础设施的开源系统社区。Eunomia Labs, Inc. 支持这里开源项目的开发与商业合作。",
     legacyBlog: "旧博客",
     sourceCode: "网站源码"
   }

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1067,7 +1067,7 @@ extra:
         - key: cupti-tutorial
           label: Open
           label_zh: 打开
-          href: /others/cuda-tutorial/
+          href: /others/cupti-tutorial/
         - key: nvbit-tutorial
           label: Open
           label_zh: 打开

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1067,7 +1067,7 @@ extra:
         - key: cupti-tutorial
           label: Open
           label_zh: 打开
-          href: /others/cupti-tutorial/
+          href: /others/cuda-tutorial/
         - key: nvbit-tutorial
           label: Open
           label_zh: 打开

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1168,6 +1168,7 @@ extra:
       lang: en
     - name: Chinese
       link: /zh/
+      lang: zh
 plugins:
   - meta
   - social

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -572,9 +572,9 @@ extra:
         zh: 教程
       secondary_href: /tutorials/
       tertiary_cta:
-        en: Products
-        zh: 产品
-      tertiary_href: /products/
+        en: Projects
+        zh: 项目
+      tertiary_href: /projects/
     capabilities_title:
       en: What Eunomia Provides
       zh: Eunomia 提供什么

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -561,8 +561,8 @@ extra:
         en: Eunomia
         zh: Eunomia
       summary:
-        en: Open-source eBPF infrastructure for runtime extension, GPU tracing, and AI Agents.
-        zh: 面向 runtime extension、GPU tracing 和 AI Agents 的开源 eBPF 基础设施。
+        en: Open-source agent-native eBPF runtime infrastructure.
+        zh: 面向 AI Agent 的开源 eBPF 运行时基础设施。
       primary_cta:
         en: GitHub
         zh: GitHub
@@ -1168,7 +1168,6 @@ extra:
       lang: en
     - name: Chinese
       link: /zh/
-      lang: zh
 plugins:
   - meta
   - social


### PR DESCRIPTION
## What changed

- Position the homepage as `Open-source agent-native eBPF runtime infrastructure.`
- Change the homepage tertiary CTA from Products to Projects.
- Document the long-term community-first identity of eunomia.dev in `CLAUDE.md`.
- Keep About and the footer community-first while explaining Eunomia Labs stewardship and support.
- Remove internal strategy wording (`moat`, `bridge-style`) from the Products page.

## Scope

- Header and primary navigation are unchanged.
- No public URLs are removed or moved.
- No pricing or product behavior changes.
- Existing projects, docs, tutorials, research, and community content remain first-class.