### PR TITLE
Daily: define io_uring BPF programmability boundaries

### DIFF
--- a/.github/seo-data/daily/2026-08-14.md
+++ b/.github/seo-data/daily/2026-08-14.md
@@ -87,7 +87,7 @@ Repository CI remains authoritative for the Daily Report checks, SEO-data valida
 ## Delivery
 
 - Branch: `daily/2026-08-14-io-uring-bpf-programmability`
-- Pull request: to be opened as a non-draft PR after the report/index/status files are complete
+- Pull request: `#158`, open as a non-draft PR
 - Production target: GitHub Pages through `Deploy Static App`
 - Merge policy: squash merge only after all expected CI succeeds and the final diff/generated output passes self-review
 - Closeout policy: one compact comment on the merged daily PR records exact merge commit, CI, production deployment, bilingual public verification, source coverage, series classification, and remaining uncertainty; no second closeout PR

--- a/.github/seo-data/daily/2026-08-14.md
+++ b/.github/seo-data/daily/2026-08-14.md
@@ -1,0 +1,103 @@
+# SEO operations — 2026-08-14
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md` and resumes the daily publication program immediately. The external `Eunomia Daily Ops` scheduler is enabled. Today's work analyzes every currently available evidence source, checks the technical SEO/GEO surface, calculates the rolling Daily Report mix, researches the next question in the active eBPF series, and publishes exactly one new bilingual Daily Report.
+
+The active series remains **eBPF Runtime, Extensibility, and Composition**. Today's selected question is how far eBPF programmability can move into `io_uring` now that current Linux source exposes both submission-time BPF filtering and an eBPF `struct_ops` execution path.
+
+No unrelated technical SEO implementation change is included. Current evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect that justifies changing the public site separately from today's report.
+
+## Data window
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | available Drive export sets covering `2026-07-27_to_2026-08-02` and `2026-08-03_to_2026-08-09`; date rows in the current GSC export still end on `2026-08-08` | available; no newer weekly export was found on `2026-08-14`, so the required complete latest 7-day and 28-day comparisons remain unavailable |
+| Google Analytics 4 | finalized organic landing-page exports for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09` | available; adjacent weekly comparison remains valid |
+| Public GitHub | current `eunomia-bpf/eunomia.dev`, merged August 12 Daily Report, and current Linux-source references checked on `2026-08-14` | available |
+| Live site | current public homepage and Daily Report navigation checked on `2026-08-14`; exact new report pages require post-merge deployment verification | available |
+| Public web / primary research sources | current Linux io_uring UAPI and source plus kernel FUSE, zero-copy receive, and ublk documentation checked through `2026-08-14` | available |
+| Cloudflare | disabled in repository configuration | not collected by design |
+
+A complete latest-seven-days versus previous-seven-days GSC comparison is still unavailable because the existing history does not provide both complete adjacent seven-day periods. The required 28-day comparison is also unavailable. Missing history is not treated as zero.
+
+## Evidence collected
+
+### Search and traffic evidence
+
+The latest equal-duration GSC slice remains `2026-08-03` through `2026-08-08` versus `2026-07-28` through `2026-08-02`. The newer slice reports **478 clicks** and **69,053 impressions**, with weighted CTR approximately **0.692%** and impression-weighted average position approximately **9.42**. The comparison slice reports **409 clicks**, **46,327 impressions**, **0.883%** CTR, and position approximately **8.18**. Clicks are about **16.9% higher** and impressions about **49.1% higher**, while CTR is about **0.191 percentage points lower** and average position is about **1.24 positions worse**.
+
+`2026-08-05` still contributes **24,516 impressions**, about **35.5%** of the newer six-day total, at position approximately **13.30** and CTR approximately **0.343%**. The current exports do not contain a date-by-page or date-by-query matrix, so this run does not attribute that spike to a specific page or query family.
+
+The finalized GA4 organic landing-page export for `2026-08-03` through `2026-08-09` contains **991 sessions** with a session-weighted engagement rate of approximately **44.90%**. The previous `2026-07-27` through `2026-08-02` export contains **1,021 sessions** at approximately **46.72%** engagement. Sessions are about **2.9% lower** and engagement about **1.81 percentage points lower**. The `(not set)` row fell from **157** to **116 sessions**; excluding it, sessions are **875 versus 864**, about **1.3% higher**, while session-weighted engagement declines from approximately **54.17%** to **50.06%**. These remain directional measurement signals, not evidence for a content or technical SEO change.
+
+No newer weekly Drive export beginning `2026-08-10` was found during today's check. The previous finalized data therefore remains the newest source-native analytics evidence and is explicitly marked stale relative to today's date rather than converted into zero.
+
+### Previous-run closeout promoted into current state
+
+The August 12 async eBPF causal-profiling report is now fully merged and deployed. PR `#155` squash-merged as `66f5a9e83939d228f3ba8c325c83fc1804f5334b` on `2026-08-14`. The exact merge commit passed the `Validate SEO Operations` push workflow and the `Deploy Static App` push workflow, including successful production deployment. This removes the stale pending-delivery state recorded before that PR merged.
+
+### Technical SEO and site evidence
+
+The public site continues to expose the Daily Report section and current eBPF/open-source project surfaces. Today's source and live-site review does not establish a new canonical, language-routing, crawl, structured-data, link, rendering, performance, or accessibility defect. The correct action is therefore to publish today's required research report without manufacturing an unrelated SEO edit.
+
+### Rolling Daily Report mix
+
+Before today's publication, the completed archive contains six reports: **4 eBPF-centered / 2 pure Agent / 0 adjacent systems**. The two pure-Agent reports already consume the long-term Agent budget, so today's report must remain eBPF-centered.
+
+After today's report is merged, the archive becomes **5 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 7**. This moves the archive into the intended eBPF-first direction while pure-Agent work remains frozen until the rolling window reaches the repository's long-term `1–2 of 10` cap.
+
+### Research selection and rejected framing
+
+A broad candidate, "which new Linux I/O hooks make eBPF useful," was rejected because it collapses several different interfaces into one generic hook story and would encourage a source-by-source feature list.
+
+The stronger question emerged from current Linux source. `IORING_REGISTER_BPF_FILTER` is a submission-time **classic BPF (cBPF)** admission mechanism, while `io_uring_bpf_ops` is a separate **eBPF `struct_ops`** execution-control mechanism with io_uring-specific kfuncs. Static `IORING_RESTRICTION_*` and LSM security checks form two additional control layers.
+
+That separation produces a concrete systems gap: a production ring can now be constrained by static restrictions, cBPF admission predicates, host-wide LSM authority, and eBPF execution policy, yet there is no common machine-readable contract for capability, authority ordering, policy generation, provenance, or resource accounting across those layers.
+
+The gap becomes more important as `io_uring` carries registered and subsystem-specific I/O objects such as FUSE-over-io-uring request queues, zero-copy networking memory, and ublk userspace block resources. The report therefore asks where the programmable boundary should stop and how to evaluate whether in-ring control is actually better than userspace validation or external hooks.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in today's delivery:
+
+- English: `/research/io-uring-bpf-programmability/`
+- Chinese: `/zh/research/io-uring-bpf-programmability/`
+
+Both Daily Report indexes are updated. The report contains the required concrete scenario, primary-source mechanism analysis, `Where current work is still weak` / `现有工作还薄弱在哪里` section, three developed research directions with mechanisms and failure conditions, and a reader-facing conclusion describing what evidence would change the result.
+
+The report advances the active series from runtime contracts, hook composition, transactional upgrade, and async causality into subsystem-native programmable I/O. The preferred next question is the final item in the current active sequence: **where should eBPF execution live in heterogeneous systems across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets?**
+
+No unrelated technical SEO implementation change is made.
+
+## Validation and self-review
+
+- No raw analytics rows, queries, Drive IDs, property/account identifiers, credentials, private URLs, or personal information are added to Git.
+- Missing Google history and the absence of a newer weekly export are recorded as unavailable/stale, never as zero.
+- The central technical distinction between cBPF request admission and eBPF `struct_ops` execution control is preserved in both language versions.
+- Technical claims are grounded in current Linux UAPI/source and kernel documentation rather than secondary summaries or vendor marketing.
+- The report explicitly keeps LSM as a separate host-security authority and does not imply that ring-local eBPF should bypass it.
+- English and Chinese pages share evidence and conclusions while using language-specific prose.
+- The intended public change remains limited to one bilingual Daily Report, both Daily Report indexes, and the operating/status metadata needed for the daily contract.
+
+Repository CI remains authoritative for the Daily Report checks, SEO-data validator, generated content, static build, links, metadata, and deployment readiness. The complete final PR diff must be self-reviewed after CI before squash merge.
+
+## Delivery
+
+- Branch: `daily/2026-08-14-io-uring-bpf-programmability`
+- Pull request: to be opened as a non-draft PR after the report/index/status files are complete
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after all expected CI succeeds and the final diff/generated output passes self-review
+- Closeout policy: one compact comment on the merged daily PR records exact merge commit, CI, production deployment, bilingual public verification, source coverage, series classification, and remaining uncertainty; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Finish today's io_uring BPF programmability report through the exact merge/deployment/public-page contract without pausing the run.
+2. Keep the active **eBPF Runtime, Extensibility, and Composition** series eBPF-centered; after today's report the archive becomes 5/7 eBPF-centered and 2/7 pure Agent.
+3. Use the next active-series question to compare where eBPF execution should live across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets.
+4. Keep reading the configured weekly Google exports; do not claim a new 7-day or 28-day comparison until enough complete history exists.
+5. Obtain date-by-page or date-by-query GSC evidence before attributing the `2026-08-05` impression spike.
+6. Investigate GA4 `(not set)` only with richer source-native dimensions rather than inferring a content problem from the aggregate.
+7. Add Cloudflare evidence only when a supported read-only path exists.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,20 +7,21 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-11`
+- Last completed daily run: `2026-08-12`
 - Last verified data window: Search Console rows through `2026-08-08`; finalized GA4 weekly export through `2026-08-09`
-- Latest daily record: `2026-08-12`
-- Last public-change pull request: `#151`, verified in its merged-PR closeout comment
-- Last verified production deployment from a daily run: `Deploy Static App` run `31511561365` for squash commit `5e57487b6055008082127129f4b68b8c2d5dc57f`
+- Latest daily record: `2026-08-14`
+- Last completed public-change pull request: `#155`
+- Last verified production deployment from a daily run: `Deploy Static App` run `31837125244` for squash commit `66f5a9e83939d228f3ba8c325c83fc1804f5334b`
+- Current daily branch: `daily/2026-08-14-io-uring-bpf-programmability`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The `2026-08-11` operation is fully closed out. PR `#151` squash-merged as `5e57487b6055008082127129f4b68b8c2d5dc57f`; the exact commit passed `Validate SEO Operations` run `31511561363` and production `Deploy Static App` run `31511561365`. The deployed Pages artifact contained both language variants of the stateful-upgrade report with the expected report structure, canonical URLs, reciprocal `hreflang` plus `x-default`, Article JSON-LD, and Daily Report index navigation.
+The `2026-08-12` operation is fully closed out. PR `#155` squash-merged as `66f5a9e83939d228f3ba8c325c83fc1804f5334b`; the exact merge commit passed the `Validate SEO Operations` push workflow and production `Deploy Static App` run `31837125244`.
 
