### PR TITLE
Daily: profile causality across async eBPF handoffs

### DIFF
--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -90,15 +90,20 @@ upgrade, safety, performance, and deployment boundaries.
    object-level replacement from application-level upgrade and developed an
    explicit prepare / migrate / commit / retire generation protocol for programs,
    links, maps, pinned state, controller recovery, and rollback.
-4. Preferred next question: what an asynchronous profiler built around modern
-   eBPF would need to reconstruct causality across syscalls, io_uring, work
-   queues, runtime tasks, and application-defined resources without unacceptable
-   overhead or sampling bias.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
+   execution from logical-work causality and developed typed, lifetime-aware
+   handoff edges, an edge-versus-context measurement budget, and a ground-truth
+   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
+   application-defined resources.
+5. Preferred next question: which new Linux I/O hooks and programmable interfaces
+   make previously impractical eBPF mechanisms possible, and what correctness,
+   portability, and performance contracts those hooks still lack.
 
-The series now has three substantial reports. A public series hub may be useful
-once the next report confirms that the sequence has enough reader value to merit
-an additional navigation surface; do not create a thin hub solely to satisfy the
-three-report threshold.
+The series now has four substantial reports. The existing Daily Report hub already
+exposes the sequence, while report-level acquisition and navigation evidence is
+still too young to justify another public navigation surface. Revisit a dedicated
+series hub when evidence shows that it improves retrieval; do not create a thin
+hub solely because the series crossed a count threshold.
 
 ### Preferred sequence
 

--- a/.github/seo-data/daily/2026-08-12.md
+++ b/.github/seo-data/daily/2026-08-12.md
@@ -90,7 +90,7 @@ Repository CI remains authoritative for the data validator, Daily Report checks,
 ## Delivery
 
 - Branch: `daily/2026-08-12-async-causal-profiler`
-- Pull request: pending creation on the same branch after the operating state files are complete
+- Pull request: `#155` on the same branch
 - Production target: GitHub Pages through `Deploy Static App`
 - Merge policy: squash merge only after all expected CI succeeds and the final diff/generated output passes self-review
 - Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, production deployment, bilingual public verification, source coverage, series classification, and remaining uncertainty; no second closeout PR

--- a/.github/seo-data/daily/2026-08-12.md
+++ b/.github/seo-data/daily/2026-08-12.md
@@ -1,0 +1,108 @@
+# SEO operations — 2026-08-12
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md`: analyze every enabled evidence source, audit technical SEO/GEO behavior, calculate the rolling Daily Report mix, research inside the active series, and publish exactly one new bilingual Daily Report. No unrelated technical SEO implementation change is included because the current evidence does not establish a new crawl, canonical, language-alternate, metadata, structured-data, redirect, rendering, accessibility, performance, or deployment defect.
+
+The active series remains **eBPF Runtime, Extensibility, and Composition**. Today's selected question is what an asynchronous profiler built around modern eBPF must track when logical work crosses syscalls, `io_uring`, workqueues, runtime tasks, and application-defined resources.
+
+## Data window
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | Drive export sets named `2026-07-27_to_2026-08-02_gsc_*.csv` and `2026-08-03_to_2026-08-09_gsc_*.csv`; date, query, page, country, device, and search-appearance dimensions | available; newest date rows still end on `2026-08-08`, so `2026-08-09` is absent from the current export despite now being older than the configured three-day finalization lag |
+| Google Analytics 4 | Drive organic landing-page exports named `2026-07-27_to_2026-08-02_ga4_*.csv` and `2026-08-03_to_2026-08-09_ga4_*.csv` | available; newest export has no date dimension and includes `2026-08-09`, so finalized-period analysis remains partial |
+| Public GitHub | current `eunomia-bpf/eunomia.dev` and recent `eunomia-bpf/bpftime` activity checked on `2026-08-12` | available |
+| Live site | current public homepage/navigation checked on `2026-08-12`; exact generated report output is required again during PR/deployment verification | available |
+| Public web / primary research sources | Linux kernel source/docs, Tokio docs, current profiler projects, 2026 systems papers and preprints checked through `2026-08-12` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
+
+A complete latest-seven-days versus previous-seven-days GSC comparison is still unavailable. The latest complete finalized seven-day window would be `2026-08-02` through `2026-08-08`, while its preceding comparison begins on `2026-07-26`, one day before the available history. The required 28-day comparison is also unavailable. Missing history is not treated as zero.
+
+A valid equal-duration comparison remains available from the overlapping history: `2026-08-03` through `2026-08-08` versus `2026-07-28` through `2026-08-02`.
+
+## Evidence collected
+
+### Search and traffic evidence
+
+For `2026-08-03` through `2026-08-08`, Search Console reports **478 clicks** and **69,053 impressions**, a weighted CTR of approximately **0.692%**, and an impression-weighted average position of approximately **9.42**. The comparable `2026-07-28` through `2026-08-02` slice reports **409 clicks**, **46,327 impressions**, **0.883%** CTR, and position approximately **8.18**. Clicks are about **16.9% higher** and impressions about **49.1% higher**, while CTR is about **0.191 percentage points lower** and average position is about **1.24 positions worse**.
+
+The movement remains non-uniform. `2026-08-05` contributes **24,516 impressions**, about **35.5%** of the newer six-day total, at position approximately **13.30** and CTR approximately **0.343%**. The current page and query exports are weekly aggregates rather than date-by-page or date-by-query matrices, so this run does not attribute the spike to one page or query family.
+
+The current device export remains desktop-heavy: desktop has **64,355 impressions** and **418 clicks**, mobile **4,614 / 59**, and tablet **84 / 1**. Desktop therefore contributes about **93.2%** of impressions. Search appearance still contains translated-result discovery with **1 click / 116 impressions**.
+
+Current page aggregates continue to show broad discovery rather than one report-driven movement. The homepage has **26 clicks / 1,077 impressions**, the Chinese GPU architecture tutorial **19 / 242**, Hello World **12 / 492**, `GPTtrace` **11 / 419**, TCX **9 / 317**, and XDP **8 / 849**. Several GPU profiling and NVIDIA source-analysis pages also have large impression counts at lower CTR. The newest Daily Report pages are too new for this weekly export to support a traffic conclusion about the report series.
+
+The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` but has no date dimension, so it is directional rather than a clean finalized-period comparison. `(not set)` remains the largest row at **116 sessions** with about **6.0%** engagement. The homepage has **43 sessions** at about **53.5%** engagement, the Chinese GPU-architecture page **28** at about **64.3%**, `GPTtrace` **18** at about **66.7%**, and the Chinese Hello World tutorial **18** at about **72.2%**. The shown export has no usable configured key-event signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative content or SEO change.
+
+### Previous-run closeout promoted into current state
+
+The `2026-08-11` daily operation is fully closed out. PR `#151` squash-merged as `5e57487b6055008082127129f4b68b8c2d5dc57f`. Its exact squash commit passed `Validate SEO Operations` run `31511561363` and production `Deploy Static App` run `31511561365`. The production Pages artifact contains the English and Chinese stateful-upgrade routes with the required report structure, canonical URLs, reciprocal `hreflang` plus `x-default`, Article JSON-LD, and Daily Report index navigation. These verified facts are promoted into `status.md` in today's change.
+
+### Repository and live-site evidence
+
+The current public homepage is crawlable and exposes Daily Report navigation alongside the repository's eBPF/runtime and project surfaces. Search-visible legacy `/en/` paths still exist, but the repository intentionally emits canonical redirect stubs for those routes. Today's evidence does not establish a new redirect, canonical, indexing, or language-routing failure.
+
+Recent public GitHub activity is consistent with the site's systems focus but is not treated as a conversion metric. `eunomia-bpf/bpftime` recently added an explicit selectable fuzzy Frida backtracer for stripped binaries and documented preload host-process behavior. The website repository also received current positioning, documentation-sync, and publication work. These are engineering signals that support continued runtime/profiling research, not proof of search demand for today's exact thesis.
+
+The pinned SEO-skill submodule remains `516e9e2dcf012506a677a749049d64c5914643e9`. A newer upstream layout removes interfaces that the current consuming repository still calls, including `change-seo-site` and `scripts/validate_seo_data.py`. Per the repository's current operating contract, the pointer is intentionally not advanced in isolation.
+
+### Rolling Daily Report mix and research evidence
+
+Before today's publication, the completed public archive contains five reports: **3 eBPF-centered / 2 pure Agent / 0 adjacent systems**. The two pure-Agent reports already occupy the long-term Agent budget, so today's report remains eBPF-centered. After publication the rolling archive becomes **4 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 6**, or about **66.7% eBPF-centered**.
+
+A weak framing, "use eBPF to build an async profiler," was rejected. Existing eBPF profilers already provide continuous CPU profiling, and recent `io_uring` work already reconstructs per-request subsystem flows. A second weak framing, "trace every asynchronous event and join them later," is retained as a strong baseline rather than presented as novelty.
+
+The narrower question passes the gap and novelty gate. Linux exposes useful but subsystem-local correlation identities: `io_uring` returns application-defined `user_data` at completion, workqueue tracepoints expose one `work_struct *` across queue and execution events, and scheduler events describe kernel-task execution. Async runtimes such as Tokio define their own task identities above the kernel boundary, while application-defined resources can require semantic adapters. Recent profiling research also shows that full tracing can be too expensive and that uniform sampling can create systematic attribution error.
+
+The report therefore develops a typed causal-edge model with explicit identity lifetime and evidence source, separates topology-defining edge capture from expensive context sampling under a fixed budget, and proposes a ground-truth benchmark that scores causal attribution rather than visual profile plausibility.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in today's delivery:
+
+- English: `/research/async-ebpf-causal-profiler/`
+- Chinese: `/zh/research/async-ebpf-causal-profiler/`
+
+Both Daily Report indexes are updated. The report contains the required concrete scenario, primary-source mechanism analysis, `Where current work is still weak` / `现有工作还薄弱在哪里` section, three developed research directions with explicit mechanism and falsification conditions, and a reader-facing conclusion describing evidence that would change the result.
+
+The report advances the active series from runtime contracts, hook composition, and transactional upgrade into measurement across asynchronous execution boundaries. The preferred next question is now which new Linux I/O hooks and programmable interfaces make eBPF mechanisms practical that were difficult or impossible with older hook sets.
+
+A separate public series hub is not added today. The existing Daily Report hub already exposes the four-report active sequence, and no report-level acquisition or navigation evidence yet shows that another public navigation surface would improve reader retrieval. This remains a future evidence-gated option rather than a cadence-driven page.
+
+No unrelated technical SEO implementation change is made because the current audit does not establish one.
+
+## Validation and self-review
+
+- No raw analytics rows, search queries, private source identifiers, credentials, account/property IDs, or Drive URLs are added to Git.
+- Search Console arithmetic uses equal finalized-duration slices and does not manufacture the missing `2026-07-26` or `2026-08-09` rows.
+- GA4 observations are described as directional because the export lacks a date dimension and a usable configured outcome signal.
+- Central technical claims use kernel/runtime documentation, source code, public profiler implementations, and current systems research rather than vendor marketing.
+- The report explicitly includes counterexamples where CPU/off-CPU profiling, cheap full tracing, or existing runtime tracing should beat the proposed mechanism.
+- English and Chinese pages share evidence and claims while using language-specific prose.
+- The intended change remains limited to one bilingual Daily Report, both Daily Report indexes, this operating record, current status, and active-series/plan continuity.
+- The SEO-skill submodule remains unchanged because a pointer-only update is incompatible with the consuming contract.
+
+Repository CI remains authoritative for the data validator, Daily Report checks, generated content, static build, link and metadata checks, and deployment readiness. The complete final PR diff and generated output must be self-reviewed after CI before squash merge.
+
+## Delivery
+
+- Branch: `daily/2026-08-12-async-causal-profiler`
+- Pull request: pending creation on the same branch after the operating state files are complete
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after all expected CI succeeds and the final diff/generated output passes self-review
+- Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, production deployment, bilingual public verification, source coverage, series classification, and remaining uncertainty; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Finish and verify today's async eBPF causal-profiling report through the exact merge/deployment/public-page contract.
+2. Continue the active **eBPF Runtime, Extensibility, and Composition** series with the next question: which new Linux I/O hooks or programmable interfaces enable eBPF mechanisms that older hook sets could not implement cleanly.
+3. Keep future reports eBPF-centered or directly adjacent until the two pure-Agent reports are diluted into the long-term mix.
+4. Keep reading both weekly Google export sets; the required complete 7-day and 28-day comparisons remain unavailable until the missing history exists.
+5. Obtain date-by-page or date-by-query GSC evidence before attributing the `2026-08-05` impression spike.
+6. Investigate GA4 `(not set)` with richer dimensions before changing measurement or content behavior.
+7. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows measurable harm from the canonical redirect stubs.
+8. Migrate the consuming SEO contract before advancing the pinned SEO-skill submodule.
+9. Add Cloudflare evidence only when a supported read-only path exists.

