### PR TITLE
Run community patrol daily

### DIFF
--- a/.agents/skills/eunomia-community-patrol/SKILL.md
+++ b/.agents/skills/eunomia-community-patrol/SKILL.md
@@ -17,8 +17,8 @@ deduplication records outside the repository.
 - Perform GitHub writes only in `eunomia-bpf` repositories.
 - Run in the Linux maintenance workspace. Do not redirect the task to Windows
   or PowerShell.
-- Schedule the patrol for 09:00 `America/Vancouver` every two calendar days.
-  Let a successful manual patrol reset the next eligible date. Retry a failed
+- Schedule the patrol for 09:00 `America/Vancouver` every calendar day. A
+  successful manual patrol does not skip the next scheduled day. Retry a failed
   run at the next daily scheduler wake and prevent overlapping runs with a
   local lock.
 - Resume the designated Codex conversation for each eligible run so the final


### PR DESCRIPTION
## Summary

- run the community patrol at 09:00 America/Vancouver every calendar day
- keep the next scheduled day eligible after a successful manual patrol
- preserve the existing overlap lock and failed-run retry behavior

The installed Linux systemd timer already fires daily, so this changes only the runbook eligibility rule. It does not change the prompt, task binding, scan scope, or authorization boundaries.

## Validation

- `quick_validate.py .agents/skills/eunomia-community-patrol`
- `systemd-analyze calendar "*-*-* 09:00:00 America/Vancouver" --iterations=3` (Aug 13, 14, and 15 at 09:00 PDT)