-The `2026-08-12` async causal-profiling report is the current daily change. Per `DAILY_TASK.md`, its exact merge commit, final CI, deployment, and bilingual public verification belong in one closeout comment on the merged daily PR rather than a second closeout pull request.
+The `2026-08-14` operation is the current daily change. It publishes the bilingual io_uring BPF programmability report, updates both Daily Report indexes, and records current analytics and research evidence. Exact merge commit, final CI, production deployment, and bilingual public verification will be recorded in one closeout comment on the merged daily PR.
 
 ## Current Daily Report mix
 
-The current change adds the sixth Daily Report:
+The completed archive before today's change contains six reports:
 
 - eBPF-centered: **4 of 6**
   - `/research/async-ebpf-causal-profiler/`
@@ -32,7 +33,9 @@ The current change adds the sixth Daily Report:
   - `/research/parallel-agent-effect-serializability/`
 - adjacent systems: **0 of 6**
 
-The current change brings the eBPF-centered share to about **66.7%**, inside the long-run 5–7/10 target proportion. The two pure-Agent reports still represent too large a share of the six-report archive relative to the eventual 1–2/10 cap, so continue to favor eBPF and adjacent systems before another pure-Agent report. The active series remains **eBPF Runtime, Extensibility, and Composition**.
+Today's report is eBPF-centered. After it merges, the rolling archive becomes **5 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 7**. This moves the publication program toward the repository's 5–7/10 eBPF target while the two pure-Agent reports still consume the long-term 1–2/10 Agent budget. Do not schedule another pure-Agent report until the rolling mix is compliant.
+
+The active series remains **eBPF Runtime, Extensibility, and Composition**.
 
 ## Current signals
 
@@ -40,43 +43,34 @@ The current change brings the eBPF-centered share to about **66.7%**, inside the
 - Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
 - Google Analytics 4: two adjacent weekly Drive organic landing-page exports available and finalized through `2026-08-09`
-- Google Search Console: two adjacent weekly sets of date, search-appearance, device, country, page, and query exports available; current date rows still end on `2026-08-08`
+- Google Search Console: two adjacent weekly sets available; current date rows still end on `2026-08-08`
+- Newer weekly Google export beginning `2026-08-10`: not found during the `2026-08-14` run
 - Cloudflare: not configured
 
-The configured Drive folder contains adjacent weekly Google export sets for `2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. Search Console date rows still stop at `2026-08-08`. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the preceding window would require `2026-07-26`, which is absent. The required 28-day comparison is also unavailable rather than inferred.
+The configured Google exports remain the newest source-native analytics evidence. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the available history does not contain both complete adjacent seven-day windows. The required 28-day comparison is also unavailable rather than inferred.
 
-A valid common-duration finalized six-day Search Console comparison is available. Search Console reports **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. That is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. The current weekly page/query aggregates cannot attribute that spike to one page or query family without a date-by-page or date-by-query export.
+A valid common-duration six-day Search Console comparison remains available: **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. This is about **+16.9% clicks** and **+49.1% impressions**. Weighted CTR moved from about **0.883%** to **0.692%**, down about **0.191 percentage points**, while impression-weighted average position moved from about **8.18** to **9.42**. `2026-08-05` alone contributed **24,516 impressions**, about **35.5%** of the newer six-day total, at position about **13.30** and CTR about **0.343%**. Current weekly page/query aggregates cannot attribute that spike to one page or query family without date-by-page or date-by-query evidence.
 
-The current device export remains desktop-heavy: desktop has **64,355 impressions / 418 clicks**, mobile **4,614 / 59**, and tablet **84 / 1**. Desktop therefore contributes about **93.2%** of impressions. Translated-result search appearance remains present at **1 click / 116 impressions**.
-
-Current page aggregates continue to show broad discovery across the homepage, eBPF tutorials, XDP/TCX, CUDA/GPU material, `GPTtrace`, AgentSight, bpftime, and long-tail systems pages. The current Daily Report pages are too new for the weekly Search Console export to support a report-level traffic conclusion. Raw query rows remain outside Git.
-
-GA4 now supports a complete adjacent weekly comparison. The `2026-08-03` through `2026-08-09` organic landing-page export contains **991 sessions** at a session-weighted engagement rate of about **44.90%**, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. Sessions are about **2.9% lower** and engagement rate about **1.81 percentage points lower**. `(not set)` falls from **157** to **116 sessions**; excluding it, sessions rise slightly from **864** to **875**, while engagement still declines from about **54.17%** to **50.06%**. The homepage rises from **34** to **43 sessions**, the Chinese GPU-architecture page from **17** to **28**, and `GPTtrace` from **5** to **18**, all small-base directional movements. Both weekly exports report zero in the `keyEvents` column, but that is not treated as proof of zero conversions without stronger configuration evidence. `(not set)` remains a measurement-quality question rather than evidence for a speculative site change.
-
-## Previous-run closeout
-
-The `2026-08-11` operation is fully closed out. PR `#151` squash-merged as `5e57487b6055008082127129f4b68b8c2d5dc57f`. Its final `Validate SEO Operations` and production `Deploy Static App` workflows succeeded for the exact squash commit. The deployed artifact contained `/research/stateful-ebpf-transactional-upgrade/` and `/zh/research/stateful-ebpf-transactional-upgrade/` with required content, canonical URLs, reciprocal language alternates, Open Graph/Article metadata, and Daily Report navigation.
+GA4 supports a complete adjacent weekly comparison. The `2026-08-03` through `2026-08-09` organic landing-page export contains **991 sessions** at a session-weighted engagement rate of about **44.90%**, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. Sessions are about **2.9% lower** and engagement about **1.81 percentage points lower**. `(not set)` falls from **157** to **116 sessions**; excluding it, sessions rise slightly from **864** to **875**, while engagement declines from about **54.17%** to **50.06%**. These remain directional measurement signals rather than evidence for an unrelated content or SEO change.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through the `Deploy Static App` workflow.
 
-The `2026-08-12` technical audit does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance defect that justifies an unrelated implementation change. The public homepage is crawlable and exposes the Daily Report entry point alongside the expected eBPF/runtime and project navigation. Search-visible legacy `/en/` paths remain a monitoring item because the repository intentionally emits canonical redirect stubs for them.
+The `2026-08-14` audit does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, or performance defect that justifies an unrelated implementation change. The correct public change for this run is the mandatory new Daily Report.
 
-The active eBPF Runtime, Extensibility, and Composition sequence now has four substantial reports in the current change. The existing Daily Report hub already exposes the sequence. A separate series hub remains deferred until report-level acquisition or navigation evidence shows that another public surface would improve retrieval; do not create a thin page only because the series crossed a count threshold.
+Today's research establishes a more precise current Linux mechanism boundary than the earlier broad "new I/O hooks" framing. `IORING_REGISTER_BPF_FILTER` is a per-opcode classic BPF admission path, while `io_uring_bpf_ops` is an eBPF `struct_ops` execution-control path with io_uring-specific kfuncs. Static restrictions and LSM security form separate control layers. The report develops capability contracts, versioned policy generations, provenance/resource accounting, and a comparative benchmark as concrete next mechanisms.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. A newer upstream layout removes interfaces the current consuming contract still names, including `change-seo-site` and `scripts/validate_seo_data.py`. Advancing the pointer still requires a coordinated consumer migration rather than an isolated submodule bump.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Advance it only through a coordinated consumer migration rather than an unrelated daily pointer bump.
 
 ## Current focus
 
-1. Complete and verify the current async eBPF causal-profiling Daily Report through final CI, squash merge, exact production deployment, and bilingual public verification.
-2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: which new Linux I/O hooks and programmable interfaces make eBPF mechanisms practical that older hook sets could not implement cleanly.
+1. Complete the `2026-08-14` io_uring BPF programmability Daily Report through final CI, squash merge, exact production deployment, bilingual public verification, and merged-PR closeout.
+2. Continue the **eBPF Runtime, Extensibility, and Composition** series with the preferred next question: where eBPF execution should live across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets.
 3. Continue favoring eBPF and adjacent systems until the rolling archive is comfortably inside the long-run 5–7/10 eBPF and 1–2/10 pure-Agent mix.
-4. Use both weekly GA4 and Search Console export sets in every run; keep required GSC 7-day and 28-day comparisons marked unavailable until complete source history exists.
+4. Keep required GSC 7-day and 28-day comparisons marked unavailable until complete source history exists; do not use missing exports as zero.
 5. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.