--- a/.github/seo-data/daily/2026-08-12.md
+++ b/.github/seo-data/daily/2026-08-12.md
@@ -12,8 +12,8 @@ This run used every source currently enabled by `.github/seo-data/site.md`.
 
 | Source | Coverage used | State |
 | --- | --- | --- |
-| Google Search Console | Drive export sets named `2026-07-27_to_2026-08-02_gsc_*.csv` and `2026-08-03_to_2026-08-09_gsc_*.csv`; date, query, page, country, device, and search-appearance dimensions | available; newest date rows still end on `2026-08-08`, so `2026-08-09` is absent from the current export despite now being older than the configured three-day finalization lag |
-| Google Analytics 4 | Drive organic landing-page exports named `2026-07-27_to_2026-08-02_ga4_*.csv` and `2026-08-03_to_2026-08-09_ga4_*.csv` | available; newest export has no date dimension and includes `2026-08-09`, so finalized-period analysis remains partial |
+| Google Search Console | Drive export sets named `2026-07-27_to_2026-08-02_gsc_*.csv` and `2026-08-03_to_2026-08-09_gsc_*.csv`; date, query, page, country, device, and search-appearance dimensions | available; newest date rows still end on `2026-08-08`, so `2026-08-09` is absent from the current export despite now being beyond the configured three-day finalization lag |
+| Google Analytics 4 | Drive organic landing-page exports named `2026-07-27_to_2026-08-02_ga4_*.csv` and `2026-08-03_to_2026-08-09_ga4_*.csv` | available; the complete `2026-08-03` through `2026-08-09` weekly export is now beyond the configured finalization lag and is comparable with the preceding weekly export |
 | Public GitHub | current `eunomia-bpf/eunomia.dev` and recent `eunomia-bpf/bpftime` activity checked on `2026-08-12` | available |
 | Live site | current public homepage/navigation checked on `2026-08-12`; exact generated report output is required again during PR/deployment verification | available |
 | Public web / primary research sources | Linux kernel source/docs, Tokio docs, current profiler projects, 2026 systems papers and preprints checked through `2026-08-12` | available |
@@ -21,7 +21,7 @@ This run used every source currently enabled by `.github/seo-data/site.md`.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison is still unavailable. The latest complete finalized seven-day window would be `2026-08-02` through `2026-08-08`, while its preceding comparison begins on `2026-07-26`, one day before the available history. The required 28-day comparison is also unavailable. Missing history is not treated as zero.
 
-A valid equal-duration comparison remains available from the overlapping history: `2026-08-03` through `2026-08-08` versus `2026-07-28` through `2026-08-02`.
+A valid equal-duration GSC comparison remains available from the overlapping history: `2026-08-03` through `2026-08-08` versus `2026-07-28` through `2026-08-02`. GA4 now has a valid adjacent weekly comparison for `2026-08-03` through `2026-08-09` versus `2026-07-27` through `2026-08-02` because the newer full export is beyond the configured finalization lag.
 
 ## Evidence collected
 
@@ -35,7 +35,7 @@ The current device export remains desktop-heavy: desktop has **64,355 impression
 
 Current page aggregates continue to show broad discovery rather than one report-driven movement. The homepage has **26 clicks / 1,077 impressions**, the Chinese GPU architecture tutorial **19 / 242**, Hello World **12 / 492**, `GPTtrace` **11 / 419**, TCX **9 / 317**, and XDP **8 / 849**. Several GPU profiling and NVIDIA source-analysis pages also have large impression counts at lower CTR. The newest Daily Report pages are too new for this weekly export to support a traffic conclusion about the report series.
 
-The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` but has no date dimension, so it is directional rather than a clean finalized-period comparison. `(not set)` remains the largest row at **116 sessions** with about **6.0%** engagement. The homepage has **43 sessions** at about **53.5%** engagement, the Chinese GPU-architecture page **28** at about **64.3%**, `GPTtrace` **18** at about **66.7%**, and the Chinese Hello World tutorial **18** at about **72.2%**. The shown export has no usable configured key-event signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative content or SEO change.
+The finalized GA4 organic landing-page export for `2026-08-03` through `2026-08-09` contains **991 sessions** with a session-weighted engagement rate of approximately **44.90%**. The preceding `2026-07-27` through `2026-08-02` export contains **1,021 sessions** at approximately **46.72%** engagement. Sessions are therefore about **2.9% lower** week over week and engagement rate about **1.81 percentage points lower**. The `(not set)` row fell from **157** to **116 sessions**, about **26.1% lower**; excluding that row, sessions are **875 versus 864**, about **1.3% higher**, while session-weighted engagement still declines from approximately **54.17%** to **50.06%**. The homepage rises from **34** to **43 sessions**, the Chinese GPU-architecture page from **17** to **28**, and `GPTtrace` from **5** to **18**, but these page movements remain small-base directional signals rather than reasons for a site change. The `keyEvents` column totals zero in both weekly exports; without stronger configuration evidence, this is not used to claim that the site had no conversions. `(not set)` remains a measurement-quality question rather than evidence for speculative content or SEO changes.
 
 ### Previous-run closeout promoted into current state
 
@@ -78,11 +78,11 @@ No unrelated technical SEO implementation change is made because the current aud
 
 - No raw analytics rows, search queries, private source identifiers, credentials, account/property IDs, or Drive URLs are added to Git.
 - Search Console arithmetic uses equal finalized-duration slices and does not manufacture the missing `2026-07-26` or `2026-08-09` rows.
-- GA4 observations are described as directional because the export lacks a date dimension and a usable configured outcome signal.
+- GA4 uses the two adjacent finalized weekly exports for its week-over-week comparison; zero-valued `keyEvents` rows are not promoted into a conversion claim without stronger configuration evidence.
 - Central technical claims use kernel/runtime documentation, source code, public profiler implementations, and current systems research rather than vendor marketing.
 - The report explicitly includes counterexamples where CPU/off-CPU profiling, cheap full tracing, or existing runtime tracing should beat the proposed mechanism.
 - English and Chinese pages share evidence and claims while using language-specific prose.
-- The intended change remains limited to one bilingual Daily Report, both Daily Report indexes, this operating record, current status, and active-series/plan continuity.
+- The intended change remains limited to one bilingual Daily Report, both Daily Report indexes, this operating record, current site/status metadata, and active-series/plan continuity.
 - The SEO-skill submodule remains unchanged because a pointer-only update is incompatible with the consuming contract.
 
 Repository CI remains authoritative for the data validator, Daily Report checks, generated content, static build, link and metadata checks, and deployment readiness. The complete final PR diff and generated output must be self-reviewed after CI before squash merge.
@@ -100,7 +100,7 @@ Repository CI remains authoritative for the data validator, Daily Report checks,
 1. Finish and verify today's async eBPF causal-profiling report through the exact merge/deployment/public-page contract.
 2. Continue the active **eBPF Runtime, Extensibility, and Composition** series with the next question: which new Linux I/O hooks or programmable interfaces enable eBPF mechanisms that older hook sets could not implement cleanly.
 3. Keep future reports eBPF-centered or directly adjacent until the two pure-Agent reports are diluted into the long-term mix.
-4. Keep reading both weekly Google export sets; the required complete 7-day and 28-day comparisons remain unavailable until the missing history exists.
+4. Keep reading both weekly Google export sets; the required complete GSC 7-day and 28-day comparisons remain unavailable until the missing history exists.
 5. Obtain date-by-page or date-by-query GSC evidence before attributing the `2026-08-05` impression spike.
 6. Investigate GA4 `(not set)` with richer dimensions before changing measurement or content behavior.
 7. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows measurable harm from the canonical redirect stubs.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -72,9 +72,10 @@ priorities that can guide a later daily run belong below.
 ## Current priorities
 
 1. Continue the **eBPF Runtime, Extensibility, and Composition** series. After the
-   stateful-upgrade report, prefer the asynchronous/causal profiling question
-   across syscalls, io_uring, work queues, runtime tasks, and application-defined
-   resources.
+   async causal-profiling report, prefer the next mechanism question: which new
+   Linux I/O hooks and programmable interfaces around `io_uring`, file access,
+   scheduling, caching, and fast paths make eBPF mechanisms practical that older
+   hook sets could not implement cleanly.
 2. Keep upcoming reports strongly eBPF-centered until the two existing pure-Agent
    reports are diluted into the long-term 5–7/10 eBPF and 1–2/10 pure-Agent mix.
 3. Use both verified weekly Search Console and GA4 Drive export sets in every run.
@@ -88,6 +89,9 @@ priorities that can guide a later daily run belong below.
 7. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside the approved eBPF and adjacent
    systems series.
-8. Migrate the consuming SEO contract before moving the pinned `seo-skills`
+8. Revisit a dedicated public hub for the active eBPF series only after report-level
+   acquisition or navigation evidence shows that it would improve retrieval beyond
+   the existing Daily Report index.
+9. Migrate the consuming SEO contract before moving the pinned `seo-skills`
    submodule to a newer upstream layout that removed interfaces this repository
    still calls.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -50,16 +50,16 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-Search Console and GA4 exports now provide two adjacent weekly export sets,
+Search Console and GA4 exports provide two adjacent weekly export sets,
 `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. As of
