### PR TITLE
docs: clarify Eunomia as an open-source systems community

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: Eunomia - Open eBPF systems research and tooling
-description: Open-source eBPF systems research, userspace runtime tooling, AI-assisted tracing, and runnable Linux observability documentation.
-keywords: eBPF, BPF, Linux kernel programming, eunomia-bpf, bpftime, eBPF tutorials, kernel tracing
+title: Eunomia - Open-source systems research community
+description: An open-source systems research community working on eBPF, programmable runtimes, AI agent observability and safety, GPU systems, and practical systems tooling.
+keywords: eBPF, BPF, Linux kernel programming, systems research, programmable runtimes, AI agents, GPU systems, eunomia-bpf, bpftime
 hide:
   - navigation
   - toc
 ---
 
-Eunomia builds open-source systems software and documentation for eBPF, userspace runtimes, AI-assisted tracing, and agent security research.
+Eunomia is an open-source systems research community building and studying programmable runtime infrastructure, eBPF tooling, AI agent systems, GPU systems, and public learning resources. We publish research prototypes, maintained open-source systems, tutorials, technical writing, and reproducible research artifacts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: Eunomia - Open-source systems research community
-description: An open-source systems research community working on eBPF, programmable runtimes, AI agent observability and safety, GPU systems, and practical systems tooling.
-keywords: eBPF, BPF, Linux kernel programming, systems research, programmable runtimes, AI agents, GPU systems, eunomia-bpf, bpftime
+title: Eunomia - Open-source systems community
+description: An open-source systems community building production-oriented systems and advancing research on eBPF, programmable runtimes, AI agents, GPU systems, and practical systems tooling.
+keywords: eBPF, BPF, Linux kernel programming, systems research, production systems, programmable runtimes, AI agents, GPU systems, eunomia-bpf, bpftime
 hide:
   - navigation
   - toc
 ---
 
-Eunomia is an open-source systems research community building and studying programmable runtime infrastructure, eBPF tooling, AI agent systems, GPU systems, and public learning resources. We publish research prototypes, maintained open-source systems, tutorials, technical writing, and reproducible research artifacts.
+Eunomia is an open-source systems community. We build and maintain open-source systems for real-world and production use, while also exploring new ideas in programmable runtimes, eBPF, AI agent systems, and GPU systems. We publish maintained projects, research prototypes, tutorials, technical writing, and reproducible research artifacts.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -2,7 +2,7 @@ site_name: eunomia
 repo_url: https://github.com/eunomia-bpf/eunomia.dev
 site_url: https://eunomia.dev
 copyright: Copyright (c) 2026 Eunomia Labs, Inc.
-site_description: 'Open-source eBPF infrastructure for userspace runtime extension, GPU tracing, AI agent observability, and hands-on Linux systems tutorials.'
+site_description: 'Open-source systems research community working on eBPF, programmable runtimes, AI agent observability and safety, GPU systems, and practical systems tooling.'
 remote_branch: docs
 edit_uri: https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs
 theme:
@@ -555,32 +555,32 @@ extra:
   home:
     hero:
       kicker:
-        en: Open-source infrastructure
-        zh: 开源基础设施
+        en: Open-source systems research community
+        zh: 开源系统研究社区
       title:
         en: Eunomia
         zh: Eunomia
       summary:
-        en: Open-source agent-native eBPF runtime infrastructure.
-        zh: 面向 AI Agent 的开源 eBPF 运行时基础设施。
+        en: We build and study programmable runtime systems for eBPF, AI agents, GPUs, and modern systems infrastructure.
+        zh: 我们围绕 eBPF、AI Agent、GPU 与现代系统基础设施构建并研究可编程运行时系统。
       primary_cta:
         en: GitHub
         zh: GitHub
       primary_href: https://github.com/eunomia-bpf
       secondary_cta:
-        en: Tutorials
-        zh: 教程
-      secondary_href: /tutorials/
+        en: Research
+        zh: 研究
+      secondary_href: /research/
       tertiary_cta:
         en: Projects
         zh: 项目
       tertiary_href: /projects/
     capabilities_title:
-      en: What Eunomia Provides
-      zh: Eunomia 提供什么
+      en: Research & Open Source
+      zh: 研究与开源
     capabilities_intro:
-      en: Runtime infrastructure, public resources, and AI agent systems define the work behind Eunomia.
-      zh: Eunomia 的工作集中在 runtime infrastructure、公开资源和 AI agent systems。
+      en: Eunomia brings together research prototypes, maintained open-source systems, and public learning resources around programmable systems.
+      zh: Eunomia 围绕可编程系统，持续发布研究原型、维护开源系统，并整理公开学习资源。
     capabilities:
       - key: runtime-extension
         eyebrow:
@@ -616,8 +616,8 @@ extra:
       en: Projects
       zh: 项目
     projects_intro:
-      en: Open-source platform projects and public resources grouped by how people use them.
-      zh: 按使用方式组织的开源平台项目和公开资源。
+      en: Selected open-source systems, research artifacts, and public resources from the community.
+      zh: 社区中的代表性开源系统、研究产物和公开资源。
     project_groups:
       - key: platform
         title:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -2,7 +2,7 @@ site_name: eunomia
 repo_url: https://github.com/eunomia-bpf/eunomia.dev
 site_url: https://eunomia.dev
 copyright: Copyright (c) 2026 Eunomia Labs, Inc.
-site_description: 'Open-source systems research community working on eBPF, programmable runtimes, AI agent observability and safety, GPU systems, and practical systems tooling.'
+site_description: 'Open-source systems community building practical systems software and advancing research in eBPF, programmable runtimes, AI agents, and GPU systems.'
 remote_branch: docs
 edit_uri: https://github.com/eunomia-bpf/eunomia.dev/tree/main/docs
 theme:
@@ -555,32 +555,32 @@ extra:
   home:
     hero:
       kicker:
-        en: Open-source systems research community
-        zh: 开源系统研究社区
+        en: Open-source systems community
+        zh: 开源系统社区
       title:
         en: Eunomia
         zh: Eunomia
       summary:
-        en: We build and study programmable runtime systems for eBPF, AI agents, GPUs, and modern systems infrastructure.
-        zh: 我们围绕 eBPF、AI Agent、GPU 与现代系统基础设施构建并研究可编程运行时系统。
+        en: Open-source systems for real-world use, plus research on eBPF, programmable runtimes, AI agents, and GPUs.
+        zh: 面向真实场景的开源系统，以及 eBPF、可编程运行时、AI Agent 和 GPU 系统研究。
       primary_cta:
         en: GitHub
         zh: GitHub
       primary_href: https://github.com/eunomia-bpf
       secondary_cta:
-        en: Research
-        zh: 研究
-      secondary_href: /research/
+        en: Tutorials
+        zh: 教程
+      secondary_href: /tutorials/
       tertiary_cta:
         en: Projects
         zh: 项目
       tertiary_href: /projects/
     capabilities_title:
-      en: Research & Open Source
-      zh: 研究与开源
+      en: What Eunomia Provides
+      zh: Eunomia 提供什么
     capabilities_intro:
-      en: Eunomia brings together research prototypes, maintained open-source systems, and public learning resources around programmable systems.
-      zh: Eunomia 围绕可编程系统，持续发布研究原型、维护开源系统，并整理公开学习资源。
+      en: Runtime infrastructure, public resources, and AI agent systems define the work behind Eunomia.
+      zh: Eunomia 的工作集中在 runtime infrastructure、公开资源和 AI agent systems。
     capabilities:
       - key: runtime-extension
         eyebrow:
@@ -616,8 +616,8 @@ extra:
       en: Projects
       zh: 项目
     projects_intro:
-      en: Selected open-source systems, research artifacts, and public resources from the community.
-      zh: 社区中的代表性开源系统、研究产物和公开资源。
+      en: Open-source platform projects and public resources grouped by how people use them.
+      zh: 按使用方式组织的开源平台项目和公开资源。
     project_groups:
       - key: platform
         title:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -561,8 +561,8 @@ extra:
         en: Eunomia
         zh: Eunomia
       summary:
-        en: Open-source systems for real-world use, plus research on eBPF, programmable runtimes, AI agents, and GPUs.
-        zh: 面向真实场景的开源系统，以及 eBPF、可编程运行时、AI Agent 和 GPU 系统研究。
+        en: Open-source agent-native eBPF runtime infrastructure.
+        zh: 面向 AI Agent 的开源 eBPF 运行时基础设施。
       primary_cta:
         en: GitHub
         zh: GitHub


### PR DESCRIPTION
## Summary

- change only the homepage kicker from `Open-source infrastructure` to `Open-source systems community`
- keep the existing eBPF-focused hero summary unchanged
- keep the existing Tutorials and Projects homepage CTAs unchanged
- update homepage/site metadata to describe Eunomia as an open-source systems community with maintained systems and research work

## Scope

Intentionally minimal. No navigation, component, project-card, product-page, layout, or hero-summary changes.