-6. Investigate GA4 `(not set)` with richer dimensions before making a measurement or content change.
-7. Revisit legacy `/en/` indexing only if fresh crawl or analytics evidence shows canonical redirect stubs are causing measurable harm.
-8. Migrate the consuming SEO contract before updating the skill submodule pointer.
-9. Add Cloudflare evidence when a supported read-only path exists.
+6. Investigate GA4 `(not set)` only with richer source-native dimensions before making a measurement or content change.
+7. Add Cloudflare evidence when a supported read-only path exists.
 
 This file is the current verified summary. Detailed history belongs in `.github/seo-data/daily/` and the merged daily pull requests.

--- a/app/tests/content.test.ts
+++ b/app/tests/content.test.ts
@@ -131,7 +131,7 @@ test("home page data keeps markdown metadata but leaves layout to React", async 
   const expectedRecentPosts = getBlogEntriesForLocale("en").slice(0, 3);
   const expectedRecentPostsZh = getBlogEntriesForLocale("zh").slice(0, 3);
   const homeDescription =
-    "Open-source eBPF systems research, userspace runtime tooling, AI-assisted tracing, and runnable Linux observability documentation.";
+    "An open-source systems community building production-oriented systems and advancing research on eBPF, programmable runtimes, AI agents, GPU systems, and practical systems tooling.";
 
   assert.equal(home.description, homeDescription);
   assert.notEqual(home.description, home.title);
@@ -257,7 +257,6 @@ test("home project cards are sourced from mkdocs config", () => {
 
   const projectKeys = new Set(home.projects.map((project) => project.key));
 
-  // Every group references only real projects, and no group is empty.
   for (const group of home.projectGroups) {
     assert.ok(group.projectKeys.length > 0, `group ${group.key} has no projects`);
     for (const key of group.projectKeys) {
@@ -265,7 +264,6 @@ test("home project cards are sourced from mkdocs config", () => {
     }
   }
 
-  // Every project is well-formed and bilingual, with usable links.
   for (const project of home.projects) {
     assert.ok(project.key.length > 0 && project.href.length > 0, `project ${project.key} missing key/href`);
     assert.ok(project.title.length > 0, `project ${project.key} missing title`);
@@ -702,8 +700,6 @@ test("docPathToRoute keeps legacy blog routes stable across locales", () => {
 test("listSitemapRoutes keeps section routes but excludes noindex'd legacy blog routes", () => {
   const rawRoutes = listSitemapRoutes();
   const routes = new Set(rawRoutes);
-  // Legacy /blogs/** pages are served with robots: noindex, so they must not
-  // appear in the sitemap (see isSitemapExcludedRoute).
   assert.ok(!routes.has("/blogs/bpftime/"));
   assert.ok(!routes.has("/zh/blogs/bpftime/"));
   assert.ok(routes.has("/eunomia-bpf/setup/build/"));
@@ -1000,7 +996,6 @@ test("static metadata generation emits feed, sitemap, robots, and shared OG asse
     assert.match(sitemap, /<loc>https:\/\/eunomia\.dev\//);
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/GPTtrace\/agentsight\//);
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/zh\/GPTtrace\/agentsight\//);
-    // Legacy noindex'd /blogs/** URLs must be excluded from the sitemap.
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/blogs\//);
     assert.doesNotMatch(sitemap, /https:\/\/eunomia\.dev\/zh\/blogs\//);
     assert.match(fs.readFileSync(path.join(publicDir, "robots.txt"), "utf8"), /Sitemap: https:\/\/eunomia\.dev\/sitemap\.xml/);

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [How Far Can eBPF Programmability Move Into io_uring?](https://eunomia.dev/research/io-uring-bpf-programmability/)
+
+Current Linux has both per-opcode io_uring BPF request filtering and an eBPF `struct_ops` execution path. This report separates the cBPF admission gate from the eBPF ring-loop control surface, then asks how restrictions, LSM authority, policy generations, provenance, and resource accounting should compose as io_uring absorbs FUSE, zero-copy networking, ublk, and other registered I/O resources.
+
 ### [What Must an eBPF Profiler Track Beyond Threads?](https://eunomia.dev/research/async-ebpf-causal-profiler/)
 
 Async work can leave one thread through `io_uring`, workqueues, runtime tasks, and application-defined resources, so CPU and off-CPU stacks can lose logical attribution even when the samples themselves are accurate. This report develops a typed causal-edge model, a budget that treats topology edges differently from context samples, and a ground-truth benchmark for cross-thread attribution.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 可编程能力能在 io_uring 里面走多远？](https://eunomia.dev/zh/research/io-uring-bpf-programmability/)
+
+当前 Linux 的 io_uring 同时出现了按 opcode 的 BPF 请求过滤和 eBPF `struct_ops` 执行路径。本文区分 cBPF admission gate 与 eBPF ring-loop control surface，并进一步分析 restriction、LSM 权限、policy generation、provenance 和资源归属怎样组合，尤其是在 io_uring 开始承载 FUSE、zero-copy networking、ublk 等注册 I/O 资源之后。
+
 ### [异步系统里，eBPF Profiler 还要追踪什么？](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)
 
 异步工作会经过 `io_uring`、workqueue、runtime task 与 application-defined resource 离开原来的线程，因此即使 CPU 与 off-CPU sample 本身准确，也可能失去逻辑归属。本文提出 typed causal-edge 模型、把 topology edge 与 context sample 分开预算的采集方法，以及用于跨线程 attribution 的 ground-truth benchmark。

--- a/docs/research/io-uring-bpf-programmability.md
+++ b/docs/research/io-uring-bpf-programmability.md
@@ -1,0 +1,282 @@
+---
+date: 2026-08-14
+title: "How Far Can eBPF Programmability Move Into io_uring?"
+description: "Current Linux has both io_uring request filters and an eBPF struct_ops control path. This report asks how those mechanisms should compose with restrictions, LSM policy, and new I/O objects before io_uring can become a safe programmable runtime boundary."
+tags:
+  - Daily Report
+  - eBPF
+  - io_uring
+  - Linux
+  - I/O
+  - Security
+  - Runtime
+research_question: "What becomes possible now that current Linux io_uring has both in-ring BPF request filtering and an eBPF struct_ops execution path, and what authority, context, lifecycle, and evaluation contracts are still missing before eBPF can safely control asynchronous I/O?"
+source_cutoff: 2026-08-14
+status: daily-report
+---
+
+# How Far Can eBPF Programmability Move Into io_uring?
+
+Suppose a storage or networking service owns one `io_uring` and submits work for many logical clients. The same ring may open files, connect sockets, issue device-specific `URING_CMD` requests, receive network payloads directly into registered userspace memory, and eventually carry filesystem work through FUSE. At that point, the ring is no longer just a faster syscall batching interface. It is an execution boundary with its own queues, registered resources, scheduling rules, and increasingly its own policy surface.
+
+Linux has traditionally offered two obvious places to control such work. A program can configure static `io_uring` restrictions when the ring is created, and system security policy can act through Linux Security Module hooks around the operations that eventually execute. Current Linux source now contains a third class of mechanism: BPF code can run *inside* the `io_uring` path itself.
+
+<!-- more -->
+
+The important detail is that there are actually two different BPF mechanisms, and treating them both as generic "eBPF hooks" hides the interesting systems problem.
+
+`IORING_REGISTER_BPF_FILTER` installs per-opcode **classic BPF (cBPF)** programs that decide whether a submission is allowed. Separately, `io_uring_bpf_ops` is an **eBPF `struct_ops`** interface that can replace a ring's loop step and call io_uring-specific kfuncs. One mechanism is deliberately small and admission-oriented. The other can participate in the ring's execution loop and access ring memory regions under verifier constraints.
+
+That split is more interesting than adding another probe point. It means `io_uring` is starting to expose several programmable control planes with different trust models, contexts, and lifetimes. The research question is no longer "where can eBPF observe I/O?" It is **how eBPF should participate in I/O execution without creating an incoherent second security and scheduling stack**.
+
+This report continues the [eBPF runtime and extensibility series](https://eunomia.dev/research/async-ebpf-causal-profiler/). The previous reports asked how userspace eBPF runtimes should define capabilities, how multiple programs compose on one hook, how stateful applications upgrade, and how asynchronous work preserves causality. `io_uring` now provides a concrete kernel subsystem where all four questions meet.
+
+## io_uring already has four different kinds of control
+
+The easiest way to see the architectural change is to compare what current Linux already exposes.
+
+| Mechanism | Scope | Programmability | Main role |
+| --- | --- | --- | --- |
+| `IORING_RESTRICTION_*` | one ring | static declarative rules | allow selected registration operations, SQE opcodes, and SQE flags |
+| `IORING_REGISTER_BPF_FILTER` | one ring and opcode | cBPF program | inspect submission context and allow or deny a request |
+| Linux Security Modules | system security boundary | LSM policy, including BPF LSM where applicable | enforce host-wide security decisions independently of one ring |
+| `io_uring_bpf_ops` | one ring | eBPF `struct_ops` plus io_uring kfuncs | participate in the ring execution loop, submit SQEs, and inspect permitted ring regions |
+
+The [io_uring UAPI](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h) still contains the older restriction interface. It can allow a registration opcode, allow an SQE opcode, or constrain SQE flags. That is useful for sandbox-style rings because it can permanently reduce what a ring may submit.
+
+The same UAPI now also includes `IORING_REGISTER_BPF_FILTER`. Unlike a static opcode allowlist, a filter can make a decision from request-specific state. This creates a natural hierarchy: restrictions describe a coarse capability envelope, while a filter can decide whether one request fits the policy inside that envelope.
+
+The eBPF `struct_ops` path goes further. It is not just a finer allowlist. It can change how an eligible ring runs work.
+
+The challenge is that these mechanisms were designed for different jobs. A production system that combines them needs to know which one is authoritative, which state each layer may observe or mutate, what happens during updates, and how an operator can explain a decision after the fact.
+
+## The new request filter is BPF, but it is deliberately not eBPF
+
+The current [BPF filter UAPI](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring/bpf_filter.h) defines an `io_uring_bpf_ctx` containing `user_data`, the SQE opcode, SQE flags, and optional opcode-specific auxiliary data. The current auxiliary union includes fields for `SOCKET`, `OPENAT`/`OPENAT2`, and `CONNECT`, such as socket family and protocol, open flags and resolve mode, or a destination address and port.
+
+The kernel's [filter implementation](https://github.com/torvalds/linux/blob/master/io_uring/bpf_filter.c) makes the intended semantics quite explicit. Filters are registered per opcode. A return value of 1 allows the request and 0 denies it. If several filters exist for one opcode, every filter must allow the request. A denial becomes `-EACCES` before the request is queued.
+
+The submission path in [`io_uring.c`](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c) runs those filters immediately after request initialization and before `trace_io_uring_submit_req()` and normal queueing. That is a useful location for admission control because the kernel has already interpreted enough of the SQE to construct a request, while execution has not yet escaped into worker, polling, device, or completion paths.
+
+There is also a compatibility mechanism that is easy to miss. A userspace filter declares the auxiliary PDU size it expects. The kernel reports the actual size for that opcode, and `IO_URING_BPF_FILTER_SZ_STRICT` can make a size mismatch reject registration. `IO_URING_BPF_FILTER_DENY_REST` can populate unconfigured opcodes with a deny filter. These are small features, but they already encode two properties that a larger programmable interface needs: explicit context version expectations and an allowlist-by-default mode.
+
+The surprising part is how the filter program is loaded. The implementation builds a `sock_fprog` and calls `bpf_prog_create_from_user()`. In other words, this is a constrained cBPF filter path, not an eBPF program loaded through a normal `BPF_PROG_LOAD` workflow.
+
+That choice makes sense for a narrow gate. A cBPF program with a fixed context is easier to reason about than a general eBPF program with maps, kfuncs, mutable shared state, and a growing helper surface. The request filter can remain close to "pure predicate over this submission."
+
+It also means that `IORING_REGISTER_BPF_FILTER` should not be described as the point where arbitrary eBPF enters io_uring. The deeper eBPF boundary lives elsewhere.
+
+## eBPF struct_ops can participate in the ring's execution loop
+
+The current [`io_uring/bpf-ops.h`](https://github.com/torvalds/linux/blob/master/io_uring/bpf-ops.h) defines `struct io_uring_bpf_ops` with a `loop_step` callback and a `ring_fd`. The implementation in [`bpf-ops.c`](https://github.com/torvalds/linux/blob/master/io_uring/bpf-ops.c) registers that structure as a BPF `struct_ops` type named `io_uring_bpf_ops`.
+
+This is real eBPF programmability. The implementation registers io_uring-specific kfuncs for `BPF_PROG_TYPE_STRUCT_OPS`. Two are especially important:
+
+- `bpf_io_uring_submit_sqes()` can submit a requested number of SQEs for the ring;
+- `bpf_io_uring_get_region()` can return a bounded pointer to selected io_uring memory regions, including the parameter memory, completion-queue region, or submission-queue region.
+
+The verifier path restricts access to the callback context, and the region kfunc checks the requested size before returning a pointer. The interface therefore does not simply expose an arbitrary `io_ring_ctx *` to eBPF. It defines a small subsystem-specific capability surface.
+
+The installation rules also show that this is not yet a generic replacement for every io_uring execution mode. Current code rejects `io_uring_bpf_ops` on rings using `IORING_SETUP_SQPOLL` or `IORING_SETUP_IOPOLL`, requires `IORING_SETUP_DEFER_TASKRUN`, and permits only one installed `bpf_ops` instance per ring. The BPF object is attached to a specific `ring_fd` and removed when its `struct_ops` link is unregistered.
+
+Those constraints are useful. They give us a concrete boundary to evaluate rather than an unlimited "programmable I/O" slogan. The eBPF program is allowed to participate in a particular ring's deferred task-run loop, with a defined set of kfuncs and memory regions.
+
+The architectural distinction is now clear:
+
+```text
+SQE submitted by application
+        |
+        v
+static ring restrictions
+        |
+        v
+cBPF per-opcode admission filter
+        |
+        v
+normal request initialization / security / issue paths
+        |
+        +----------> asynchronous workers, poll, device paths
+        |
+        v
+eBPF struct_ops-controlled ring loop
+        |
+        +----------> submit SQEs / inspect permitted ring regions
+        v
+completion handling
+```
+
+This is not the exact call graph for every operation, but it captures the useful design separation. The cBPF filter decides whether a request may enter. The eBPF `struct_ops` path can influence how a supported ring progresses work. LSM and subsystem security checks remain separate authority boundaries.
+
+## Why this matters more as io_uring absorbs new I/O objects
+
+If io_uring only batched `read()` and `write()`, an in-ring execution control plane would still be interesting, but the scope would be limited. Current Linux is moving more subsystem-specific work into the ring.
+
+The kernel's [FUSE-over-io-uring documentation](https://docs.kernel.org/next/filesystems/fuse-io-uring.html) describes a userspace FUSE daemon registering `IORING_OP_URING_CMD` entries on the FUSE connection. Once registration is active, the kernel can enqueue FUSE requests to per-CPU io_uring queues and the daemon returns a result while fetching the next request. The documentation explicitly says the interface is still in development and does not yet support every request type.
+
+This changes what a ring represents. It can become the transport for a filesystem control path rather than merely a queue of syscalls initiated by the application.
+
+The [io_uring zero-copy receive documentation](https://docs.kernel.org/networking/iou-zcrx.html) moves another boundary. Packet headers remain in the normal kernel TCP stack, but payload data can land directly in registered userspace memory. Flow steering and RSS decide which hardware receive queues feed the zero-copy path, and the application recycles buffers through an io_uring refill ring.
+
+Again, the ring is now tied to resources that live beyond one ordinary syscall argument: NIC queues, registered memory, refill metadata, multishot receive state, and application buffer lifetimes.
+
+The block layer is evolving similarly. The kernel's [ublk documentation](https://docs.kernel.org/block/ublk.html) describes userspace block servers built around io_uring commands, including newer zero-copy support using registered kernel buffers. A trusted userspace server becomes responsible for preserving buffer correctness when servicing client I/O.
+
+These examples make the eBPF `struct_ops` interface more consequential. An eBPF program that controls a ring loop may eventually sit near filesystem, networking, block, or device-specific work. A subsystem-specific kfunc that is harmless for a synthetic benchmark can become part of a real storage or networking authority path when the ring owns registered resources.
+
+The right abstraction therefore cannot be "give eBPF more io_uring internals." It needs to state exactly which I/O capabilities the program controls and which system security decisions remain outside its authority.
+
+## eBPF should compose with LSM, not become a parallel security stack
+
+Current [`io_uring.c`](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c) calls `security_uring_allowed()` during ring setup. io_uring also invokes security checks in credential and operation-specific paths. More generally, Linux Security Modules exist to make host security policy authoritative across subsystems, not only inside one file descriptor.
+
+A ring-local BPF program solves a different problem. It can express policy from the perspective of one application or one ring. For example, a service might want one tenant-facing ring to connect only to a known address class, deny filesystem opens with selected flags, or use a custom deferred-task execution policy. Those are useful local constraints even when the host LSM already permits the process to perform the underlying operations.
+
+The dangerous design would let a ring-local eBPF program reinterpret system authority. If the struct_ops program can create or submit work through a path that no longer encounters the same LSM checks as a normal request, programmability becomes a bypass surface. Conversely, if every ring-local decision has to re-run a large host policy engine, the hot-path benefit may disappear.
+
+The clean model is asymmetric:
+
+1. **LSM remains the upper security authority.** Ring-local programs may further restrict or schedule work, but cannot grant an operation that host policy denies.
+2. **cBPF filters provide cheap request admission.** Their small context and pure allow/deny semantics make them suitable for a narrow predicate.
+3. **eBPF struct_ops provides execution policy inside an explicitly supported ring mode.** Its kfunc and memory access surface is capability-limited and should stay auditable.
+4. **Static restrictions define irreversible or hard-to-broaden capability envelopes when that is desired.** A dynamic program should not silently widen a ring that was intentionally created with a smaller static authority set.
+
+Linux already contains pieces of this hierarchy. What is missing is a machine-readable contract that makes the relationship explicit enough for application authors, verifiers, and operators to rely on it.
+
+## Where current work is still weak
+
+### Filter context is much richer for some opcodes than others
+
+The base cBPF context always contains opcode, SQE flags, and `user_data`. The current [`opdef.c`](https://github.com/torvalds/linux/blob/master/io_uring/opdef.c) adds semantic filter payloads for `CONNECT`, `OPENAT`/`OPENAT2`, and `SOCKET`. Many other operations have no equivalent opcode-specific payload.
+
+That means two policies with the same conceptual goal can have very different observability. A filter can inspect an address for `CONNECT`, but a future policy over `URING_CMD`, zero-copy receive resources, registered files, or subsystem-specific command fields may see far less semantic information.
+
+The missing property is not "more fields." It is a principled rule for **which semantic state is safe and stable enough to expose at the admission boundary**. The current PDU-size negotiation is a useful compatibility seed, but it does not define how new fields acquire semantics or how policy remains portable across kernel versions.
+
+A decisive test would take the same policy, such as "this ring may access only resources in tenant T," across file, socket, FUSE, ublk, and zero-copy receive operations. If each opcode needs unrelated ad hoc parsing or privileged side channels, the context model is too fragmented.
+
+### The control planes have no common precedence or provenance model
+
+Static restrictions, cBPF filters, LSM decisions, and eBPF `struct_ops` all answer different questions. Their interaction is currently implicit in code paths rather than represented as one policy graph.
+
+Operators will eventually ask simple questions that are hard to answer from that arrangement:
+
+- Which rule denied this SQE?
+- Which version of the ring-local policy was active?
+- Did an eBPF loop submit the request or did userspace submit it directly?
+- Which LSM decision still applies to a request generated by an in-ring execution policy?
+- Did the ring inherit or copy a filter set from another restriction object?
+
+The cBPF filter implementation already uses copy-on-write behavior for filter sets, and the eBPF struct_ops object has its own link lifecycle. These mechanisms are individually understandable, but they do not produce one common provenance record.
+
+A production runtime needs a stable answer for every admitted, denied, generated, and completed request. Without that, programmability can improve control while making incidents harder to explain.
+
+### Updating one ring's programmable state is not a transaction
+
+The active series already examined [transactional upgrades for stateful eBPF applications](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/). io_uring exposes the same problem in a narrower and more operationally important form.
+
+A ring may simultaneously depend on static restrictions, a set of cBPF opcode filters, one eBPF struct_ops link, registered files, memory regions, personalities, buffer rings, FUSE entries, or zero-copy network resources. Changing only one of those objects can temporarily create a policy that no intended generation ever specified.
+
+For example, an operator might install a new execution policy before the matching filter context is available, or update a resource registration while an old struct_ops program still assumes the previous layout. The kernel's current individual APIs can each be correct while the application-level transition is inconsistent.
+
+The missing mechanism is a generation boundary across *related programmable I/O state*. Whether that belongs in io_uring itself or in a userspace controller is an open design choice, but the evaluation must include concurrent submissions and failure in the middle of an update.
+
+### Resource accounting is weaker than the new execution boundary
+
+Once eBPF can drive a ring loop and the ring can own substantial registered resources, CPU instruction count is not enough for accounting. A policy may trigger submissions, retain registered memory, interact with FUSE queues, or change how often the application crosses into the kernel.
+
+A safe runtime needs attribution for at least:
+
+- eBPF execution time and invocation count;
+- SQEs submitted by userspace versus generated or progressed through the BPF-controlled loop;
+- bytes and lifetime of registered memory reachable by the ring;
+- completion-queue pressure and dropped or deferred work;
+- subsystem-specific resources such as FUSE queue entries or zero-copy receive buffers.
+
+Without this accounting, a program can be verifier-safe but still be operationally expensive. This is the same distinction the [userspace eBPF runtime contract](https://eunomia.dev/research/userspace-ebpf-runtime-contract/) made between memory safety and runtime resource authority, now applied to a kernel I/O substrate.
+
+## Promising directions with academic and production value
+
+### 1. A typed capability contract for programmable io_uring
+
+**Gap.** The current interfaces expose a mixture of static restrictions, cBPF context fields, eBPF `struct_ops` callbacks, and kfunc-accessible regions, but no single description of what a ring-local program is allowed to observe or cause.
+
+**Mechanism.** Define a machine-readable capability descriptor for a programmable ring. It would name the permitted SQE classes, semantic context fields, registered-resource classes, eBPF kfuncs, writable or read-only regions, and whether BPF-originated submission is allowed. The descriptor would be bound to the ring and queryable from userspace. BTF can describe eBPF-side typed structures, while the existing filter PDU-size negotiation can remain the compatibility mechanism for the intentionally small cBPF gate.
+
+The key is to keep cBPF and eBPF separate where their trust models differ while giving both a common capability vocabulary. A descriptor might say that `CONNECT` admission exposes destination family/address/port to cBPF, while the eBPF loop can submit only opcodes A and B and access only the CQ region.
+
+**Delta.** This is different from adding more filter fields or more kfuncs. The artifact is the contract that constrains and explains those interfaces.
+
+**Artifact and evaluation.** Implement a prototype around current io_uring query/registration APIs and a liburing inspection tool. Test file, network, FUSE, and ublk workloads. Measure whether the same high-level capability policy maps cleanly across opcodes, how many kernel-version conditionals remain, and whether a verifier or controller can reject incompatible program/ring combinations before activation.
+
+**Academic value.** The general question is how a subsystem-specific eBPF runtime exposes heterogeneous capabilities without collapsing into an unstable internal API.
+
+**Production value.** Operators can inspect what a ring-local program can actually do before attaching it, rather than reviewing BPF source plus kernel internals.
+
+**Failure condition.** If the descriptor simply mirrors dozens of unstable implementation fields and cannot reduce compatibility logic, it adds bureaucracy without providing a useful abstraction.
+
+### 2. Versioned ring policy generations with explicit authority ordering
+
+**Gap.** A ring's effective policy spans objects that update independently and whose precedence is implicit.
+
+**Mechanism.** Treat related restrictions, cBPF filters, eBPF struct_ops, and registered-resource assumptions as one versioned policy generation. Build the next generation off-path, validate it against the target ring capabilities, then activate it with one generation switch. Requests record the generation under which they entered the ring. Completions and audit events preserve that generation even if policy changes while the request is in flight.
+
+The generation also defines authority ordering: static restriction envelope first, host LSM authority always applicable, ring-local cBPF admission next, and eBPF execution policy last within its granted capabilities. A generated submission inherits the same or a strictly narrower generation instead of starting an untracked authority chain.
+
+**Delta.** The previous transactional-upgrade report focused on general stateful BPF applications. Here the test case is stricter: the transaction must cover a live asynchronous I/O queue whose old requests and new requests overlap in time.
+
+**Artifact and evaluation.** Implement generation tagging in a userspace controller first, then evaluate whether a small kernel primitive is needed for atomic activation. Inject process crashes and update failures while fio, a network proxy, FUSE, and ublk workloads submit continuously. Score unauthorized windows, request loss, generation ambiguity, rollback time, and hot-path overhead.
+
+**Academic value.** This exposes a general concurrency problem at the boundary between policy versioning and asynchronous execution.
+
+**Production value.** A service can update ring-local policy without draining every queue or accepting a temporary mixed configuration that is difficult to audit.
+
+**Failure condition.** If normal link replacement plus application-level quiescence already provides negligible downtime and no measurable inconsistent window, a new generation primitive is unnecessary.
+
+### 3. A benchmark for in-ring eBPF control versus external hooks
+
+**Gap.** It is easy to argue that an in-ring eBPF control point is faster or more expressive than LSM, tracing, seccomp-style constraints, or userspace validation. There is not yet a standard workload that tells us when the extra control surface is actually worth its complexity.
+
+**Mechanism.** Build one benchmark suite where the same policy is implemented at several boundaries:
+
+1. userspace validation before SQE submission;
+2. static `IORING_RESTRICTION_*` where expressible;
+3. cBPF `IORING_REGISTER_BPF_FILTER`;
+4. host security policy at an LSM-relevant boundary;
+5. eBPF `io_uring_bpf_ops` for execution policies that need the ring loop;
+6. a tracing-only baseline that observes but does not enforce.
+
+Use policies that force the mechanisms to differ. Examples include destination-aware socket admission, file-open constraints, tenant-specific registered-buffer use, request scheduling under completion pressure, and a BPF-driven loop that batches submission adaptively.
+
+**Artifact and evaluation.** Use microbenchmarks plus realistic network, storage, FUSE, and ublk services. Measure per-I/O latency, throughput, CPU cycles, cache effects, policy precision, bypass attempts, tail latency under overload, and update behavior. Run ablations with no semantic PDU, no region kfunc access, and no BPF-originated submission.
+
+**Academic value.** The result would identify which control decisions benefit from being moved inside an asynchronous I/O runtime rather than attached before or after it.
+
+**Production value.** Kernel and runtime maintainers get evidence for whether a proposed new io_uring BPF context field or kfunc solves a real deployment problem.
+
+**Failure condition.** If external hooks and userspace validation match the in-ring mechanisms on both overhead and policy precision for realistic workloads, the correct design is to keep io_uring's BPF surface small.
+
+## The design target is a narrow programmable boundary, not unlimited in-kernel plugins
+
+Current Linux source is already enough to reject two extremes.
+
+The first extreme says io_uring only needs observability. That is no longer accurate because the kernel contains both a submission-time BPF decision path and an eBPF execution-control interface.
+
+The second extreme says this should grow into a general-purpose eBPF runtime with access to arbitrary io_uring internals. The current implementation points in the opposite direction. The cBPF filter intentionally has a small predicate context. The eBPF path exposes specific BTF-checked callback state and selected kfuncs. It restricts which ring modes can attach the struct_ops implementation. These constraints are features if the goal is a maintainable subsystem interface.
+
+The more useful target is a **narrow programmable boundary with explicit authority**:
+
+- stable semantic context where request admission needs it;
+- a deliberately small eBPF execution interface where in-ring control has measurable value;
+- host security policy that remains authoritative;
+- versioned lifecycle and provenance across the pieces;
+- resource accounting that measures effects beyond verifier safety.
+
+That design would make io_uring a strong case study for a broader eBPF question. As BPF moves from observing subsystems to participating in their control loops, the main interface problem shifts from "which hook can I attach to?" to "what capability does this attachment grant, and how does it compose with the rest of the system?"
+
+## What would change this conclusion?
+
+This argument assumes that in-ring decisions provide either lower overhead, better semantic context, or tighter execution control than policies placed outside io_uring. The benchmark above could show that the assumption is wrong.
+
+If static restrictions plus existing LSM and userspace validation cover nearly every production policy with comparable overhead, io_uring should keep the new BPF surfaces narrow and specialized. If eBPF struct_ops cannot expose useful execution control without depending on unstable ring internals, the interface may be better treated as an experimental optimization hook rather than a runtime boundary. If cBPF filter overhead becomes material on high-IOPS paths, the right answer may be to push more decisions into static capabilities rather than make the filter richer.
+
+The opposite result would be more interesting. If FUSE, zero-copy networking, ublk, and other ring-centric workloads repeatedly need request semantics and execution control that external hooks cannot express cheaply, then io_uring offers a concrete path toward subsystem-native eBPF programmability. In that case, the next work should not be a larger pile of hooks. It should be a coherent contract for capability, authority, updates, provenance, and resource cost.

--- a/docs/research/io-uring-bpf-programmability.zh.md
+++ b/docs/research/io-uring-bpf-programmability.zh.md
@@ -1,0 +1,292 @@
+---
+date: 2026-08-14
+title: "eBPF 可编程能力能在 io_uring 里面走多远？"
+description: "当前 Linux 的 io_uring 已经同时出现请求过滤和 eBPF struct_ops 控制路径。本文分析这些机制怎样与静态限制、LSM 安全策略和新型 I/O 对象组合，以及 io_uring 要成为安全的可编程运行时边界还缺什么。"
+tags:
+  - Daily Report
+  - eBPF
+  - io_uring
+  - Linux
+  - I/O
+  - Security
+  - Runtime
+research_question: "当当前 Linux io_uring 同时拥有 ring 内 BPF 请求过滤和 eBPF struct_ops 执行路径后，哪些机制第一次变得可行，以及在让 eBPF 安全控制异步 I/O 之前，权限、上下文、生命周期和评测还缺哪些明确契约？"
+source_cutoff: 2026-08-14
+status: daily-report
+---
+
+# eBPF 可编程能力能在 io_uring 里面走多远？
+
+设想一个存储或网络服务只维护一个 `io_uring`，却替多个逻辑租户提交工作。这个 ring 可能同时负责打开文件、连接 socket、发送设备专用的 `URING_CMD`、把网络 payload 直接收进预注册的用户态内存，甚至承载 FUSE 的文件系统请求。到了这个阶段，`io_uring` 已经不只是把 syscall 批量化得更快。它开始像一个有自己队列、注册资源、调度规则和安全边界的执行环境。
+
+过去如果要约束这些操作，通常会想到两个位置。应用创建 ring 时可以配置静态 restriction，系统级安全策略则可以通过 Linux Security Module 在真正执行文件、网络或凭据相关操作时作最终判断。当前 Linux 源码里已经出现了第三类机制：BPF 程序可以直接运行在 `io_uring` 自己的执行路径里。
+
+<!-- more -->
+
+这里有一个很容易写错、但恰好最值得研究的细节：当前 `io_uring` 里面其实有两套不同的 BPF 机制。
+
+`IORING_REGISTER_BPF_FILTER` 安装的是按 opcode 绑定的 **classic BPF（cBPF）** 过滤器，用来决定一个 submission 能不能进入后续执行。另一边，`io_uring_bpf_ops` 是真正的 **eBPF `struct_ops`** 接口，可以接管 ring 的一次 loop step，并通过 io_uring 专用 kfunc 提交 SQE 或访问受限的 ring memory region。
+
+前者刻意做得很小，接近“对当前请求做一次纯粹的 allow/deny 判断”；后者已经进入执行控制。这个分裂比“Linux 又多了一个 eBPF hook”更重要，因为它说明同一个 I/O 子系统里正在形成几层不同的可编程控制面，而它们的权限、上下文和生命周期并不相同。
+
+因此，真正的问题已经从“eBPF 能不能观察 I/O”变成了：**eBPF 应该怎样参与 I/O 执行，同时不在 Linux 里面再造一套互相打架的安全、调度和资源控制系统？**
+
+本文延续 [eBPF runtime 与 extensibility 系列](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)。前面的文章分别讨论过用户态 eBPF runtime contract、多个程序共享 hook、状态化应用升级，以及异步执行中的因果关系。`io_uring` 是一个很好的具体例子，因为这几个问题现在开始在同一个真实内核子系统里汇合。
+
+## io_uring 里面已经存在四层不同的控制
+
+先看当前 Linux 已经提供了什么。
+
+| 机制 | 作用范围 | 可编程程度 | 主要用途 |
+| --- | --- | --- | --- |
+| `IORING_RESTRICTION_*` | 单个 ring | 静态声明式规则 | 限制允许的注册操作、SQE opcode 和 SQE flags |
+| `IORING_REGISTER_BPF_FILTER` | 单个 ring + opcode | cBPF 程序 | 查看 submission 上下文并允许或拒绝请求 |
+| Linux Security Modules | 系统安全边界 | LSM policy，包括适用场景下的 BPF LSM | 独立于单个 ring 做主机级安全判定 |
+| `io_uring_bpf_ops` | 单个 ring | eBPF `struct_ops` + io_uring kfunc | 参与 ring execution loop、提交 SQE、读取允许访问的 ring region |
+
+当前 [io_uring UAPI](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring.h) 仍然保留早期的 restriction 接口。它可以允许某个 registration opcode、允许某类 SQE，或者限制 SQE flags。对于 sandbox 风格的 ring，这很有用，因为能力可以在创建阶段就被收窄。
+
+同一份 UAPI 现在还包含 `IORING_REGISTER_BPF_FILTER`。与静态 allowlist 不同，filter 可以根据当前请求的状态决定是否允许。这自然形成了两层关系：restriction 定义粗粒度的 capability envelope，filter 再判断某一个具体请求是不是满足策略。
+
+而 eBPF `struct_ops` 更进一步。它不是更复杂的 allowlist，而是允许 eBPF 参与一个受支持 ring 的执行推进。
+
+问题在于，这四层机制原本解决的是不同事情。如果生产系统开始同时使用它们，就必须回答几个很实际的问题：谁拥有最终权限，哪一层可以读写什么状态，更新时怎样保证版本一致，以及事后如何解释一条请求到底被哪层允许、拒绝或生成。
+
+## 请求过滤器叫 BPF，但它现在刻意不是 eBPF
+
+当前 [BPF filter UAPI](https://github.com/torvalds/linux/blob/master/include/uapi/linux/io_uring/bpf_filter.h) 定义了 `io_uring_bpf_ctx`。基础字段包括 `user_data`、SQE opcode、SQE flags，以及可选的 opcode-specific auxiliary data。当前的辅助结构已经覆盖了几类有语义的信息：
+
+- `SOCKET` 的 family、type、protocol；
+- `OPENAT` / `OPENAT2` 的 flags、mode、resolve；
+- `CONNECT` 的地址族、port、IPv4/IPv6 地址。
+
+内核的 [filter implementation](https://github.com/torvalds/linux/blob/master/io_uring/bpf_filter.c) 也把语义写得很直接。过滤器按 opcode 注册，返回 1 表示允许，返回 0 表示拒绝。同一个 opcode 如果挂了多个 filter，所有 filter 都必须通过。拒绝会在请求真正进入队列之前变成 `-EACCES`。
+
+[`io_uring.c`](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c) 的 submission path 会在 `io_init_req()` 之后执行这些 filter，然后才进入常规的 submit trace 和 queue 路径。这个位置适合 admission control，因为 kernel 已经把 SQE 解释成 request，能准备出一定语义上下文，但 work 还没有逃逸到 worker、poll、device 或 completion 路径里。
+
+这套接口还有一个值得注意的兼容机制。用户态 filter 会声明自己期望的 auxiliary PDU 大小；kernel 也会告诉用户态该 opcode 的实际 size。`IO_URING_BPF_FILTER_SZ_STRICT` 可以在 size 不匹配时直接拒绝注册，`IO_URING_BPF_FILTER_DENY_REST` 则可以把所有没有明确配置的 opcode 设成默认拒绝。
+
+这两个小功能其实已经反映出两个更大的 runtime 需求：上下文版本要明确，默认权限边界也要明确。
+
+最关键的是程序怎么被加载。当前实现构造 `sock_fprog`，然后调用 `bpf_prog_create_from_user()`，因此这个路径是受限的 cBPF filter，而不是通过普通 `BPF_PROG_LOAD` 加载的 eBPF 程序。
+
+对于一个热路径上的小型 admission gate，这个选择是合理的。固定 context 的 cBPF predicate 比带 map、kfunc、共享可变状态和不断扩展 helper surface 的通用 eBPF 更容易分析。
+
+所以，`IORING_REGISTER_BPF_FILTER` 不应该被包装成“任意 eBPF 已经进入 io_uring”。真正更深的 eBPF 边界在另一条路径上。
+
+## eBPF struct_ops 已经开始参与 ring 的 execution loop
+
+当前 [`io_uring/bpf-ops.h`](https://github.com/torvalds/linux/blob/master/io_uring/bpf-ops.h) 定义了 `struct io_uring_bpf_ops`，其中包含 `loop_step` callback 和 `ring_fd`。[`bpf-ops.c`](https://github.com/torvalds/linux/blob/master/io_uring/bpf-ops.c) 把它注册成名为 `io_uring_bpf_ops` 的 BPF `struct_ops` 类型。
+
+这才是真正的 eBPF programmability。实现还为 `BPF_PROG_TYPE_STRUCT_OPS` 注册了 io_uring 专用的 kfunc，其中两个特别重要：
+
+- `bpf_io_uring_submit_sqes()` 可以让程序为这个 ring 提交指定数量的 SQE；
+- `bpf_io_uring_get_region()` 可以返回经过 size 检查的指针，让程序访问选定的 io_uring memory region，例如 parameter memory、completion queue region 或 submission queue region。
+
+verifier 还会限制 callback context 的访问范围，region kfunc 在返回指针前也会检查请求长度。因此，这个接口并不是把任意 `io_ring_ctx *` 整个交给 eBPF，而是在做一个小型、subsystem-specific 的 capability surface。
+
+安装条件也说明它目前并不打算覆盖所有 io_uring 模式。当前代码会拒绝带 `IORING_SETUP_SQPOLL` 或 `IORING_SETUP_IOPOLL` 的 ring，要求 `IORING_SETUP_DEFER_TASKRUN`，而且一个 ring 只能装一个 `bpf_ops` instance。BPF object 通过 `ring_fd` 绑定到具体 ring，并随着 `struct_ops` link 生命周期被卸载。
+
+这些限制不应该简单理解成“功能还不完整”。如果目标是建立可维护的内核接口，限制本身就是设计的一部分。我们终于可以讨论一个明确的问题：一个 eBPF 程序被允许参与某个 defer-task-run ring 的执行循环，但它只能调用指定 kfunc，也只能看到明确授权的 region。
+
+从架构上，可以把当前几层关系粗略理解成：
+
+```text
+application 提交 SQE
+        |
+        v
+静态 ring restrictions
+        |
+        v
+按 opcode 的 cBPF admission filter
+        |
+        v
+普通 request 初始化 / security / issue 路径
+        |
+        +----------> worker、poll、device 等异步执行
+        |
+        v
+eBPF struct_ops 控制的 ring loop
+        |
+        +----------> submit SQE / 读取允许的 ring region
+        v
+completion handling
+```
+
+这不是每一个 opcode 的精确 call graph，但它抓住了设计上最重要的区别。cBPF filter 决定请求能不能进来，eBPF `struct_ops` 可以影响一个受支持 ring 怎样推进执行，而 LSM 和各子系统自己的安全检查仍然是独立的权限边界。
+
+## io_uring 开始承载更多 I/O 对象后，这个问题会放大
+
+如果 `io_uring` 永远只是在批量提交 `read()` 和 `write()`，ring 内执行控制仍然有价值，但边界会相对简单。当前 Linux 正把更多 subsystem-specific 工作放进 ring。
+
+内核的 [FUSE-over-io-uring 文档](https://docs.kernel.org/next/filesystems/fuse-io-uring.html) 描述了用户态 FUSE daemon 使用 `IORING_OP_URING_CMD` 在 FUSE connection 上注册请求条目。注册完成后，kernel 可以把 FUSE request 放到 per-CPU io_uring queue，daemon 返回结果时同时获取下一条请求。文档也明确说这套接口仍在开发中，并没有覆盖所有 request 类型。
+
+这意味着 ring 已经可以成为文件系统控制路径的 transport，而不只是“应用主动发起 syscall 的队列”。
+
+[io_uring zero-copy receive 文档](https://docs.kernel.org/networking/iou-zcrx.html) 又移动了一层边界。packet header 仍由普通 kernel TCP stack 处理，但 payload 可以直接进入预注册的用户态内存。flow steering 和 RSS 负责把 NIC receive queue 对接到 zero-copy path，应用还要通过 io_uring refill ring 回收 buffer。
+
+于是一个 ring 绑定的对象不再只有 syscall 参数，还包括 NIC queue、registered memory、refill metadata、multishot receive state 和应用自己的 buffer lifetime。
+
+block 层也在发生类似变化。[ublk 文档](https://docs.kernel.org/block/ublk.html) 描述了基于 io_uring command 的 userspace block server，较新的 zero-copy 模式还会使用 registered kernel buffer。trusted userspace server 需要在服务 client I/O 时维护 buffer correctness。
+
+这些例子让 eBPF `struct_ops` 的意义变得更大。一个能控制 ring loop 的 eBPF 程序，未来可能非常靠近文件系统、网络、block 或设备专用的执行路径。某个在 microbenchmark 里看起来无害的 kfunc，一旦 ring 持有大量 registered resource，就可能变成真正的权限或资源成本边界。
+
+因此，正确抽象不应该是“把更多 io_uring internal 暴露给 eBPF”，而应该说明程序到底控制哪些 I/O capability，哪些系统安全决定永远不属于它。
+
+## eBPF 应该和 LSM 组合，而不是再造一套平行安全栈
+
+当前 [`io_uring.c`](https://github.com/torvalds/linux/blob/master/io_uring/io_uring.c) 会在 ring setup 期间调用 `security_uring_allowed()`，io_uring 在 credential 和具体 operation path 上也有独立安全检查。更大的原则是，LSM 用来表达跨子系统的 host-level security policy，而不是只管理某一个 file descriptor。
+
+ring-local BPF 解决的事情不一样。它可以从“这个应用、这个 ring”的视角做更窄的约束。例如，一个服务可能希望某个 tenant-facing ring 只能连接特定地址范围、禁止带某些 flag 的 file open，或者使用一个自定义 deferred-task execution policy。即使 host LSM 允许整个进程执行这些底层操作，这种局部收窄仍然有价值。
+
+真正危险的设计，是让 ring-local eBPF 重新解释系统权限。如果 struct_ops program 能通过一条不会经过同等 LSM 检查的新路径生成工作，programmability 就可能变成 bypass surface。反过来，如果每一个 ring-local decision 都要重新跑一遍大型 host policy engine，hot path 的价值又可能消失。
+
+更清楚的关系应该是非对称的：
+
+1. **LSM 仍然是更高层的安全权限。** ring-local program 可以进一步限制或调度，但不能授予 host policy 已经拒绝的操作。
+2. **cBPF filter 做低成本 request admission。** 小 context + allow/deny 语义适合做窄 predicate。
+3. **eBPF struct_ops 只在明确授权的 ring mode 里参与 execution policy。** kfunc 和 memory access surface 要保持 capability-limited、可审计。
+4. **静态 restriction 在需要时定义不可随意扩大的 capability envelope。** 动态程序不应该悄悄把一个本来故意收窄的 ring 权限重新放大。
+
+Linux 已经有这些关系的零件，但还缺一个足够明确的机器可读契约，让 application author、verifier 和 operator 都能依赖它。
+
+## 现有工作还薄弱在哪里
+
+### 不同 opcode 能拿到的语义上下文差异很大
+
+cBPF base context 总有 opcode、SQE flags 和 `user_data`。当前 [`opdef.c`](https://github.com/torvalds/linux/blob/master/io_uring/opdef.c) 还给 `CONNECT`、`OPENAT` / `OPENAT2`、`SOCKET` 添加了 semantic filter payload，但很多其他 operation 并没有对应上下文。
+
+于是，同一个高层策略在不同 opcode 上可能有完全不同的可实现性。filter 能看到 `CONNECT` 的目标地址，但如果以后要约束 `URING_CMD`、zero-copy receive resource、registered file 或设备专用字段，现有 context 可能根本没有对应语义。
+
+这里缺的并不是一句“再加几个字段”，而是一条稳定原则：**哪些语义状态适合在 admission boundary 被暴露，而且能跨 kernel version 保持可解释性。** 当前 PDU size negotiation 是一个不错的兼容性起点，但还没有定义新字段怎样获得长期语义，也没有解决 policy portability。
+
+一个很直接的实验，是把“这个 ring 只能访问 tenant T 的资源”这类策略同时应用到 file、socket、FUSE、ublk 和 zero-copy receive。如果每个 opcode 最后都要写完全不同的 ad hoc parser 或依赖额外 privileged side channel，那么 context model 还不够统一。
+
+### 多层控制面缺少共同的优先级与 provenance
+
+静态 restriction、cBPF filter、LSM 和 eBPF `struct_ops` 各自回答不同问题，但它们的关系主要隐含在 kernel code path 里，没有形成一个可查询的 policy graph。
+
+生产环境很快会问这些简单问题：
+
+- 这条 SQE 到底被哪条规则拒绝？
+- 当时生效的是哪个 ring-local policy 版本？
+- 这个请求是 userspace 提交的，还是 eBPF loop 生成或推进的？
+- BPF 生成的请求仍然经过哪一层 LSM 判断？
+- 一个 filter set 从别的 restriction object copy 过来后，当前 lineage 是什么？
+
+cBPF filter implementation 本身已经有 filter set 的 copy-on-write 行为，而 eBPF struct_ops 有另一套 link lifecycle。每一部分单独看都能理解，但没有共同的 provenance record。
+
+如果无法稳定回答“谁允许、谁拒绝、谁生成、当时是什么版本”，programmability 可能让控制更灵活，却让 incident 更难解释。
+
+### 一个 ring 的可编程状态更新还不是事务
+
+前面的 [有状态 eBPF 应用升级](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/) 已经讨论过通用的 transactional upgrade 问题。`io_uring` 把这个问题变得更窄，也更容易进入生产 hot path。
+
+一个 ring 可能同时依赖静态 restriction、一组 cBPF opcode filter、一个 eBPF struct_ops link、registered file、memory region、personality、buffer ring、FUSE entry 或 zero-copy network resource。单独更新其中一个对象，即使每个 API 自己都正确，也可能产生一个任何正式 generation 都没有定义过的临时状态。
+
+例如，operator 可能先安装了新 execution policy，但匹配的新 filter context 还没准备好；或者 resource registration 已经切到新布局，旧 struct_ops program 却仍按老布局理解 region。
+
+这里缺的是跨**相关 programmable I/O state** 的 generation boundary。它最终应该放在 io_uring kernel API 里，还是由 userspace controller 管理，可以继续讨论，但评测一定要覆盖并发 submission 和更新中途失败。
+
+### 新的 execution boundary 已经超过传统 eBPF accounting
+
+当 eBPF 能驱动 ring loop，而 ring 又持有大量 registered resource 时，只统计 BPF instruction count 不够。程序可能触发 submission、长期占用注册内存、推进 FUSE queue，或者改变用户态和 kernel 之间的交互频率。
+
+至少需要归属这些成本：
+
+- eBPF 执行时间和 invocation count；
+- userspace 原始提交与 BPF-controlled loop 生成或推进的 SQE；
+- ring 可访问 registered memory 的字节数和 lifetime；
+- completion queue pressure，以及 deferred / dropped work；
+- FUSE queue entry、zero-copy receive buffer 等 subsystem-specific resource。
+
+否则，一个程序可以 verifier-safe，却仍然在生产系统里非常昂贵。这和 [用户态 eBPF runtime contract](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/) 讨论的区别一样：memory safety 不等于 runtime resource authority。
+
+## 哪些方向值得继续做
+
+### 1. 给 programmable io_uring 一个类型化 capability contract
+
+**缺口。** 现有接口混合了静态 restriction、cBPF context field、eBPF `struct_ops` callback 和 kfunc-accessible region，却没有一个统一描述告诉系统“这个 ring-local program 到底能观察什么、能造成什么 effect”。
+
+**机制。** 为 programmable ring 定义机器可读的 capability descriptor。它声明允许的 SQE class、semantic context field、registered-resource class、eBPF kfunc、可读写 region，以及是否允许 BPF-originated submission。descriptor 与 ring 绑定，userspace 可以查询。eBPF 侧可以继续用 BTF 描述类型，而 cBPF gate 保留现有 PDU-size negotiation 作为兼容机制。
+
+关键不是强行把 cBPF 和 eBPF 合并成一种程序模型，而是让两者共享一套 capability vocabulary，同时保留不同 trust model。例如 descriptor 可以说：`CONNECT` admission 允许 cBPF 看到 destination family/address/port，而 eBPF loop 只能提交 opcode A/B，并且只能读 CQ region。
+
+**与现有机制的差别。** 这不是单纯增加 filter field 或 kfunc，真正的 artifact 是约束并解释这些接口的 contract。
+
+**实现与评测。** 可以先围绕现有 io_uring query/registration API 做 prototype，再配一个 liburing inspection tool。用 file、network、FUSE、ublk workload 检查同一个高层 capability policy 能否跨 opcode 映射，统计需要多少 kernel-version conditional，并测试 verifier/controller 能否在 activation 前拒绝不兼容的 program/ring 组合。
+
+**学术价值。** 这是一个更一般的问题：subsystem-specific eBPF runtime 怎样暴露异构 capability，而不退化成不稳定的 kernel-internal API。
+
+**生产价值。** operator 在 attach 前就能查询 ring-local program 的真实权限，不必把 BPF source 和内核实现一起人工审计。
+
+**失败条件。** 如果 descriptor 最终只是照抄几十个不稳定 implementation field，而且没有减少兼容代码，它只增加了管理负担。
+
+### 2. 用 versioned ring policy generation 明确权限顺序
+
+**缺口。** 一个 ring 的有效策略分散在独立更新的对象里，而且 precedence 隐含在执行路径中。
+
+**机制。** 把相关 restriction、cBPF filter、eBPF struct_ops 和 registered-resource assumption 视为一个 versioned policy generation。新 generation 先离线构造，验证和目标 ring capability 匹配后，再通过一次 generation switch 激活。请求进入 ring 时记录自己的 generation；即使 policy 在请求完成前已经更新，completion 和 audit record 仍保留原 generation。
+
+同一个 generation 还显式定义 authority ordering：静态 restriction envelope 先约束能力，host LSM 始终保持有效，ring-local cBPF admission 在其下进一步收窄，eBPF execution policy 只能在授予的 capability 里工作。BPF 生成的 submission 继承同一个或更窄的 generation，不能凭空产生新的 authority chain。
+
+**与现有工作的差别。** 前面的 transactional-upgrade report 讨论通用 stateful BPF application。这里的 testcase 更严格，因为它必须处理 live async I/O queue，新旧 request 会同时在飞。
+
+**实现与评测。** 可以先在 userspace controller 里实现 generation tagging，再判断是否真的需要一个小型 kernel atomic-activation primitive。用 fio、network proxy、FUSE 和 ublk 持续提交请求，同时注入 process crash 和 update failure。指标包括 unauthorized window、request loss、generation ambiguity、rollback latency 和 hot-path overhead。
+
+**学术价值。** 它把 policy versioning 与 asynchronous execution 的 concurrency 问题变成可验证对象。
+
+**生产价值。** 服务可以更新 ring-local policy，而不必先完全 drain queue，也不会接受一个很难审计的混合配置窗口。
+
+**失败条件。** 如果普通 link replacement 配合 application-level quiescence 已经能做到接近零停顿，也不会产生可测的 inconsistent window，就没有必要新增 generation primitive。
+
+### 3. 建一个 in-ring eBPF control 与外部 hook 的对照 benchmark
+
+**缺口。** 很容易宣称 ring 内 eBPF 比 LSM、tracing、userspace validation 或静态 constraint 更快、更有语义。但现在缺少一个标准 workload 告诉我们，额外的 control surface 到底什么时候值得。
+
+**机制。** 同一组 policy 分别放到几个 boundary 上实现：
+
+1. SQE submit 前的 userspace validation；
+2. 能表达时使用静态 `IORING_RESTRICTION_*`；
+3. cBPF `IORING_REGISTER_BPF_FILTER`；
+4. LSM-relevant host security boundary；
+5. 对需要 ring loop control 的 workload 使用 eBPF `io_uring_bpf_ops`；
+6. 只观察、不 enforcement 的 tracing baseline。
+
+policy 要故意选择那些能拉开机制差异的场景，例如 destination-aware socket admission、file-open constraint、tenant-specific registered buffer、completion pressure 下的 request scheduling，以及根据负载自适应 batch submission 的 BPF-controlled loop。
+
+**实现与评测。** 除 microbenchmark 外，再加入真实 network、storage、FUSE 和 ublk service。测 per-I/O latency、throughput、CPU cycles、cache effect、policy precision、bypass attempt、overload tail latency 和 update behavior。还要做几个 ablation：去掉 semantic PDU、去掉 region kfunc access、去掉 BPF-originated submission。
+
+**学术价值。** 这个 benchmark 可以回答什么控制决策真正值得放进 asynchronous I/O runtime，而不是在它前后挂 hook。
+
+**生产价值。** kernel/runtime maintainer 能据此判断一个新的 io_uring BPF context field 或 kfunc 是否解决真实部署问题。
+
+**失败条件。** 如果外部 hook 和 userspace validation 在真实 workload 上同时达到同样的开销和 policy precision，正确方向就是保持 io_uring BPF surface 足够小。
+
+## 目标应该是窄而明确的可编程边界，而不是无限扩张的内核插件
+
+当前 Linux 源码已经足以排除两个极端判断。
+
+第一个极端认为 io_uring 只需要 observability。这个判断已经过时，因为当前 kernel 同时存在 submission-time BPF decision path 和 eBPF execution-control interface。
+
+第二个极端则认为，既然已经有 eBPF struct_ops，就应该继续扩成能访问任意 io_uring internal 的通用 in-kernel runtime。当前实现反而说明边界控制很重要。cBPF filter 刻意只拿小型 predicate context，eBPF path 只暴露经过 BTF/verifier 检查的 callback state 和 selected kfunc，struct_ops 也限制可 attach 的 ring mode。
+
+如果目标是可维护的 subsystem interface，这些限制应该被当作 feature。
+
+更合理的设计目标是一个**窄而权限明确的 programmable boundary**：
+
+- admission 需要语义时，暴露稳定而有限的 semantic context；
+- 只有当 ring 内控制具有可测价值时，才增加小型 eBPF execution interface；
+- host security policy 始终保持最高权限；
+- lifecycle 和 provenance 能跨多层对象做 versioned tracking；
+- resource accounting 能衡量 verifier safety 之外的真实成本。
+
+`io_uring` 因此也成为一个更一般的 eBPF case study。当 BPF 从“观察某个 subsystem”走向“参与 subsystem control loop”，最重要的接口问题会从“哪里有 hook 可以 attach”转成“这个 attachment 到底授予了什么 capability，它又怎样和系统其他控制面组合”。
+
+## 什么证据会改变这个结论？
+
+本文的判断依赖一个前提：ring 内 decision 至少在 overhead、semantic context 或 execution control 中有一项明显优于放在 io_uring 外部的 policy。
+
+上面的 benchmark 完全可能证明这个前提不成立。如果静态 restriction、现有 LSM 和 userspace validation 已经覆盖绝大多数生产 policy，并且性能没有明显差距，那么 io_uring 应该把新的 BPF surface 保持得很窄。如果 eBPF struct_ops 只有暴露大量不稳定 ring internal 才能提供有用 control，那它更适合作为实验性 optimization hook，而不是稳定 runtime boundary。如果 cBPF filter 在极高 IOPS 下也出现明显 hot-path cost，正确方向可能是把更多 decision 前移到静态 capability，而不是把 filter 做得更复杂。
+
+反过来，如果 FUSE、zero-copy networking、ublk 和其他 ring-centric workload 反复需要外部 hook 无法低成本表达的 request semantic 与 execution control，那么 `io_uring` 就提供了一条很具体的 subsystem-native eBPF programmability 路径。那时下一步不该继续堆更多 hook，而应该把 capability、authority、update、provenance 和 resource cost 做成一套能长期依赖的契约。


### PR DESCRIPTION
## Summary

- publish exactly one new bilingual Daily Report on current Linux io_uring BPF programmability
- distinguish `IORING_REGISTER_BPF_FILTER` as a cBPF admission path from `io_uring_bpf_ops` as an eBPF `struct_ops` execution-control path
- analyze how static restrictions, LSM authority, cBPF admission, and eBPF execution policy should compose
- use FUSE-over-io-uring, zero-copy receive, and ublk as concrete pressure tests for the programmable I/O boundary
- refresh the August 14 data/state record without inventing a technical SEO change
- move the rolling archive from 4/6 to 5/7 eBPF-centered reports after merge

## Research

The report develops three testable directions:

1. a typed capability contract for programmable io_uring;
2. versioned ring policy generations with explicit authority ordering;
3. a benchmark comparing in-ring BPF control with userspace validation, static restrictions, LSM boundaries, and tracing-only hooks.

English: `/research/io-uring-bpf-programmability/`
Chinese: `/zh/research/io-uring-bpf-programmability/`

## Analytics / SEO state

- newest source-native Google evidence remains GSC rows through `2026-08-08` and finalized GA4 through `2026-08-09`; no newer weekly export beginning `2026-08-10` was found today
- GSC common six-day comparison remains 478 clicks / 69,053 impressions vs 409 / 46,327; CTR 0.692% vs 0.883%; average position ~9.42 vs ~8.18
- GA4 finalized weekly comparison remains 991 sessions at ~44.90% weighted engagement vs 1,021 at ~46.72%
- Cloudflare remains disabled by repository configuration
- the audit did not establish an evidence-backed crawl, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect, so no unrelated SEO implementation change is included

## Validation contract

Per `DAILY_TASK.md`, this PR must pass final repository CI, receive complete diff/generated-output self-review, squash merge, deploy the exact squash commit, verify both public language routes, and receive one merged-PR closeout comment. No second closeout PR.