-`2026-08-11`, Search Console rows through `2026-08-08` are usable under the
-three-day finalization lag. A complete latest-7-days versus previous-7-days
-comparison is still unavailable because the required preceding period begins on
-`2026-07-26`, one day before the available history. The 28-day comparison is
-also unavailable. The newest GA4 landing-page export has no date dimension and
-includes `2026-08-09`, so it remains partial for finalized-period comparison.
-Public repository and live-site data supplement these exports but do not replace
-their source-native meanings.
+`2026-08-12`, the full GA4 weekly export through `2026-08-09` is beyond the
+configured three-day finalization lag and can be compared with the preceding
+weekly export. Search Console date rows still stop at `2026-08-08`; its complete
+latest-7-days versus previous-7-days comparison remains unavailable because the
+required preceding period begins on `2026-07-26`, one day before the available
+history. The 28-day comparison is also unavailable. Public repository and
+live-site data supplement these exports but do not replace their source-native
+meanings.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,63 +7,70 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-09`
+- Last completed daily run: `2026-08-11`
 - Last verified data window: Search Console rows through `2026-08-08`; GA4 weekly export through `2026-08-09` is partial for finalized analysis
-- Latest daily record: `2026-08-11`
-- Last public-change pull request: `#149`, verified in its merged-PR closeout comment
-- Last verified production deployment from a daily run: `Deploy Static App` run `31322000113` for squash commit `db383576aab403c63c4192bc8b52d75f300f58ce`
+- Latest daily record: `2026-08-12`
+- Last public-change pull request: `#151`, verified in its merged-PR closeout comment
+- Last verified production deployment from a daily run: `Deploy Static App` run `31511561365` for squash commit `5e57487b6055008082127129f4b68b8c2d5dc57f`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The `2026-08-11` daily record and stateful-upgrade report are in the current daily change. The prior `2026-08-10` attempt was closed without merge or deployment after `main` advanced; it is not counted as a completed daily publication. Per `DAILY_TASK.md`, exact merge/deployment/public verification for the current change belongs in the single merged-PR closeout comment, and the next run will promote those verified facts into this summary.
+The `2026-08-11` operation is fully closed out. PR `#151` squash-merged as `5e57487b6055008082127129f4b68b8c2d5dc57f`; the exact commit passed `Validate SEO Operations` run `31511561363` and production `Deploy Static App` run `31511561365`. The deployed Pages artifact contained both language variants of the stateful-upgrade report with the expected report structure, canonical URLs, reciprocal `hreflang` plus `x-default`, Article JSON-LD, and Daily Report index navigation.
+
+The `2026-08-12` async causal-profiling report is the current daily change. Per `DAILY_TASK.md`, its exact merge commit, final CI, deployment, and bilingual public verification belong in one closeout comment on the merged daily PR rather than a second closeout pull request.
 
 ## Current Daily Report mix
 
-The current change adds the fifth Daily Report:
+The current change adds the sixth Daily Report:
 
-- eBPF-centered: **3 of 5**
+- eBPF-centered: **4 of 6**
+  - `/research/async-ebpf-causal-profiler/`
   - `/research/stateful-ebpf-transactional-upgrade/`
   - `/research/ebpf-hook-composition-contract/`
   - `/research/userspace-ebpf-runtime-contract/`
-- pure Agent-centered: **2 of 5**
+- pure Agent-centered: **2 of 6**
   - `/research/agent-trace-evidence-budget/`
   - `/research/parallel-agent-effect-serializability/`
-- adjacent systems: **0 of 5**
+- adjacent systems: **0 of 6**
 
-The eBPF share is now 60%, which is inside the long-run 5–7/10 target proportion, while the two pure-Agent reports still occupy too much of the current five-report archive relative to the eventual 1–2/10 cap. Continue to favor eBPF and adjacent systems before another pure-Agent report. The active series remains **eBPF Runtime, Extensibility, and Composition**.
+The current change brings the eBPF-centered share to about **66.7%**, inside the long-run 5–7/10 target proportion. The two pure-Agent reports still represent too large a share of the six-report archive relative to the eventual 1–2/10 cap, so continue to favor eBPF and adjacent systems before another pure-Agent report. The active series remains **eBPF Runtime, Extensibility, and Composition**.
 
 ## Current signals
 
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
-- Google Analytics 4: two weekly Drive organic landing-page exports available; the newest export includes a non-finalized date and has no date dimension
-- Google Search Console: two adjacent weekly sets of date, search-appearance, device, country, page, and query exports available; current date rows extend through `2026-08-08`
+- Google Analytics 4: two weekly Drive organic landing-page exports available; the newest export includes `2026-08-09` and has no date dimension
+- Google Search Console: two adjacent weekly sets of date, search-appearance, device, country, page, and query exports available; current date rows still end on `2026-08-08`
 - Cloudflare: not configured
 
-The configured Drive folder now contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. With the configured three-day finalization lag on `2026-08-11`, Search Console rows through `2026-08-08` are usable. The latest complete finalized seven-day GSC window is therefore `2026-08-02` through `2026-08-08`, but its preceding comparison would require `2026-07-26`, which is absent. The required 7-day versus previous-7-day comparison and the 28-day comparison remain unavailable rather than being inferred.
+The configured Drive folder contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. The current Search Console date export still has rows only through `2026-08-08`. A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the preceding window would require `2026-07-26`, which is absent. The required 28-day comparison also remains unavailable rather than being inferred.
 
 A valid common-duration finalized six-day comparison is available. Search Console reports **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. That is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. The current weekly page/query aggregates cannot attribute that spike to one page or query family without a date-by-page or date-by-query export.
 
-The latest device export remains desktop-heavy at about **93.2%** of impressions. Translated-result search appearance is still present. Current page/query aggregates continue to show discovery around eBPF tutorials, XDP, CUDA/GPU material, project names, and long-tail systems questions. Raw query rows remain outside Git.
+The current device export remains desktop-heavy: desktop has **64,355 impressions / 418 clicks**, mobile **4,614 / 59**, and tablet **84 / 1**. Desktop therefore contributes about **93.2%** of impressions. Translated-result search appearance remains present at **1 click / 116 impressions**.
 
-The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` without a date dimension, so it is directional rather than a clean finalized-period comparison. `(not set)` remains the largest row at **116 sessions** with about **6.0%** engagement; the homepage has **43 sessions** at about **53.5%** engagement; the Chinese GPU-architecture page has **28 sessions** at about **64.3%** engagement; `GPTtrace` has **18 sessions** at about **66.7%** engagement; and the Chinese Hello World tutorial has **18 sessions** at about **72.2%** engagement. The export has no usable configured outcome signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative site change.
+Current page aggregates continue to show broad discovery across the homepage, eBPF tutorials, XDP/TCX, CUDA/GPU material, `GPTtrace`, AgentSight, bpftime, and long-tail systems pages. The current Daily Report pages are too new for the weekly Search Console export to support a report-level traffic conclusion. Raw query rows remain outside Git.
+
+The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` without a date dimension, so it remains directional rather than a clean finalized-period comparison. `(not set)` is the largest row at **116 sessions** with about **6.0%** engagement; the homepage has **43 sessions** at about **53.5%** engagement; the Chinese GPU-architecture page **28** at about **64.3%**; `GPTtrace` **18** at about **66.7%**; and the Chinese Hello World tutorial **18** at about **72.2%**. The export has no usable configured outcome signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative site change.
 
 ## Previous-run closeout
 
-The `2026-08-09` operation is fully closed out. PR `#149` squash-merged as `db383576aab403c63c4192bc8b52d75f300f58ce`. Its final `Validate SEO Operations` and `Deploy Static App` checks succeeded. Production `Deploy Static App` run `31322000113` completed successfully for that exact squash commit, and the deployed artifact contained the English and Chinese hook-composition pages with the required content, canonical URLs, reciprocal language alternates, Open Graph metadata, and Article JSON-LD.
+The `2026-08-11` operation is fully closed out. PR `#151` squash-merged as `5e57487b6055008082127129f4b68b8c2d5dc57f`. Its final `Validate SEO Operations` and production `Deploy Static App` workflows succeeded for the exact squash commit. The deployed artifact contained `/research/stateful-ebpf-transactional-upgrade/` and `/zh/research/stateful-ebpf-transactional-upgrade/` with required content, canonical URLs, reciprocal language alternates, Open Graph/Article metadata, and Daily Report navigation.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through the `Deploy Static App` workflow.
 
-The `2026-08-11` technical audit does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance defect that justifies an unrelated implementation change. The public homepage currently exposes the Daily Report entry point and the expected eBPF/runtime navigation. The newest GA4 slice still contains some legacy `/en/` traffic, but the repository intentionally emits canonical redirect stubs for those paths; this remains a monitoring item rather than a proven defect.
+The `2026-08-12` technical audit does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance defect that justifies an unrelated implementation change. The public homepage is crawlable and exposes the Daily Report entry point alongside the expected eBPF/runtime and project navigation. Search-visible legacy `/en/` paths remain a monitoring item because the repository intentionally emits canonical redirect stubs for them.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` currently points at `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`, but that newer layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer still requires a coordinated consumer migration rather than an isolated submodule bump.
+The active eBPF Runtime, Extensibility, and Composition sequence now has four substantial reports in the current change. The existing Daily Report hub already exposes the sequence. A separate series hub remains deferred until report-level acquisition or navigation evidence shows that another public surface would improve retrieval; do not create a thin page only because the series crossed a count threshold.
+
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. A newer upstream layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer still requires a coordinated consumer migration rather than an isolated submodule bump.
 
 ## Current focus
 
-1. Complete and verify the current stateful eBPF transactional-upgrade Daily Report from the latest `main`.
-2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: what an asynchronous profiler built around modern eBPF needs to reconstruct causality across syscalls, io_uring, work queues, runtime tasks, and application-defined resources without unacceptable overhead or sampling bias.
+1. Complete and verify the current async eBPF causal-profiling Daily Report through final CI, squash merge, exact production deployment, and bilingual public verification.
+2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: which new Linux I/O hooks and programmable interfaces make eBPF mechanisms practical that older hook sets could not implement cleanly.
 3. Continue favoring eBPF and adjacent systems until the rolling archive is comfortably inside the long-run 5–7/10 eBPF and 1–2/10 pure-Agent mix.
 4. Use both weekly GA4 and Search Console export sets in every run; keep required 7-day and 28-day comparisons marked unavailable until complete source history exists.
 5. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -8,7 +8,7 @@
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
 - Last completed daily run: `2026-08-11`
-- Last verified data window: Search Console rows through `2026-08-08`; GA4 weekly export through `2026-08-09` is partial for finalized analysis
+- Last verified data window: Search Console rows through `2026-08-08`; finalized GA4 weekly export through `2026-08-09`
 - Latest daily record: `2026-08-12`
 - Last public-change pull request: `#151`, verified in its merged-PR closeout comment
 - Last verified production deployment from a daily run: `Deploy Static App` run `31511561365` for squash commit `5e57487b6055008082127129f4b68b8c2d5dc57f`
@@ -39,19 +39,19 @@ The current change brings the eBPF-centered share to about **66.7%**, inside the
 - Live-site technical evidence: available
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
-- Google Analytics 4: two weekly Drive organic landing-page exports available; the newest export includes `2026-08-09` and has no date dimension
+- Google Analytics 4: two adjacent weekly Drive organic landing-page exports available and finalized through `2026-08-09`
 - Google Search Console: two adjacent weekly sets of date, search-appearance, device, country, page, and query exports available; current date rows still end on `2026-08-08`
 - Cloudflare: not configured
 
-The configured Drive folder contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. The current Search Console date export still has rows only through `2026-08-08`. A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the preceding window would require `2026-07-26`, which is absent. The required 28-day comparison also remains unavailable rather than being inferred.
+The configured Drive folder contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. Search Console date rows still stop at `2026-08-08`. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the preceding window would require `2026-07-26`, which is absent. The required 28-day comparison is also unavailable rather than inferred.
 
-A valid common-duration finalized six-day comparison is available. Search Console reports **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. That is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. The current weekly page/query aggregates cannot attribute that spike to one page or query family without a date-by-page or date-by-query export.
+A valid common-duration finalized six-day Search Console comparison is available. Search Console reports **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. That is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. The current weekly page/query aggregates cannot attribute that spike to one page or query family without a date-by-page or date-by-query export.
 
 The current device export remains desktop-heavy: desktop has **64,355 impressions / 418 clicks**, mobile **4,614 / 59**, and tablet **84 / 1**. Desktop therefore contributes about **93.2%** of impressions. Translated-result search appearance remains present at **1 click / 116 impressions**.
 
 Current page aggregates continue to show broad discovery across the homepage, eBPF tutorials, XDP/TCX, CUDA/GPU material, `GPTtrace`, AgentSight, bpftime, and long-tail systems pages. The current Daily Report pages are too new for the weekly Search Console export to support a report-level traffic conclusion. Raw query rows remain outside Git.
 
-The newest GA4 organic landing-page export covers `2026-08-03` through `2026-08-09` without a date dimension, so it remains directional rather than a clean finalized-period comparison. `(not set)` is the largest row at **116 sessions** with about **6.0%** engagement; the homepage has **43 sessions** at about **53.5%** engagement; the Chinese GPU-architecture page **28** at about **64.3%**; `GPTtrace` **18** at about **66.7%**; and the Chinese Hello World tutorial **18** at about **72.2%**. The export has no usable configured outcome signal for site-wide conversion claims. `(not set)` remains a measurement-quality question, not evidence for a speculative site change.
+GA4 now supports a complete adjacent weekly comparison. The `2026-08-03` through `2026-08-09` organic landing-page export contains **991 sessions** at a session-weighted engagement rate of about **44.90%**, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. Sessions are about **2.9% lower** and engagement rate about **1.81 percentage points lower**. `(not set)` falls from **157** to **116 sessions**; excluding it, sessions rise slightly from **864** to **875**, while engagement still declines from about **54.17%** to **50.06%**. The homepage rises from **34** to **43 sessions**, the Chinese GPU-architecture page from **17** to **28**, and `GPTtrace` from **5** to **18**, all small-base directional movements. Both weekly exports report zero in the `keyEvents` column, but that is not treated as proof of zero conversions without stronger configuration evidence. `(not set)` remains a measurement-quality question rather than evidence for a speculative site change.
 
 ## Previous-run closeout
 
@@ -72,7 +72,7 @@ The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c591464
 1. Complete and verify the current async eBPF causal-profiling Daily Report through final CI, squash merge, exact production deployment, and bilingual public verification.
 2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: which new Linux I/O hooks and programmable interfaces make eBPF mechanisms practical that older hook sets could not implement cleanly.
 3. Continue favoring eBPF and adjacent systems until the rolling archive is comfortably inside the long-run 5–7/10 eBPF and 1–2/10 pure-Agent mix.
-4. Use both weekly GA4 and Search Console export sets in every run; keep required 7-day and 28-day comparisons marked unavailable until complete source history exists.
+4. Use both weekly GA4 and Search Console export sets in every run; keep required GSC 7-day and 28-day comparisons marked unavailable until complete source history exists.
 5. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.
 6. Investigate GA4 `(not set)` with richer dimensions before making a measurement or content change.
 7. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows canonical redirect stubs are causing measurable harm.

--- a/docs/research/async-ebpf-causal-profiler.md
+++ b/docs/research/async-ebpf-causal-profiler.md
@@ -1,0 +1,338 @@
+---
+date: 2026-08-12
+title: "What Must an eBPF Profiler Track Beyond Threads?"
+description: "Async runtimes move work across threads, queues, and resources. This report asks how eBPF profiling can recover causal paths without tracing everything."
+tags:
+  - Daily Report
+  - eBPF
+  - Profiling
+  - Observability
+  - Linux
+research_question: "What causal identities and handoff edges must an eBPF-based asynchronous profiler capture across syscalls, io_uring, work queues, runtime tasks, and application-defined resources, and how can it do so without full tracing overhead or biased attribution?"
+source_cutoff: 2026-08-12
+status: daily-report
+---
+
+# What Must an eBPF Profiler Track Beyond Threads?
+
+Imagine a request handler that looks cheap in a normal CPU profile. It parses a request, submits an `io_uring` read, yields, resumes as a runtime task on another worker thread, queues a kernel work item, touches an application-managed cache, and finally sends a response. The request spends little continuous time on any one thread.
+
+A CPU flamegraph can show the functions that ran. An off-CPU profile can show where threads waited. A full trace can record many of the transitions. None of those automatically tells us that these pieces belong to one logical request, especially after the work leaves the original thread.
+
+<!-- more -->
+
+That is the core problem for asynchronous profiling. **Thread identity is no longer a sufficient causal identity.** Modern Linux already exposes useful handoff evidence. `io_uring` carries application-provided `user_data` from submission to completion. Workqueue tracepoints expose the same `work_struct *` when work is queued and when its callback starts. Async runtimes such as Tokio have their own task IDs and tracing spans. Application-defined resources such as buffer pools or query caches have identities that may exist only in program logic.
+
+The pieces are individually observable, but they do not form one common causal graph by themselves.
+
+The useful research question is therefore narrower than "build an async profiler with eBPF." The missing mechanism is a **typed causal-edge contract** that says which identity links two execution contexts, how long that identity is valid, how confident the link is, and what the profiler should report when an edge was not observed. A practical system should capture cheap synchronization and handoff edges more reliably than expensive stack context, then sample richer context under an explicit budget instead of pretending that an incomplete trace is complete.
+
+This report continues the [eBPF runtime and extensibility series](https://eunomia.dev/research/userspace-ebpf-runtime-contract/). It also builds on Eunomia's [wall-clock eBPF profiler tutorial](https://eunomia.dev/tutorials/32-wallclock-profiler/), which combines on-CPU and off-CPU accounting. The step beyond wall-clock accounting is preserving causality when logical work changes execution context.
+
+## CPU and off-CPU profiles stop being request histories
+
+Continuous eBPF profiling is already practical. Parca's eBPF profiler automatically discovers processes and produces pprof profiles. Grafana's OpenTelemetry eBPF profiler collects system-wide CPU stack samples and ships them through the OpenTelemetry profiling pipeline. These systems are valuable because they provide low-friction, always-on visibility without application SDK instrumentation.
+
+Their natural aggregation key is still close to a process, thread, stack, cgroup, or service label. That is exactly what a conventional profile needs. It is not necessarily what an asynchronous request needs.
+
+Consider three simplified execution intervals:
+
+```text
+thread 17: request A -> submit async read -> yield
+thread 23: request B -> CPU work -> yield
+thread 31: completion of A -> resume task A -> queue work
+```
+
+A CPU profile attributes execution to stacks sampled on threads 17, 23, and 31. An off-CPU profile can attribute waiting intervals to the thread or stack that blocked. But request A is not a thread. Its causal path moved from one task to an asynchronous I/O request and later to another execution context.
+
+This is not specific to Rust. Event loops, fibers, green threads, coroutine schedulers, work-stealing runtimes, user-level RPC systems, and callback-heavy C/C++ programs all separate logical work from the kernel thread currently executing it.
+
+Tokio's own documentation makes this boundary explicit. A Tokio task has an opaque ID that uniquely identifies a currently running task, while the runtime can schedule many tasks across worker threads. Tokio's tracing guide also explains why ordinary thread-oriented logs are difficult in asynchronous systems: tasks are multiplexed on threads, so events from different logical flows become interleaved. The runtime can expose task semantics, but application tracing is still needed to get the richest causal context.
+
+The consequence is simple: **a profiler that only samples thread stacks can be accurate about CPU execution and still be wrong about which logical operation paid for it.**
+
+## Linux already exposes several strong causal handoff keys
+
+The situation is not hopeless. Several important asynchronous mechanisms have explicit identities that can be observed at their handoff boundaries.
+
+### `io_uring` carries a user-selected correlation value
+
+The Linux `io_uring` UAPI defines a 64-bit `user_data` field in each submission queue entry. The corresponding completion queue entry returns the same value. Applications normally use it to identify which request completed.
+
+That is unusually useful for profiling. If the profiler can observe submission and completion while preserving `user_data`, it has a natural edge:
+
+```text
+submitting logical context
+        |
+        | io_uring user_data = X
+        v
+   async request X
+        |
+        | completion user_data = X
+        v
+completion-handling context
+```
+
+Current kernel source also contains `io_uring` tracepoints around request submission and completion. The exact internal execution path is richer than one submit/complete pair: requests may complete inline, use task work, be punted to io-wq workers, be polled, form links, or emit multiple completions. That is why correlating only `sched_switch` events cannot reconstruct an `io_uring` request lifecycle.
+
+Recent work makes the opportunity and the limitation concrete. The 2026 `uringscope` preprint reconstructs per-request `io_uring` flows with CO-RE eBPF and explicitly studies the fidelity/overhead tradeoff. It also points out that the relevant kernel tracepoint surface is not a stable ABI, so portability is part of the profiler problem rather than an implementation detail.
+
+`io_uring` therefore gives us a good subsystem-local causal key, not yet a system-wide causal identity.
+
+### Workqueues expose one object across queue and execution events
+
+Linux workqueue tracepoints similarly expose a `struct work_struct *work` when work is queued, activated, starts executing, and finishes. That makes it possible to connect a producer context to a later worker callback even when a different kernel worker thread performs the work.
+
+A profiler can model:
+
+```text
+producer context
+    |
+    | queue_work(work=W)
+    v
+work instance W
+    |
+    | execute_start(work=W)
+    v
+worker execution
+```
+
+The pointer is useful because the queue and execute events name the same object. It is not a permanent global identifier. Objects can be reused after their lifetime ends, events can be dropped, and a profiler that runs for days cannot treat a raw address as an eternal unique ID.
+
+This immediately suggests a general rule for asynchronous profiling: **every correlation key needs an explicit lifetime or generation boundary.** A pointer, file descriptor, runtime task ID, request token, or application handle is only meaningful inside the scope where reuse is impossible or detectable.
+
+### Thread scheduling remains useful, but as one edge type
+
+Scheduler events still matter. They explain when a kernel task runs, blocks, wakes, migrates, or competes for CPU. Off-CPU profiling depends on exactly this evidence. The mistake is to promote the kernel task to the universal causal unit.
+
+A better model treats scheduling as one family of edges among several:
+
+- task runnable -> task running;
+- syscall caller -> kernel operation;
+- submitting task -> `io_uring` request;
+- work producer -> workqueue item;
+- runtime parent task -> spawned task;
+- request -> application-defined resource event.
+
+The final profile should be able to aggregate by thread when that is useful, but it should not require all causal paths to remain inside one thread.
+
+## Runtime tasks and application resources cross the kernel visibility boundary
+
+Pure eBPF observation has an important limit: the kernel sees execution and kernel objects, but it does not automatically know the semantic identity of every user-space task or resource.
+
+Tokio provides an instructive example. It has task IDs, and its tracing ecosystem can expose structured task information. Those IDs are meaningful because the runtime defines them. The kernel scheduler sees the worker thread that polls a future, not the Rust future as a kernel task.
+
+The same problem becomes stronger for application-defined resources. A database buffer pool page, an internal query cache entry, a model-serving KV-cache block, or a temporary compiler object may dominate performance while having no kernel object whose identity captures its semantic role.
+
+The OSDI 2026 `gigiprofiler` work is strong evidence for this boundary. It targets performance problems caused by application-defined resources precisely because their semantics are not visible in ordinary system-level metrics. Its design combines semantic inference with static analysis, then instruments resource-use events and attributes them back to requests. It diagnosed 15 known issues across five applications and found two additional MariaDB issues confirmed by developers.
+
+This is a useful counterexample to an overambitious "zero-instrumentation eBPF sees everything" thesis. It does not. A system-level profiler can discover many effects without application cooperation, but logical task IDs and resource semantics sometimes exist only above the kernel boundary.
+
+The practical design should therefore be **hybrid, not purity-driven**:
+
+1. use eBPF for kernel-visible handoffs, scheduling, syscalls, I/O, process boundaries, and low-level resources;
+2. consume runtime-native task IDs when runtimes expose them;
+3. allow small application adapters for resource identities that cannot be inferred safely;
+4. keep every edge tagged with its source so downstream analysis knows which relationships were directly observed, inferred, or missing.
+
+This is similar in spirit to the [userspace eBPF runtime contract](https://eunomia.dev/research/userspace-ebpf-runtime-contract/): portability comes from making host-specific capabilities explicit, not from pretending every backend exposes the same semantics.
+
+## Full tracing is not the obvious answer
+
+Once we admit that profiles need causal edges, the tempting solution is to trace every event and join everything offline. That works for some workloads and is the strongest baseline a proposed profiler should beat. It is not automatically suitable for always-on deployment.
+
+Two recent OSDI 2026 systems illustrate opposite sides of the measurement problem.
+
+`StriaTrace` observes that production LLM inference tracing can be prohibitively expensive. Its design traces key synchronization points and critical paths, then enables detailed tracing around abnormalities. The reported evaluation reduces tracing overhead by 97.8% relative to alternatives while retaining enough evidence to diagnose hundreds of anomalies across 19 root-cause classes.
+
+`Blink` attacks a different problem: sampling itself can lie. In flat workloads with thousands of short-lived routines, sampling profilers can suffer from skid, shadow effects, and incomplete function coverage. The paper reports that these effects create systematic measurement error, not merely wider confidence intervals. Blink uses lightweight instrumentation and reports 99.999% accuracy at about 1% overhead for its target workloads.
+
+Together they rule out a simplistic design choice:
+
+- tracing every edge can be too expensive;
+- sampling every context can be systematically biased;
+- therefore "sample less" is not by itself an overhead solution.
+
+An asynchronous causal profiler needs to distinguish **which events define graph structure** from **which events provide expensive context**.
+
+A queue handoff may be rare and semantically decisive. Missing it can split one request into two unrelated profiles. A stack sample inside a long CPU phase can be statistically redundant because neighboring samples are similar. Those two event classes should not share the same sampling policy.
+
+## A sparse typed causal graph is a better profiling object
+
+The profiler does not need a complete event log. It needs enough evidence to reconstruct the parts of the causal graph that affect attribution.
+
+One possible internal model is:
+
+```text
+Node {
+    type: thread | runtime_task | io_request | work_item | resource | request
+    id: source-specific identity
+    generation: lifetime discriminator
+}
+
+Edge {
+    type: submit | complete | queue | wake | spawn | resume | acquire | release
+    src: Node
+    dst: Node
+    time: timestamp
+    source: kernel | runtime | application | inferred
+    confidence: observed | reconstructed | unknown
+}
+
+Sample {
+    node: Node
+    stack: optional stack context
+    weight: measured or statistical weight
+    inclusion_probability: optional sampling probability
+}
+```
+
+The important design choice is that a missing edge is not silently replaced with a guessed parent. If a completion arrives after its submission record was evicted, the system should preserve an orphaned completion or an `unknown` parent. That makes uncertainty visible instead of fabricating a clean request flamegraph.
+
+This graph does not need to remain in raw form. Once edges are joined, it can be compressed into profile stacks such as:
+
+```text
+request A
+  -> tokio task 91
+    -> io_uring read X
+      -> completion
+        -> tokio task 91
+          -> cache shard 4
+            -> function foo
+```
+
+The output can still be pprof-like and flamegraph-friendly. The difference is that stack ancestry now includes causal handoffs, not only call-stack ancestry.
+
+This is close to what an async profiler should mean: **profile weights attached to a reconstructed causality tree or DAG, with explicit evidence quality.**
+
+## Where current work is still weak
+
+### Correlation identities are local to each subsystem
+
+`io_uring` has `user_data`. Workqueues expose `work_struct *`. Runtime systems can expose task IDs. Networking, timers, futexes, block I/O, and user-level queues use other identities or no convenient identity at all.
+
+The missing mechanism is a common representation that can say, "this identifier is unique only inside ring R until completion," or "this pointer identifies one work item until execute-end," and can map those scoped identities into a profiler-wide node namespace.
+
+Without lifetime semantics, pointer or ID reuse creates false joins. Without source semantics, two 64-bit values from different subsystems can look comparable when they are not.
+
+A decisive test is long-running stress with aggressive object reuse. If a proposed profiler cannot keep causal precision when request IDs, pointers, and runtime task IDs wrap or are reused, the identity model is not strong enough.
+
+### Kernel observation cannot recover every logical task or resource
+
+A pure eBPF profiler can observe the worker thread that polls a future, but the runtime defines the future's task identity. It can observe memory accesses and syscalls around a database, but an application-defined cache entry or buffer pool has semantics that may not correspond to a kernel resource.
+
+The missing mechanism is a small adapter contract for runtime and application identities, with a safe fallback to `unknown` when no adapter exists.
+
+The research question is not whether adapters can be added. They obviously can. The interesting question is how small the adapter can be while preserving the zero- or low-instrumentation advantage for the rest of the system. If every framework needs invasive tracing, the result has collapsed back into ordinary distributed tracing.
+
+### The profiler lacks a budget model for graph edges versus context samples
+
+Traditional profilers often choose a sample frequency. Tracers often choose which events to enable. An asynchronous profiler needs both decisions at once.
+
+Missing a decisive handoff edge can destroy attribution for all later samples. Missing one of many similar CPU samples may barely change the aggregate. A uniform sampling probability therefore spends measurement budget poorly.
+
+The missing mechanism is an explicit budget allocator that protects high-value causal edges and samples expensive context separately. It should also record inclusion probabilities or another defensible weighting model so that aggregate estimates remain interpretable.
+
+The falsifier is empirical: if deterministic edge capture plus sampled context does not produce better attribution accuracy per unit overhead than full tracing, uniform sampling, or ordinary profiles, the extra machinery is not justified.
+
+### There is no common ground-truth benchmark for asynchronous causal attribution
+
+A generated flamegraph can look plausible even when its ancestry is wrong. That is dangerous because visual plausibility is not a correctness metric.
+
+The missing artifact is a benchmark that knows the true parent-child relationships across several asynchronous mechanisms and can inject difficult cases such as work stealing, completion reordering, multishot I/O, object reuse, dropped events, nested runtime tasks, and application-resource contention.
+
+The main metric should not only be runtime overhead. It should include causal-edge precision and recall, attribution error for wall time and resource cost, orphan rate, false-join rate, and error under event loss.
+
+If ordinary OpenTelemetry/runtime tracing already provides the same attribution accuracy at similar deployment cost for the target workloads, an eBPF-centered causal profiler should admit that result rather than claim novelty from its data source.
+
+## Promising directions with academic and production value
+
+### A typed causal-edge substrate for eBPF profiling
+
+**Gap.** Linux exposes useful asynchronous handoff identities, but each subsystem defines identity and lifetime differently. There is no common profiler contract across `io_uring`, workqueues, scheduler activity, runtime tasks, and application resources.
+
+**Mechanism.** Build a small edge-normalization layer. Each adapter emits scoped node identities and typed handoff edges. A kernel adapter might convert `(ring, user_data, generation)` into an `io_request` node and `(work pointer, queue generation)` into a `work_item` node. Runtime adapters map a Tokio task ID or another runtime-native handle into a `runtime_task` node. Every edge records source, lifetime scope, timestamps, and whether it was directly observed or reconstructed.
+
+The kernel side should keep only short-lived correlation state in bounded BPF maps. Userspace owns longer-term joining, generation management, eviction reporting, and graph compression. This avoids turning eBPF maps into an unbounded trace database.
+
+**Delta.** The delta from a conventional trace is not another event schema. It is the explicit cross-subsystem identity and lifetime contract plus the rule that unknown ancestry remains unknown. The delta from ordinary pprof is causal ancestry that can cross thread boundaries.
+
+**Artifact.** A libbpf or Aya-based collector with adapters for scheduler/syscalls, `io_uring`, workqueues, and one async runtime, plus a pprof-compatible exporter that can encode causal frames as synthetic profile labels or stack frames. The [eunomia-bpf developer tutorial](https://github.com/eunomia-bpf/bpf-developer-tutorial) could provide small reproducible eBPF probes for the kernel adapters.
+
+**Evaluation.** Build controlled pipelines that move one request through increasing numbers of handoffs. Measure edge precision/recall, false joins under pointer/ID reuse, memory consumed per live causal node, event-loss behavior, and end-to-end attribution error. Compare against perf/eBPF CPU profiling, wall-clock on/off-CPU profiling, runtime-native tracing, and full event tracing.
+
+**Academic value.** The research question is whether a small set of typed lifetime-aware edges is sufficient to reconstruct useful causality across heterogeneous asynchronous mechanisms.
+
+**Production value.** Operators get request- or operation-oriented profiles without requiring every component to adopt one tracing SDK, while still seeing where evidence is incomplete.
+
+**Failure condition.** If real applications require so many runtime-specific edge types that no compact contract emerges, the right abstraction is per-runtime tracing rather than a common causal profiler.
+
+### A budgeted edge-aware profiler with honest statistical weights
+
+**Gap.** Always-on full tracing can be expensive, while uniform stack sampling can miss short phases and causal handoffs or introduce systematic bias.
+
+**Mechanism.** Separate capture into two planes. The **edge plane** prioritizes semantically decisive handoffs such as queue, submit, completion, wake, spawn, and resource-acquire events. The **context plane** samples stacks, arguments, resource counters, or payload metadata under a configurable budget. Expensive context can be sampled adaptively by causal node, phase, or anomaly signal.
+
+When sampling is probabilistic, record enough information to estimate inclusion probability or to bound the class of valid aggregates. When a required edge was dropped because a buffer overflowed or correlation state was evicted, emit an explicit coverage break rather than joining across the gap.
+
+A useful adaptive policy could increase context sampling when a causal path crosses many subsystems, accumulates unexpected delay, or reaches a rare error, while keeping ordinary paths cheap. StriaTrace's key-synchronization and anomaly-focused design is a strong production baseline for this idea, while Blink is a warning that sampling policy must be validated against systematic error rather than tuned only for overhead.
+
+**Delta.** The novelty is treating causal edges and context samples as different statistical objects with different loss costs. Conventional sampling frequencies do not capture this asymmetry.
+
+**Artifact.** An always-on profiler with a fixed CPU/event budget, configurable edge priorities, event-loss telemetry, and a query layer that reports both estimated cost and causal coverage.
+
+**Evaluation.** Replay workloads under budgets from very small to near-full tracing. Compare causal attribution error, CPU overhead, event volume, tail-latency perturbation, and diagnostic success. Include flat workloads similar to Blink's failure mode so the profiler cannot win by choosing only easy heavy-hitter distributions.
+
+**Academic value.** This becomes a measurement problem: what is the optimal allocation of a fixed observability budget between topology-defining events and value-estimating samples?
+
+**Production value.** Teams can run the profiler continuously with a predictable cost and know when a diagnosis is based on incomplete causality instead of receiving a falsely precise flamegraph.
+
+**Failure condition.** If the edge plane itself dominates overhead on high-event-rate workloads, or if no stable weighting scheme survives adaptive sampling, the design needs stronger aggregation at source or a narrower supported workload class.
+
+### A ground-truth async causality benchmark
+
+**Gap.** Existing profilers can be compared on CPU overhead and profile shape while still disagreeing about which logical operation caused the work.
+
+**Mechanism.** Build a benchmark harness where every logical operation carries a hidden ground-truth ID through controlled asynchronous mechanisms. Include synchronous calls, `io_uring`, kernel workqueues, timers, futex handoffs, a Tokio or equivalent task runtime, and one application-defined resource such as a bounded cache or buffer pool. The ground-truth channel is used only by the evaluator, not by the profiler under test.
+
+Fault modes should deliberately stress the identity model: work stealing, concurrent reuse of pools, delayed and out-of-order completion, multishot requests, dropped trace records, truncated buffers, nested task spawn, cancellation, and application-resource reuse.
+
+**Delta.** The benchmark scores *causal attribution*, not merely whether expected trace events appeared. It can therefore compare a CPU sampler, an off-CPU profiler, full tracing, runtime/OpenTelemetry instrumentation, `uringscope`-style subsystem reconstruction, and a hybrid causal profiler under the same workloads.
+
+**Artifact.** A reproducible Linux benchmark suite, reference traces, and metrics for edge precision/recall, false joins, orphan rate, attributed wall-time error, resource-cost error, overhead, and tail perturbation.
+
+**Evaluation.** Run across kernel versions, CPU counts, runtime worker counts, queue depths, request fan-out, and controlled event-loss rates. Include both thread-affine workloads, where ordinary profiling should win on simplicity, and heavily asynchronous workloads, where causal reconstruction should show measurable benefit.
+
+**Academic value.** The benchmark turns a vague claim about "understanding async systems" into a falsifiable profiling problem.
+
+**Production value.** Tool builders can tell users which async mechanisms and loss regimes are supported rather than marketing a generic low-overhead profiler with unknown attribution accuracy.
+
+**Failure condition.** If causal accuracy has little correlation with real diagnostic outcomes, then edge precision is the wrong target metric and the benchmark should be redesigned around operator decisions.
+
+## What would change this conclusion?
+
+The strongest counterexample is a workload whose performance is mostly thread-local. A CPU-bound worker pool, a synchronous service, or an application where request identity never leaves one thread may be diagnosed perfectly well by CPU plus off-CPU profiles. Such systems do not need a causal graph merely because the profiler can build one.
+
+A second counterexample is cheap full tracing. If relevant synchronization and runtime events can be traced continuously with negligible overhead, bounded storage, and stable schemas, then a complex edge/context budget may be unnecessary. `uringscope` already shows that targeted request reconstruction can be practical for one subsystem; future kernels or tracing infrastructure could make broader full-fidelity capture much cheaper.
+
+A third counterexample is instrumentation availability. If the runtime and application already emit high-quality OpenTelemetry or native causal spans, the eBPF layer may be most valuable for validating system effects and filling low-level gaps rather than reconstructing the primary request graph.
+
+Finally, the proposed graph is only useful if it improves diagnosis. A prototype should be rejected if its causal flamegraphs are more visually sophisticated but do not reduce time-to-root-cause, improve attribution accuracy, or discover failures that simpler profiles miss.
+
+The thesis is therefore bounded: **eBPF can provide a strong system-level edge substrate for asynchronous profiling, but a trustworthy profiler must combine subsystem-local identities, runtime/application semantics, explicit lifetime rules, and a measurement budget that treats missing causality as uncertainty rather than inventing a clean thread-shaped story.**
+
+## References
+
+- [Linux Kernel Tracepoint API: workqueue tracepoints](https://docs.kernel.org/core-api/tracepoint.html)
+- [Linux `io_uring` UAPI: SQE and CQE `user_data`](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h)
+- [Linux `io_uring` implementation and tracepoints](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c)
+- [Tokio task IDs](https://docs.rs/tokio/latest/tokio/task/struct.Id.html)
+- [Tokio: Getting started with Tracing](https://tokio.rs/tokio/topics/tracing)
+- [Parca continuous profiling and eBPF profiler](https://github.com/parca-dev/parca)
+- [Grafana Pyroscope: OpenTelemetry eBPF profiler](https://grafana.com/docs/pyroscope/latest/configure-client/opentelemetry/ebpf-profiler/)
+- [uringscope: Portable, Low-Overhead Observability for io_uring](https://arxiv.org/abs/2606.15137)
+- [Beyond Thread States: Diagnosing Performance Degradation with eBPF and Thread Dynamics](https://arxiv.org/abs/2605.25298)
+- [When Sampling Lies: Trustworthy Performance Profiling for Flat Workloads with Blink](https://www.usenix.org/conference/osdi26/presentation/devsot)
+- [StriaTrace: Efficient Tracing and Diagnosis for Online LLM Inference](https://www.usenix.org/conference/osdi26/presentation/wu-haonan)
+- [Diagnosing Performance Issues in Application-Defined Resources](https://www.usenix.org/conference/osdi26/presentation/hu-yigong)
+- [SysOM-AI: Continuous Cross-Layer Performance Diagnosis for Production AI Training](https://arxiv.org/abs/2603.29235)

--- a/docs/research/async-ebpf-causal-profiler.zh.md
+++ b/docs/research/async-ebpf-causal-profiler.zh.md
@@ -1,0 +1,336 @@
+---
+date: 2026-08-12
+title: "异步系统里，eBPF Profiler 还要追踪什么？"
+description: "异步运行时让工作跨越线程、队列与应用资源。本文分析 eBPF profiler 如何重建因果路径，并在不全量追踪的前提下控制开销与采样偏差。"
+tags:
+  - Daily Report
+  - eBPF
+  - Profiling
+  - Observability
+  - Linux
+research_question: "eBPF 异步 profiler 要跨越 syscall、io_uring、workqueue、runtime task 与应用自定义资源重建因果关系，需要哪些身份与 handoff edge，又该如何在不承担全量 tracing 开销和采样偏差的前提下完成这件事？"
+source_cutoff: 2026-08-12
+status: daily-report
+---
+
+# 异步系统里，eBPF Profiler 还要追踪什么？
+
+假设一个请求在普通 CPU profile 里几乎不显眼。它先解析请求，提交一次 `io_uring` 读取，然后 yield；稍后同一个逻辑任务在另一条 worker thread 上恢复，又触发一个 kernel work item，访问应用自己管理的 cache，最后才发回响应。整个请求没有长时间连续占用任何一条线程。
+
+CPU flamegraph 能告诉我们哪些函数运行过，off-CPU profile 能告诉我们线程在哪里等待，全量 trace 也许能记录其中很多转换。但这些工具不会天然知道，分散在几条线程、几个队列和多个资源上的事件其实属于同一个逻辑请求。
+
+<!-- more -->
+
+这就是异步 profiling 的核心问题：**thread identity 已经不足以充当 causal identity。** Linux 其实已经暴露了不少很有价值的 handoff 证据。`io_uring` 会把应用提供的 `user_data` 从 submission 带回 completion；workqueue tracepoint 在排队和开始执行时都暴露同一个 `work_struct *`；Tokio 一类 async runtime 有自己的 task ID 和 tracing span；buffer pool、query cache 这类 application-defined resource 则可能只有应用代码自己知道它们的语义身份。
+
+这些证据分别可以看到，但它们不会自动拼成一个统一的因果图。
+
+所以真正值得研究的问题不是泛泛地“用 eBPF 做一个 async profiler”，而是建立一个**带类型的 causal-edge contract**：什么 identity 能连接两个执行上下文，这个 identity 有效多久，这条关联来自直接观测还是重建，以及某条 edge 没看到时 profiler 应该怎样表示不确定性。一个可部署的系统应该优先保住便宜但决定因果结构的 handoff edge，再在明确预算下采样昂贵的 stack 和上下文，而不是把不完整的 trace 渲染成看似完整的故事。
+
+本文继续 [eBPF Runtime, Extensibility, and Composition](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/) 系列，也承接 Eunomia 已有的 [on-CPU + off-CPU wall-clock profiler 教程](https://eunomia.dev/zh/tutorials/32-wallclock-profiler/)。wall-clock profiling 的下一步，不只是把等待时间补进 flamegraph，而是在逻辑工作跨执行上下文之后还能保留因果关系。
+
+## CPU 与 off-CPU profile 不是请求历史
+
+持续 eBPF profiling 已经是成熟而实用的方向。Parca 的 eBPF profiler 可以自动发现进程并生成 pprof profile；Grafana 的 OpenTelemetry eBPF profiler 可以在 Linux host 上系统级采样 CPU stack，再通过 OpenTelemetry profiling pipeline 发送出去。这类方案的价值很明确：无需为每个应用接 SDK，就能低成本长期获得执行热点。
+
+它们自然的聚合单位仍接近 process、thread、stack、cgroup 或 service label。对传统 profiler 来说这完全合理，但异步请求的逻辑身份未必等于这些单位。
+
+考虑一个简化执行过程：
+
+```text
+thread 17: request A -> submit async read -> yield
+thread 23: request B -> CPU work -> yield
+thread 31: completion of A -> resume task A -> queue work
+```
+
+CPU profiler 会把执行栈采在 thread 17、23、31 上。off-CPU profiler 可以计算一条线程何时阻塞、何时被唤醒。但 request A 并不是一条线程。它先变成一个 async I/O request，之后又进入另一个执行上下文。
+
+这也不是 Rust 特有的问题。event loop、fiber、green thread、coroutine scheduler、work-stealing runtime、用户态 RPC runtime 和 callback 密集的 C/C++ 程序都可能让逻辑工作脱离最初的 kernel thread。
+
+Tokio 的文档直接展示了这个边界。Tokio task 有一个 opaque ID，用来唯一标识当前运行中的 task；runtime 可以把大量 task 调度到 worker threads 上。Tokio 的 tracing 文档也解释了为什么异步系统里普通 thread-oriented log 很难读：多个 task 被复用在同一线程上，不同逻辑流的事件会互相穿插。runtime 能暴露 task 语义，但最丰富的应用因果上下文仍然需要上层 instrumentation。
+
+所以一个 profiler 完全可能**准确地描述 CPU 在哪里执行，却错误地回答“这是谁的成本”**。
+
+## Linux 已经提供了一些很强的 handoff key
+
+异步因果并非完全不可见。几个关键 Linux 子系统已经有可以跨执行上下文关联事件的 identity。
+
+### `io_uring` 自带应用选择的 correlation value
+
+Linux `io_uring` UAPI 在每个 SQE 中定义了 64-bit `user_data`，对应 CQE 会把同一个值带回来。应用通常就靠它判断“哪一个请求完成了”。
+
+对 profiler 来说，这几乎是天然的 causal edge：
+
+```text
+提交时的逻辑上下文
+        |
+        | io_uring user_data = X
+        v
+   async request X
+        |
+        | completion user_data = X
+        v
+完成处理时的上下文
+```
+
+当前 Linux kernel source 也在 `io_uring` 请求提交和完成等路径上提供 tracepoint。不过实际 request lifecycle 比 submit/complete 两点复杂得多：请求可能 inline complete，也可能通过 task work、io-wq worker、poll path、linked request 或 multishot completion 继续执行。因此仅靠 `sched_switch` 很难恢复一个 `io_uring` request 的真实路径。
+
+2026 年的 `uringscope` preprint 把这个机会和局限讲得很清楚。它用 CO-RE eBPF 重建 per-request `io_uring` flow，并专门评估 fidelity 和 overhead 的取舍。同时它指出相关 kernel tracepoint surface 不是稳定 ABI，所以 portability 本身就是 profiler 设计的一部分。
+
+因此 `io_uring` 给了我们一个很好的**子系统内部 causal key**，但它仍然不是系统范围的统一 identity。
+
+### Workqueue 在排队和执行阶段暴露同一个对象
+
+Linux workqueue tracepoint 会在 queue、activate、execute-start、execute-end 等阶段暴露 `struct work_struct *work`。即使实际 callback 由另一条 kernel worker thread 执行，profiler 仍可以把 producer 与 worker 连接起来：
+
+```text
+producer context
+    |
+    | queue_work(work=W)
+    v
+work instance W
+    |
+    | execute_start(work=W)
+    v
+worker execution
+```
+
+这个 pointer 很有用，因为两端确实在命名同一个 work object。但 raw pointer 不是永久 global ID。对象生命周期结束后地址可以重用，trace event 也可能丢失。一个运行几天的 profiler 不能把地址当成永不重复的身份。
+
+这直接导出一个更一般的设计原则：**每一种 correlation key 都必须带生命周期或 generation 语义。** pointer、file descriptor、runtime task ID、request token 或应用 handle，都只在一个明确作用域里安全。
+
+### Scheduler 仍然重要，但只是 edge 类型之一
+
+scheduler event 当然不能丢。它们解释 kernel task 什么时候 runnable、什么时候真正运行、什么时候 block、wake、migrate 或争抢 CPU，off-CPU profiling 也依赖这些证据。
+
+问题只是不能再把 kernel task 升格成所有因果关系的唯一单位。更合理的模型应该同时容纳：
+
+- task runnable -> task running；
+- syscall caller -> kernel operation；
+- submitting task -> `io_uring` request；
+- work producer -> workqueue item；
+- runtime parent task -> spawned task；
+- request -> application-defined resource event。
+
+最终输出仍然可以按 thread 聚合，但整个因果链不应该被强制限制在一条 thread 内。
+
+## Runtime task 和应用资源越过了 kernel visibility 边界
+
+纯 eBPF observation 有一个必须承认的边界：kernel 可以看到执行和 kernel object，但它不会自动理解每一个用户态 task 或资源的语义身份。
+
+Tokio 就是很清楚的例子。它有 task ID，也能通过 tracing 生态暴露结构化 task 信息。这个 ID 之所以有意义，是因为 runtime 自己定义了 task。kernel scheduler 看到的是“某条 worker thread 正在 poll future”，并不会把这个 future 当成 kernel task。
+
+application-defined resource 更明显。数据库 buffer pool page、内部 query cache entry、模型服务的 KV-cache block、编译器临时对象，都可能直接决定性能，却没有一个 kernel resource ID 能表达它们在应用中的真实角色。
+
+OSDI 2026 的 `gigiprofiler` 正好说明了这个缺口。它研究 application-defined resource 导致的性能问题，因为普通 system-level metric 看不到这些资源的语义。它用 LLM semantic inference 找候选资源，再用 static analysis 验证，运行时记录 resource usage 并关联到 request。论文在 5 个应用的 15 个真实问题上完成诊断，还发现了 2 个之后被 MariaDB 开发者确认的新问题。
+
+这对“zero-instrumentation eBPF 可以看到一切”是一个很强的反例。系统级 profiler 确实能在无需应用 SDK 的情况下看到大量 effect，但 logical task 和 application resource 的身份有时只存在于 kernel 之上。
+
+因此更合理的方案应该是 **hybrid，而不是追求纯粹**：
+
+1. eBPF 负责 kernel-visible handoff、scheduler、syscall、I/O、process boundary 和低层资源；
+2. runtime 能提供 task ID 时直接消费 runtime-native identity；
+3. application-defined resource 无法可靠推断时允许极小 adapter；
+4. 每条 edge 都保留来源，明确它是 direct observation、reconstruction 还是缺失。
+
+这和前面的 [用户态 eBPF runtime contract](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/) 是同一个设计思想：可移植性来自显式表达 backend 能力差异，而不是假装所有环境都暴露相同语义。
+
+## “全部 trace 下来”也不是显然正确的答案
+
+既然 profiling 需要 causal edge，一个直接方案就是把所有相关 event 全量追踪，再离线 join。这是很强的 baseline，也应该进入实验，但它不一定适合 always-on production。
+
+OSDI 2026 有两项工作从两个方向说明了 measurement 的难点。
+
+`StriaTrace` 观察到 production LLM inference 的细粒度 tracing 可能开销过高。它选择追踪关键 synchronization point 和 critical path，并只在异常附近展开详细 tracing。论文报告相对替代方案降低 97.8% tracing overhead，并在生产开发流程中诊断了数百个、覆盖 19 类 root cause 的异常。
+
+`Blink` 研究的是另一面：sampling 本身也可能“撒谎”。对于包含大量短函数、没有明显 heavy hitter 的 flat workload，perf 一类 sampling profiler 会因为 skid、shadow effect 和 function coverage 不完整产生系统性误差，而不只是 variance 变大。Blink 用轻量 instrumentation 换取精确覆盖，在其目标 workload 上报告约 1% overhead 和 99.999% accuracy。
+
+两项结果放在一起，排除了一个过度简单的策略：
+
+- 全量 trace 可能太贵；
+- uniform sample 可能系统性偏；
+- 所以单纯“少采一点”不是充分的 overhead 方案。
+
+异步 causal profiler 必须区分**哪些 event 决定图结构**，哪些 event 只是提供昂贵上下文。
+
+一个 queue handoff 也许不频繁，却非常关键。丢掉它可能直接把一个 request 分裂成两个互不相关的 profile。相反，在很长的 CPU phase 里少掉一个 stack sample，可能对最终 aggregate 几乎没有影响。这两类 event 不应该共用同一种 sampling policy。
+
+## 更合理的 profiling object 是稀疏 typed causal graph
+
+profiler 不一定要保存完整 event log。它需要的是足够多的证据，恢复对成本归属有意义的 causal graph。
+
+内部数据模型可以类似：
+
+```text
+Node {
+    type: thread | runtime_task | io_request | work_item | resource | request
+    id: source-specific identity
+    generation: lifetime discriminator
+}
+
+Edge {
+    type: submit | complete | queue | wake | spawn | resume | acquire | release
+    src: Node
+    dst: Node
+    time: timestamp
+    source: kernel | runtime | application | inferred
+    confidence: observed | reconstructed | unknown
+}
+
+Sample {
+    node: Node
+    stack: optional stack context
+    weight: measured or statistical weight
+    inclusion_probability: optional sampling probability
+}
+```
+
+这里最重要的一点不是 schema 长什么样，而是**缺失 edge 不能被静默猜出来**。如果 completion 到达时 submission record 已经被 eviction，系统应该保留 orphaned completion 或 `unknown` parent，而不是硬把它接到“最可能”的 request 上。
+
+joined graph 最终也不必原样展示。它可以压缩成 pprof/flamegraph 兼容的 causal stack：
+
+```text
+request A
+  -> tokio task 91
+    -> io_uring read X
+      -> completion
+        -> tokio task 91
+          -> cache shard 4
+            -> function foo
+```
+
+这样输出仍然是大家熟悉的 profile，但 ancestry 不再只有 call-stack ancestry，还包含跨 thread 的 causal handoff。
+
+这才更接近“async profiler”应该解决的问题：**把 profile weight 挂到重建出来的 causality tree/DAG 上，并同时暴露证据质量。**
+
+## 现有工作还薄弱在哪里
+
+### 各子系统的 correlation identity 仍然彼此割裂
+
+`io_uring` 有 `user_data`，workqueue 有 `work_struct *`，runtime 有 task ID，timer、futex、network、block I/O 和用户态 queue 又有各自的 identity，或者根本没有方便的统一 key。
+
+缺的不是再发明一个 64-bit ID，而是一种表示法，能明确说“这个 ID 只在 ring R 内、直到 completion 前唯一”，或者“这个 pointer 只在这次 work lifetime 内有效”，并把这些 scoped identity 映射到 profiler 自己的 node namespace。
+
+没有 lifetime 语义，pointer/ID reuse 会制造 false join；没有 source 语义，来自不同 subsystem 的两个 64-bit value 看上去一样，实际却完全不可比较。
+
+最直接的实验是长时间高并发运行并主动制造对象复用。如果 profiler 在 request ID、pointer 和 runtime task ID 大量 reuse 后无法维持 causal precision，这个 identity model 就不够强。
+
+### Kernel 无法恢复所有 logical task 和 resource
+
+纯 eBPF 可以看到 future 被哪条 worker thread poll，却不能天然知道 runtime 定义的 task identity；可以看到数据库周围的 syscall 与 memory behavior，却不懂某个 cache entry 或 buffer pool page 的应用语义。
+
+缺少的是一个很小的 runtime/application adapter contract，并且在 adapter 不存在时必须安全退化到 `unknown`。
+
+研究价值不在于“adapter 能不能写”，答案当然是能。真正的问题是 adapter 能多小，同时让系统其余部分保留 zero/low-instrumentation 优势。如果每个 framework 都要大规模埋点，系统就退化回普通 distributed tracing。
+
+### Edge 与 context 没有统一的 measurement budget
+
+传统 profiler 常决定 sample frequency，tracer 常决定 enable 哪些 event。async profiler 两个问题都要同时回答。
+
+漏掉一个决定性 handoff edge，后面的所有 sample 可能全部失去 attribution；漏掉很多相似 CPU sample 中的一次，对 aggregate 影响却很小。因此 uniform sampling 会把 observability budget 花在错误的位置。
+
+缺少的是一个明确的 budget allocator，优先保护 high-value causal edge，再单独采样 stack、argument、resource counter 等昂贵上下文。对于 probabilistic sample，还要保留 inclusion probability 或其他可解释 weighting 机制。
+
+如果实验表明“deterministic edge + sampled context”在相同 overhead 下并不能比 full tracing、uniform sampling 或普通 profile 得到更准确的 attribution，这套额外机制就应该被否定。
+
+### 还缺一个真正测 causal attribution 的 ground-truth benchmark
+
+一个 flamegraph 看起来很合理，不代表它的 ancestry 是真的。这在 profiling 里尤其危险，因为视觉合理性很容易被误当成 correctness。
+
+缺少的是一个 benchmark，能够知道跨多种 async mechanism 的真实 parent-child 关系，并主动制造 work stealing、completion reorder、multishot I/O、object reuse、event loss、nested task 和 application-resource contention 等困难情况。
+
+核心指标不能只有 runtime overhead，还应该包括 causal-edge precision/recall、wall time/resource cost attribution error、orphan rate、false-join rate，以及 event loss 下的退化曲线。
+
+如果普通 OpenTelemetry/runtime tracing 在目标 workload 上以相似 deployment cost 就能获得同等 attribution accuracy，那么 eBPF causal profiler 应该接受这个结果，而不是因为底层数据来自 eBPF 就宣称新颖性。
+
+## 具有学术价值和生产价值的方向
+
+### 为 eBPF profiler 建立 typed causal-edge substrate
+
+**Gap.** Linux 已经暴露多个异步 handoff identity，但每个 subsystem 的 identity 和 lifetime 语义不同，`io_uring`、workqueue、scheduler、runtime task 与应用资源之间没有共同 contract。
+
+**Mechanism.** 建一个很薄的 edge normalization layer。每个 adapter 输出 scoped node identity 与 typed handoff edge。kernel adapter 可以把 `(ring, user_data, generation)` 映射成 `io_request`，把 `(work pointer, queue generation)` 映射成 `work_item`；runtime adapter 把 Tokio task ID 等 runtime-native handle 映射成 `runtime_task`。每条 edge 都记录 source、lifetime scope、timestamp，以及它是直接观测还是重建。
+
+kernel side 只在有界 BPF map 中保存短生命周期 correlation state。长时间 join、generation management、eviction report 和 graph compression 放到 userspace，避免把 BPF map 变成无限增长的 trace database。
+
+**Delta.** 和普通 trace 的区别不是再造一个 event schema，而是显式定义 cross-subsystem identity/lifetime，以及“unknown ancestry 必须保持 unknown”的规则。和普通 pprof 的区别则是 stack ancestry 可以跨 thread。
+
+**Artifact.** 一个基于 libbpf 或 Aya 的 collector，先实现 scheduler/syscall、`io_uring`、workqueue 和一种 async runtime adapter，再提供 pprof-compatible exporter，把 causal frame 编码成 synthetic frame 或 label。kernel adapter 的最小复现 probe 可以继续放进 [eunomia-bpf developer tutorial](https://github.com/eunomia-bpf/bpf-developer-tutorial)。
+
+**Evaluation.** 构建逐步增加 handoff 数量的请求 pipeline，测 edge precision/recall、pointer/ID reuse 下的 false join、每个 live causal node 的内存开销、event loss 后的行为和最终 attribution error。baseline 包括 perf/eBPF CPU profiling、wall-clock on/off-CPU profiling、runtime-native tracing 和 full tracing。
+
+**Academic value.** 问题变成：一组很小的 typed、lifetime-aware edge，是否足以跨异构 async mechanism 重建有用因果关系。
+
+**Production value.** operator 可以得到 request/operation-oriented profile，不需要所有组件统一接入某个 tracing SDK，同时还能看到证据哪里不完整。
+
+**Failure condition.** 如果真实应用需要大量彼此无关的 runtime-specific edge type，最终没有紧凑共同 contract，那么应该回到 per-runtime tracing，而不是强行做统一 causal profiler。
+
+### 在固定预算下分开保护 edge 与 context
+
+**Gap.** always-on full tracing 可能太贵，uniform stack sampling 又可能漏掉短 phase、关键 handoff，甚至产生系统性 bias。
+
+**Mechanism.** 把采集拆成两层。**edge plane** 优先捕获 queue、submit、completion、wake、spawn、resource acquire 等决定因果拓扑的事件；**context plane** 在固定预算下采样 stack、argument、resource counter 或 payload metadata。昂贵 context 可以按 causal node、phase 或 anomaly signal 自适应增加。
+
+如果采用概率采样，就记录足够信息估计 inclusion probability，或者明确哪些 aggregate 仍然有效。当 buffer overflow 或 correlation-state eviction 导致 edge 丢失时，输出 coverage break，而不是跨缺口继续 join。
+
+一个实用策略可以在 causal path 跨越更多 subsystem、累计异常 latency 或进入 rare error 时提高 context sampling，普通路径保持低成本。`StriaTrace` 的 key synchronization + abnormality-focused tracing 是很强的生产 baseline；`Blink` 则提醒我们 sampling policy 必须针对 systematic error 验证，而不是只看 overhead。
+
+**Delta.** 核心新意是把 causal edge 和 context sample 当成损失代价不同的统计对象，而不是给所有事件一个统一 sample rate。
+
+**Artifact.** 一个有固定 CPU/event budget、可配置 edge priority、event-loss telemetry 的 always-on profiler，query 输出同时给 cost estimate 与 causal coverage。
+
+**Evaluation.** 从很小预算一直跑到接近 full trace，比较 attribution error、CPU overhead、event volume、tail-latency perturbation 和实际 diagnosis success。必须加入类似 Blink 的 flat workload，避免 profiler 只在 heavy-hitter workload 上显得准确。
+
+**Academic value.** 这是一个清晰的 measurement 问题：固定 observability budget 应该怎样在“定义拓扑的事件”和“估计数值的 sample”之间分配。
+
+**Production value.** 团队可以长期运行 profiler，并知道某次 diagnosis 的 causal evidence 是否完整，而不是得到一个非常精确但其实错误的 flamegraph。
+
+**Failure condition.** 如果高事件率 workload 中 edge plane 本身就成为主要 overhead，或者 adaptive sampling 无法维持可解释权重，就需要更强的 source-side aggregation，或缩小支持 workload 范围。
+
+### 建立 async causality ground-truth benchmark
+
+**Gap.** profiler 可以在 overhead 和 profile shape 上互相比较，却不一定知道“这些工作到底属于哪个逻辑请求”。
+
+**Mechanism.** 设计一个 evaluator-only ground-truth channel，让每个逻辑 operation 穿过一组可控 async mechanism：同步调用、`io_uring`、kernel workqueue、timer、futex handoff、Tokio 等 task runtime，再加一个有界 cache/buffer pool 作为 application-defined resource。ground-truth ID 只供 evaluator 使用，不能暴露给被测 profiler。
+
+故障模式主动覆盖 work stealing、pool reuse、delayed/out-of-order completion、multishot request、trace record loss、buffer truncation、nested task spawn、cancellation 和 application-resource reuse。
+
+**Delta.** benchmark 评分的是 causal attribution，不只是“该出现的 event 有没有出现”。这样可以在同一 workload 上比较 CPU sampler、off-CPU profiler、full tracing、runtime/OpenTelemetry instrumentation、`uringscope` 一类 subsystem reconstruction 与 hybrid causal profiler。
+
+**Artifact.** 可复现 Linux benchmark suite、reference trace，以及 edge precision/recall、false join、orphan rate、wall-time attribution error、resource-cost error、overhead 和 tail perturbation 指标。
+
+**Evaluation.** 跨 kernel version、CPU 数量、runtime worker 数量、queue depth、request fan-out 和人工 event-loss rate 测试。必须同时包含 thread-affine workload，让普通 profiler 在简单场景里应该赢，也包含高度异步 workload，验证 causal reconstruction 是否真的带来收益。
+
+**Academic value.** 它把“更懂 async system”这种模糊 claim 变成可证伪 profiling 问题。
+
+**Production value.** profiler 作者可以明确告诉用户哪些 async mechanism 与 event-loss regime 是被验证支持的，而不是只宣传“低开销”。
+
+**Failure condition.** 如果 causal accuracy 和真实 diagnosis outcome 几乎没有相关性，那么 edge precision 不是正确目标，benchmark 应该转向 operator decision。
+
+## 什么证据会改变这个结论？
+
+最直接的反例是 thread-local workload。CPU-bound worker pool、同步 service，或者 request identity 始终不离开同一条 thread 的应用，可能用 CPU + off-CPU profile 就足够了。不能因为技术上能画 causal graph，就强迫所有 workload 使用它。
+
+第二个反例是 full tracing 变得足够便宜。如果关键 synchronization/runtime event 能以接近零的持续开销、稳定 schema 和有界存储长期全量采集，那么复杂的 edge/context budget 就没有必要。`uringscope` 已经说明针对一个 subsystem 做 request reconstruction 可以很实用，未来 kernel/tracing infrastructure 也可能让更广泛的 full-fidelity capture 继续降价。
+
+第三个反例是上层 instrumentation 已经很好。如果 runtime 和应用已经产生高质量 OpenTelemetry 或 native causal span，那么 eBPF 更适合做 system-effect validation 与低层 gap filling，而不是重建 primary request graph。
+
+最后，这张图必须真的帮助 diagnosis。若 prototype 只是画出更复杂的 causal flamegraph，却没有降低 root-cause 时间、提高 attribution accuracy，或者发现普通 profile 看不到的问题，就应该否定它。
+
+因此本文的结论有明确边界：**eBPF 很适合成为异步 profiling 的 system-level edge substrate，但可信 profiler 必须同时处理 subsystem-local identity、runtime/application semantics、显式 lifetime，以及 edge 与 context 不同的 measurement budget。缺失的因果证据应该被表示为不确定，而不是被补成一个干净的 thread-shaped story。**
+
+## 参考资料
+
+- [Linux Kernel Tracepoint API: workqueue tracepoints](https://docs.kernel.org/core-api/tracepoint.html)
+- [Linux `io_uring` UAPI: SQE and CQE `user_data`](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h)
+- [Linux `io_uring` implementation and tracepoints](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c)
+- [Tokio task IDs](https://docs.rs/tokio/latest/tokio/task/struct.Id.html)
+- [Tokio: Getting started with Tracing](https://tokio.rs/tokio/topics/tracing)
+- [Parca continuous profiling and eBPF profiler](https://github.com/parca-dev/parca)
+- [Grafana Pyroscope: OpenTelemetry eBPF profiler](https://grafana.com/docs/pyroscope/latest/configure-client/opentelemetry/ebpf-profiler/)
+- [uringscope: Portable, Low-Overhead Observability for io_uring](https://arxiv.org/abs/2606.15137)
+- [Beyond Thread States: Diagnosing Performance Degradation with eBPF and Thread Dynamics](https://arxiv.org/abs/2605.25298)
+- [When Sampling Lies: Trustworthy Performance Profiling for Flat Workloads with Blink](https://www.usenix.org/conference/osdi26/presentation/devsot)
+- [StriaTrace: Efficient Tracing and Diagnosis for Online LLM Inference](https://www.usenix.org/conference/osdi26/presentation/wu-haonan)
+- [Diagnosing Performance Issues in Application-Defined Resources](https://www.usenix.org/conference/osdi26/presentation/hu-yigong)
+- [SysOM-AI: Continuous Cross-Layer Performance Diagnosis for Production AI Training](https://arxiv.org/abs/2603.29235)

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [What Must an eBPF Profiler Track Beyond Threads?](https://eunomia.dev/research/async-ebpf-causal-profiler/)
+
+Async work can leave one thread through `io_uring`, workqueues, runtime tasks, and application-defined resources, so CPU and off-CPU stacks can lose logical attribution even when the samples themselves are accurate. This report develops a typed causal-edge model, a budget that treats topology edges differently from context samples, and a ground-truth benchmark for cross-thread attribution.
+
 ### [Can a Stateful eBPF Application Upgrade Atomically?](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/)
 
 One BPF link can replace one program cleanly, but real stateful applications also span maps, pinned objects, multiple hooks, and userspace controllers. This report separates simple state reuse from semantic state migration and develops generation-gated activation, BTF-aware migration, and crash-consistent recovery as testable upgrade mechanisms.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [异步系统里，eBPF Profiler 还要追踪什么？](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)
+
+异步工作会经过 `io_uring`、workqueue、runtime task 与 application-defined resource 离开原来的线程，因此即使 CPU 与 off-CPU sample 本身准确，也可能失去逻辑归属。本文提出 typed causal-edge 模型、把 topology edge 与 context sample 分开预算的采集方法，以及用于跨线程 attribution 的 ground-truth benchmark。
+
 ### [有状态 eBPF 应用能不能原子升级？](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/)
 
 单个 BPF link 可以干净地替换一个程序，但真实有状态应用还跨越 maps、pinned objects、多个 hooks 和用户态控制器。本文区分简单 state reuse 与 semantic state migration，并把 generation-gated activation、BTF-aware migration 和 crash-consistent recovery 发展成可验证的升级机制。


### PR DESCRIPTION
## Summary

- publish exactly one new bilingual Daily Report on causal attribution across asynchronous eBPF-visible handoffs
- analyze every enabled data source and refresh the finalized Google-data boundary for 2026-08-12
- record the valid GA4 week-over-week comparison and the still-partial GSC comparison without treating missing history as zero
- keep the active eBPF Runtime, Extensibility, and Composition series at 4/6 eBPF-centered reports
- make no unrelated technical SEO implementation change because the audit did not establish a new defect

## Research

The report asks what an eBPF profiler must track after logical work stops being thread-affine. It compares kernel-visible identities such as `io_uring` `user_data` and workqueue objects with runtime/application identities, then develops:

1. a typed lifetime-aware causal-edge substrate;
2. an edge-versus-context observability budget with explicit loss/uncertainty;
3. a ground-truth benchmark for causal attribution across asynchronous mechanisms.

English: `/research/async-ebpf-causal-profiler/`
Chinese: `/zh/research/async-ebpf-causal-profiler/`

## Analytics / SEO state

- GSC equal finalized six-day slice: 478 clicks / 69,053 impressions vs 409 / 46,327; CTR 0.692% vs 0.883%; position ~9.42 vs ~8.18. The required complete 7-day comparison remains unavailable because 2026-07-26 is missing.
- GA4 finalized weekly comparison: 991 sessions at ~44.90% session-weighted engagement vs 1,021 at ~46.72%; sessions -2.9%, engagement rate -1.81 pp.
- `(not set)` fell from 157 to 116 sessions; excluding it, sessions are 875 vs 864, so no content or SEO change is inferred from the aggregate decline.
- Cloudflare remains disabled by repository configuration.
- No evidence-backed crawl, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment fix is included.

## Validation contract

Per `DAILY_TASK.md`, this PR must pass final repository CI, receive a complete diff/generated-output self-review, squash merge, deploy the exact squash commit, verify both public language routes, and receive one merged-PR closeout comment. No second closeout PR.