### PR TITLE
Daily: define heterogeneous eBPF execution placement

### DIFF
--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -70,13 +70,15 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Active series — eBPF Runtime, Extensibility, and Composition
+## Completed series — eBPF Runtime, Extensibility, and Composition
 
 Working question: **What mechanisms are still missing if eBPF is treated as a
 programmable runtime substrate rather than only a kernel observability feature?**
 
-This series should connect kernel and userspace execution, composition, state,
-upgrade, safety, performance, and deployment boundaries.
+This series connected kernel and userspace execution, composition, state,
+upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
+execution placement. It reached the normal six-report series boundary on
+`2026-08-17`.
 
 ### Published progress
 
@@ -99,73 +101,40 @@ upgrade, safety, performance, and deployment boundaries.
    per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
    path, then developed a typed capability contract, versioned ring policy
    generations, explicit provenance, and a comparative control-boundary benchmark.
-6. Preferred next question: where eBPF execution should live across kernel,
-   userspace, NIC/DPU, GPU-adjacent, and device-side targets, and what state,
-   verifier, memory-visibility, coordination, and observability contracts are
-   required when execution crosses those boundaries.
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
+   backend compatibility from execution placement and developed a target manifest,
+   generation-scoped state ownership, and a ground-truth placement/provenance
+   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
 
-The series now has five substantial reports. The existing Daily Report hub already
-exposes the sequence, while report-level acquisition and navigation evidence is
-still too young to justify another public navigation surface. Revisit a dedicated
-series hub when evidence shows that it improves retrieval; do not create a thin
-hub solely because the series crossed a count threshold.
+The Daily Report index already exposes the sequence. Report-level acquisition and
+navigation evidence is still too young to justify a dedicated public series hub.
+Revisit that decision only when evidence shows a retrieval benefit.
 
-### Preferred sequence
-
-1. **What is still missing for first-class userspace eBPF?**
-   - Compare kernel eBPF, uprobes, DBI, language runtimes, and bpftime-style
-     execution.
-   - Focus on attach semantics, state, compatibility, safety, and which workloads
-     genuinely benefit from moving execution out of the kernel.
-
-2. **How should multiple independent eBPF extensions share one hook safely?**
-   - Study ordering, isolation, attribution, state sharing, resource accounting,
-     and conflicting policies.
-   - Compare dispatcher chains, tail calls, trampolines, vBPF-style approaches,
-     and explicit composition contracts.
-
-3. **Can a stateful eBPF application be upgraded transactionally?**
-   - Go beyond replacing one program pointer.
-   - Analyze coordinated changes to programs, links, maps, pinned state, userspace
-     controllers, and rollback after partial failure.
-
-4. **What would an asynchronous profiler built around modern eBPF look like?**
-   - Cover syscalls, async runtimes, io_uring, work queues, task handoff, causality,
-     sampling bias, and application-defined resources.
-   - Ask which causal edges can be reconstructed online with acceptable overhead.
-
-5. **Which new Linux I/O hooks make previously impractical eBPF mechanisms
-   possible?**
-   - Study recent io_uring and related programmable I/O interfaces, file access,
-     policy, caching, scheduling, and fast-path control.
-   - Prefer concrete mechanisms that could not be implemented cleanly with older
-     hook sets.
-
-6. **Where should eBPF execution live in heterogeneous systems?**
-   - Compare kernel, userspace, DPU/NIC, GPU-adjacent, and device-side execution.
-   - Investigate state placement, verifier assumptions, memory visibility,
-     cross-device coordination, and observability/control tradeoffs.
-
-These are research questions, not fixed titles. Final titles and claims must come
-from the day's evidence.
-
-## Queued series — eBPF Observability and Profiling
+## Active series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 
+The runtime/extensibility series is complete at six reports. The next scheduled
+run should start here and remain eBPF-centered. The preferred next question is
+**page-level memory attribution**: how to distinguish allocation from pages that
+were actually touched, faulted, reclaimed, migrated, or responsible for memory
+bandwidth, while preserving provenance across `mmap`, `brk`, allocator and
+runtime boundaries.
+
 Candidate topics:
 
-1. async and syscall causal profiling across thread and process handoff;
-2. page-level memory attribution: RSS, touched versus untouched allocation,
-   mmap/brk provenance, page faults, reclaim, and memory bandwidth;
-3. sampling theory for profilers: phase locking, randomized sampling, bias, and
+1. page-level memory attribution: RSS, touched versus untouched allocation,
+   `mmap`/`brk` provenance, page faults, reclaim, migration, and memory bandwidth;
+2. sampling theory for profilers: phase locking, randomized sampling, bias, and
    confidence intervals;
-4. always-on semantic compression that preserves diagnostic evidence instead of
+3. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
-5. application-defined resource profiling that combines static discovery,
+4. application-defined resource profiling that combines static discovery,
    runtime eBPF evidence, and online validation;
-6. causal profiling for GPU host-side bottlenecks and megakernel execution.
+5. causal profiling for GPU host-side bottlenecks and megakernel execution;
+6. revisit async and syscall causal profiling only when new mechanism or
+   evaluation evidence materially extends the published causal-profiler report.
 
 ## Queued series — eBPF Networking and Security
 

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -70,15 +70,17 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Completed series — eBPF Runtime, Extensibility, and Composition
+## Active series — eBPF Runtime, Extensibility, and Composition
 
 Working question: **What mechanisms are still missing if eBPF is treated as a
 programmable runtime substrate rather than only a kernel observability feature?**
 
-This series connected kernel and userspace execution, composition, state,
+This series connects kernel and userspace execution, composition, state,
 upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
-execution placement. It reached the normal six-report series boundary on
-`2026-08-17`.
+execution placement. The `2026-08-17` report reaches the normal six-report series
+boundary. The next scheduled run should promote eBPF Observability and Profiling
+to active before selecting its report rather than extending this sequence by
+default.
 
 ### Published progress
 
@@ -110,17 +112,16 @@ The Daily Report index already exposes the sequence. Report-level acquisition an
 navigation evidence is still too young to justify a dedicated public series hub.
 Revisit that decision only when evidence shows a retrieval benefit.
 
-## Active series — eBPF Observability and Profiling
+## Queued series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 
-The runtime/extensibility series is complete at six reports. The next scheduled
-run should start here and remain eBPF-centered. The preferred next question is
-**page-level memory attribution**: how to distinguish allocation from pages that
-were actually touched, faulted, reclaimed, migrated, or responsible for memory
-bandwidth, while preserving provenance across `mmap`, `brk`, allocator and
-runtime boundaries.
+This is the preferred next series after the runtime/extensibility sequence reaches
+six reports. Its preferred first question is **page-level memory attribution**:
+how to distinguish allocation from pages that were actually touched, faulted,
+reclaimed, migrated, or responsible for memory bandwidth while preserving
+provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
 Candidate topics:
 

--- a/.github/seo-data/daily/2026-08-17.md
+++ b/.github/seo-data/daily/2026-08-17.md
@@ -1,0 +1,152 @@
+# SEO operations — 2026-08-17
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md`: analyze every enabled evidence source, audit technical SEO/GEO behavior, calculate the rolling Daily Report mix before topic selection, research inside the active series, and publish exactly one new bilingual Daily Report through a fresh branch and one non-draft pull request.
+
+The selected report is the sixth and final normal-length entry in **eBPF Runtime, Extensibility, and Composition**: heterogeneous eBPF execution placement across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets. It is distinct from the earlier portable userspace-runtime-contract report. That earlier report asks whether one backend satisfies the program's execution contract; today's report asks which eligible backend should own execution and state when several targets satisfy the contract, and how placement can change without semantic drift.
+
+No unrelated technical SEO implementation change is included because today's evidence does not establish a new defect.
+
+## Data window
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | Drive export sets for `2026-07-27` to `2026-08-02` and `2026-08-03` to `2026-08-09`; newest date rows through `2026-08-08` | available historical evidence, stale relative to today |
+| Google Analytics 4 | organic landing-page exports for `2026-07-27` to `2026-08-02` and `2026-08-03` to `2026-08-09` | available historical evidence, finalized through `2026-08-09` |
+| Public GitHub | current repository state plus the public-safe portfolio snapshot refreshed `2026-08-17 08:05 UTC` | available |
+| Live / public technical surface | repository-generated checks for homepage, robots, sitemap, canonical and current site inventory | available |
+| Public web / primary research | RFC 9669, current Linux verifier and BPF offload source, hXDP, gpu_ext, fabric_ext, and current project/runtime evidence | available |
+| Cloudflare | disabled in repository configuration | not collected by design |
+
+The configured Drive folder was searched again on `2026-08-17`; no export beginning `2026-08-10` was present. Missing or delayed analytics are not treated as zero. With the repository's three-day finalization lag, the Google evidence is clearly stale rather than a fresh view of the last week.
+
+A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the available date history does not provide both adjacent complete windows. The required 28-day GSC comparison is also unavailable. GA4 has the two complete adjacent weekly exports below, but not enough verified history for the required 28-day comparison.
+
+## Evidence collected
+
+### Search and traffic evidence
+
+The valid equal-duration GSC comparison remains `2026-08-03` through `2026-08-08` against `2026-07-28` through `2026-08-02`:
+
+- newer slice: **478 clicks / 69,053 impressions**, weighted CTR about **0.692%**, impression-weighted average position about **9.42**;
+- older slice: **409 clicks / 46,327 impressions**, weighted CTR about **0.883%**, average position about **8.18**;
+- clicks are about **16.9% higher** and impressions about **49.1% higher**;
+- CTR is about **0.191 percentage points lower** and average position about **1.24 positions worse**.
+
+`2026-08-05` contributes **24,516 impressions**, about **35.5%** of the newer six-day slice. The available page and query files are weekly aggregates rather than date-by-page or date-by-query matrices, so that spike still cannot be attributed safely to one page, query, or report.
+
+The finalized GA4 organic landing-page comparison remains:
+
+- `2026-08-03` through `2026-08-09`: **991 sessions**, about **44.90%** session-weighted engagement;
+- `2026-07-27` through `2026-08-02`: **1,021 sessions**, about **46.72%** engagement;
+- sessions are about **2.9% lower** and engagement about **1.81 percentage points lower**;
+- `(not set)` fell from **157** to **116 sessions**; excluding it, sessions increased from **864** to **875**, about **1.3%**.
+
+These remain measurement and acquisition signals. They do not provide evidence for an unrelated content rewrite or technical SEO change.
+
+### Public-safe GitHub and technical-site evidence
+
+The repository's public-safe operating brief was refreshed at `2026-08-17 08:05 UTC`. It reports:
+
+- homepage HTTP 200 in **192 ms**;
+- `robots.txt` and sitemap reachable;
+- **664** sitemap entries;
+- canonical homepage `https://eunomia.dev/`;
+- **97** active non-fork repositories in the public GitHub portfolio snapshot;
+- **9,756** stars, **1,275** forks, and **278** open issue/PR records in that snapshot;
+- **59** DEV articles, **43** public reactions, and **4** comments.
+
+These are public operating context, not a blended SEO KPI. The technical evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect. The repository already generates and validates the relevant static artifacts. Today's site edits are therefore limited to the mandatory report and directly coupled bilingual index/navigation changes.
+
+### Previous-run closeout
+
+The August 16 daily delivery is fully complete as PR `#160`.
+
+- PR `#160` squash-merged as `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`.
+- Exact-commit `Validate SEO Operations` run `31958113036` completed successfully.
+- Exact-commit `Deploy Static App` run `31958113001` completed successfully.
+- The merged pull request has one conversation comment and no review comments, matching the repository's single-closeout-comment contract.
+
+These verified facts replace the stale PR `#155` closeout state that remained in `status.md` before this run.
+
+### Rolling Daily Report mix
+
+Before today's publication, the completed archive contains seven reports: **5 eBPF-centered / 2 pure Agent / 0 adjacent systems**.
+
+The selected heterogeneous-placement report is eBPF-centered because eBPF execution environments, state placement, verifier assumptions, and target-specific runtime semantics are its central mechanism. After merge, the archive becomes **6 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 8**. This remains within the eBPF-first editorial policy and does not consume additional pure-Agent budget.
+
+Today's report also completes the active Runtime, Extensibility, and Composition series at six substantial reports. `content-series.md` therefore advances **eBPF Observability and Profiling** to the active series for the next scheduled publication, with page-level memory attribution as the preferred first question.
+
+### Research selection and novelty check
+
+The broad candidate “offload eBPF to more devices” was rejected because target-specific offload is already well established and would produce only a feature survey.
+
+The narrower placement question passes the gap gate after comparing several primary mechanisms:
+
+- [RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html) standardizes BPF instruction conformance groups, but not event, helper, memory, state, or effect semantics.
+- Linux [verifier documentation](https://docs.kernel.org/bpf/verifier.html) makes context access and allowed function calls program-type-specific, showing that one ISA does not imply one execution environment.
+- Current Linux [`kernel/bpf/offload.c`](https://github.com/torvalds/linux/blob/master/kernel/bpf/offload.c) implements real hardware offload through device-bound networking semantics rather than a generic heterogeneous placement API.
+- [hXDP](https://www.usenix.org/conference/osdi20/presentation/brunella) demonstrates that reconstructing XDP's map/helper environment on an FPGA NIC can deliver target-specific latency and throughput advantages.
+- [gpu_ext](https://arxiv.org/abs/2512.12615) demonstrates that some GPU policy events require device-side execution rather than host-only observation.
+- [fabric_ext](https://arxiv.org/abs/2607.26335) is the strongest neighboring design: it already lowers one semantic movement policy across GPU, runtime/driver, DPU/NIC and CXL-side targets. Today's report explicitly treats it as adjacent prior work rather than claiming cross-device eBPF compilation is absent.
+
+The remaining gap is **generic execution ownership among multiple semantically eligible targets**: how to express event/state/memory/authority requirements, reject invalid placements, choose among valid ones, and preserve state/effect semantics if placement changes.
+
+The report develops three testable directions:
+
+1. a machine-readable target manifest and placement planner that filters semantic-invalid targets before optimizing crossing cost and latency;
+2. generation-scoped state ownership and migration rather than pretending maps are globally coherent across host and device memory domains;
+3. a ground-truth placement/provenance benchmark that runs the same logical policy in multiple locations and tests when static placement, split placement, or later dynamic migration is actually justified.
+
+The report deliberately recommends static or slowly changing placement first. Transparent dynamic migration is a follow-on only if phase-changing benchmarks show benefits larger than state-transfer and transition cost.
+
+### Skill freshness
+
+The repository remains pinned to SEO skill commit `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `AutoArchive/seo-skill` is now at `f42128a3f05c73cf10c786a2711c488bb3a14839` and has added a newer operating layout including off-site visibility collection. The consuming repository still names interfaces from the pinned layout, so a pointer-only submodule update is not mixed into this daily content delivery.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in this delivery:
+
+- English: `/research/heterogeneous-ebpf-execution-placement/`
+- Chinese: `/zh/research/heterogeneous-ebpf-execution-placement/`
+
+Both Daily Report indexes are updated with the new report and equivalent language-specific summaries. `content-series.md` records the sixth runtime-series report, closes that normal six-report sequence, and promotes eBPF Observability and Profiling as the next active series. `plan.md` records the new durable priority. `status.md` is refreshed with the actual PR #160 closeout, today's technical brief, stale analytics coverage, current branch, and current editorial mix.
+
+No unrelated technical SEO implementation change is made.
+
+## Validation and self-review contract
+
+- No raw analytics rows, private queries, Drive IDs, account/property identifiers, credentials, private URLs, or personal information are added to Git.
+- Missing Google history and stale export cadence are explicit; unavailable data is not treated as zero.
+- The English meta description is 155 characters and stays within the repository SEO target.
+- The Chinese description is written independently for the same thesis and kept compact for search snippets.
+- Public research claims link to primary sources or project artifacts.
+- The report credits fabric_ext as strong adjacent work and states a falsifier: if its movement-graph abstraction generalizes cleanly to the broader event-policy problem, a separate placement abstraction is unnecessary.
+- The report distinguishes backend compatibility from target selection, so it does not duplicate `/research/userspace-ebpf-runtime-contract/`.
+- English and Chinese pages share evidence and conclusions while using language-specific prose.
+- The intended change is limited to one bilingual report, its two indexes, and directly coupled operating/series state.
+
+Repository CI remains authoritative for Daily Report checks, SEO-data validation, generated content, static build, links, metadata, and deployment readiness. After CI is green, the complete diff and generated output must receive a clean final self-review before squash merge. The exact squash commit must then pass production `Deploy Static App`, both public language routes must be verified, and exactly one compact closeout comment must be added to the merged PR.
+
+## Delivery
+
+- Branch: `daily/2026-08-17-heterogeneous-ebpf-placement`
+- Pull request: to be opened as one non-draft daily PR
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after expected CI succeeds and the final diff/generated output passes self-review
+- Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, deployment, bilingual verification, source coverage, series classification, and remaining uncertainty; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Complete and verify today's heterogeneous eBPF placement report through the exact merge/deployment/public-page contract.
+2. Start the next Daily Report inside **eBPF Observability and Profiling**, with page-level memory attribution as the preferred first question unless primary evidence rejects it.
+3. Keep future reports eBPF-centered or directly adjacent while the two existing pure-Agent reports occupy the current Agent budget.
+4. Keep the required GSC 7-day and 28-day comparisons unavailable until source coverage supports them.
+5. Obtain date-by-page or date-by-query GSC evidence before attributing the `2026-08-05` impression spike.
+6. Investigate GA4 `(not set)` only with richer source-native dimensions.
+7. Migrate the consuming SEO contract before advancing the pinned SEO-skill submodule.
+8. Add Cloudflare evidence only when repository configuration enables a supported read-only source.

--- a/.github/seo-data/daily/2026-08-17.md
+++ b/.github/seo-data/daily/2026-08-17.md
@@ -78,7 +78,7 @@ Before today's publication, the completed archive contains seven reports: **5 eB
 
 The selected heterogeneous-placement report is eBPF-centered because eBPF execution environments, state placement, verifier assumptions, and target-specific runtime semantics are its central mechanism. After merge, the archive becomes **6 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 8**. This remains within the eBPF-first editorial policy and does not consume additional pure-Agent budget.
 
-Today's report also completes the active Runtime, Extensibility, and Composition series at six substantial reports. `content-series.md` therefore advances **eBPF Observability and Profiling** to the active series for the next scheduled publication, with page-level memory attribution as the preferred first question.
+Today's report brings the Runtime, Extensibility, and Composition series to its normal six-report boundary. `content-series.md` records that boundary while retaining the current active-series heading required by the repository validator; the next scheduled run should promote **eBPF Observability and Profiling** before selecting its report, with page-level memory attribution as the preferred first question.
 
 ### Research selection and novelty check
 
@@ -114,7 +114,7 @@ Exactly one new bilingual Daily Report is included in this delivery:
 - English: `/research/heterogeneous-ebpf-execution-placement/`
 - Chinese: `/zh/research/heterogeneous-ebpf-execution-placement/`
 
-Both Daily Report indexes are updated with the new report and equivalent language-specific summaries. `content-series.md` records the sixth runtime-series report, closes that normal six-report sequence, and promotes eBPF Observability and Profiling as the next active series. `plan.md` records the new durable priority. `status.md` is refreshed with the actual PR #160 closeout, today's technical brief, stale analytics coverage, current branch, and current editorial mix.
+Both Daily Report indexes are updated with the new report and equivalent language-specific summaries. `content-series.md` records the sixth runtime-series report and identifies eBPF Observability and Profiling as the next series to promote. `plan.md` records the same durable next priority. `status.md` is refreshed with the actual PR #160 closeout, today's technical brief, stale analytics coverage, current branch, and current editorial mix.
 
 No unrelated technical SEO implementation change is made.
 
@@ -130,12 +130,14 @@ No unrelated technical SEO implementation change is made.
 - English and Chinese pages share evidence and conclusions while using language-specific prose.
 - The intended change is limited to one bilingual report, its two indexes, and directly coupled operating/series state.
 
-Repository CI remains authoritative for Daily Report checks, SEO-data validation, generated content, static build, links, metadata, and deployment readiness. After CI is green, the complete diff and generated output must receive a clean final self-review before squash merge. The exact squash commit must then pass production `Deploy Static App`, both public language routes must be verified, and exactly one compact closeout comment must be added to the merged PR.
+Repository CI remains authoritative for Daily Report checks, SEO-data validation, generated content, static build, links, metadata, and deployment readiness. The first PR validation run exposed the validator's explicit active-series contract after `content-series.md` prematurely changed that heading. The same branch was corrected to keep the validated current heading while recording the six-report boundary and next-series transition. Final CI after that correction remains the authoritative result.
+
+After CI is green, the complete diff and generated output must receive a clean final self-review before squash merge. The exact squash commit must then pass production `Deploy Static App`, both public language routes must be verified, and exactly one compact closeout comment must be added to the merged PR.
 
 ## Delivery
 
 - Branch: `daily/2026-08-17-heterogeneous-ebpf-placement`
-- Pull request: to be opened as one non-draft daily PR
+- Pull request: `#161`, non-draft
 - Production target: GitHub Pages through `Deploy Static App`
 - Merge policy: squash merge only after expected CI succeeds and the final diff/generated output passes self-review
 - Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, deployment, bilingual verification, source coverage, series classification, and remaining uncertainty; no second closeout PR
@@ -143,7 +145,7 @@ Repository CI remains authoritative for Daily Report checks, SEO-data validation
 ## Decisions and follow-ups
 
 1. Complete and verify today's heterogeneous eBPF placement report through the exact merge/deployment/public-page contract.
-2. Start the next Daily Report inside **eBPF Observability and Profiling**, with page-level memory attribution as the preferred first question unless primary evidence rejects it.
+2. On the next scheduled run, promote **eBPF Observability and Profiling** to active before topic selection, with page-level memory attribution as the preferred first question unless primary evidence rejects it.
 3. Keep future reports eBPF-centered or directly adjacent while the two existing pure-Agent reports occupy the current Agent budget.
 4. Keep the required GSC 7-day and 28-day comparisons unavailable until source coverage supports them.
 5. Obtain date-by-page or date-by-query GSC evidence before attributing the `2026-08-05` impression spike.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,15 +71,17 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Continue the **eBPF Runtime, Extensibility, and Composition** series. After the
-   io_uring programmability report, prefer the remaining mechanism question:
-   where eBPF execution should live across kernel, userspace, NIC/DPU,
-   GPU-adjacent, and device-side targets, including state placement, verifier
-   assumptions, memory visibility, coordination, and observability/control tradeoffs.
+1. Start the **eBPF Observability and Profiling** series after completing the
+   six-report Runtime, Extensibility, and Composition sequence. Prefer the next
+   mechanism question on page-level memory attribution: distinguish reserved or
+   allocated memory from pages actually touched, faulted, reclaimed, migrated, or
+   responsible for bandwidth, while preserving `mmap`/`brk`, allocator, runtime,
+   and process provenance.
 2. Keep pure-Agent reports capped while the archive is small. After the current
-   report the rolling archive is 5 eBPF-centered / 2 pure Agent / 0 adjacent out
-   of 7, so upcoming work should continue to favor eBPF or directly adjacent
-   systems rather than add another pure-Agent report.
+   heterogeneous-placement report merges, the rolling archive becomes 6
+   eBPF-centered / 2 pure Agent / 0 adjacent out of 8, so the next report should
+   remain eBPF-centered or directly adjacent rather than add another pure-Agent
+   report.
 3. Use both verified weekly Search Console and GA4 Drive export sets in every run.
    Keep accumulating history until a complete previous-7-day and 28-day comparison
    can be made without inventing missing dates.
@@ -91,9 +93,10 @@ priorities that can guide a later daily run belong below.
 7. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside the approved eBPF and adjacent
    systems series.
-8. Revisit a dedicated public hub for the active eBPF series only after report-level
-   acquisition or navigation evidence shows that it would improve retrieval beyond
-   the existing Daily Report index.
+8. Revisit a dedicated public hub for the completed eBPF runtime series only after
+   report-level acquisition or navigation evidence shows that it would improve
+   retrieval beyond the existing Daily Report index.
 9. Migrate the consuming SEO contract before moving the pinned `seo-skills`
    submodule to a newer upstream layout that removed interfaces this repository
-   still calls.
+   still calls. Upstream movement alone is not evidence that a pointer-only bump
+   is safe.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,69 +7,70 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-12`
+- Last completed daily run: `2026-08-16`
 - Last verified data window: Search Console rows through `2026-08-08`; finalized GA4 weekly export through `2026-08-09`
-- Latest daily record: `2026-08-16`
-- Last completed public-change pull request: `#155`
-- Last verified production deployment from a daily run: `Deploy Static App` run `31837125244` for squash commit `66f5a9e83939d228f3ba8c325c83fc1804f5334b`
-- Current daily branch: `daily/2026-08-16-io-uring-bpf-programmability`
-- Superseded incomplete pull requests: `#158` and `#159`, both closed without merge
+- Latest daily record: `2026-08-17`
+- Last completed public-change pull request: `#160`
+- Last verified production deployment from a daily run: `Deploy Static App` run `31958113001` for squash commit `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`
+- Current daily branch: `daily/2026-08-17-heterogeneous-ebpf-placement`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#155` is fully closed out. It squash-merged as `66f5a9e83939d228f3ba8c325c83fc1804f5334b`; the exact commit passed `Validate SEO Operations` run `31837125489` and `Deploy Static App` run `31837125244`. The exact Pages artifact contains both language variants of the async causal-profiling report with the expected gap, directions, conclusion-boundary sections, canonical URLs, reciprocal language alternates plus `x-default`, and Article JSON-LD.
+PR `#160` is fully closed out. It squash-merged as `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`; the exact commit passed `Validate SEO Operations` run `31958113036` and `Deploy Static App` run `31958113001`. The merged pull request has one conversation comment and no review comments, consistent with the repository's one-closeout-comment contract.
 
-The io_uring report was researched on the superseded August 14/15 attempts, but neither PR `#158` nor `#159` merged. They therefore do not count as completed Daily Report publications. The still-valid report is replayed from current `main` in the August 16 run without reverting unrelated work that landed after those branches were created.
+The published io_uring report moved the archive to seven reports and completed the fifth eBPF-centered entry. The current August 17 branch begins from the latest default branch after that closeout and adds the sixth, final report in the Runtime, Extensibility, and Composition series.
 
 ## Current Daily Report mix
 
-The completed archive before the current change contains six reports:
+Before the current change, the completed archive contains seven reports:
 
-- eBPF-centered: **4 of 6**
+- eBPF-centered: **5 of 7**
+  - `/research/io-uring-bpf-programmability/`
   - `/research/async-ebpf-causal-profiler/`
   - `/research/stateful-ebpf-transactional-upgrade/`
   - `/research/ebpf-hook-composition-contract/`
   - `/research/userspace-ebpf-runtime-contract/`
-- pure Agent-centered: **2 of 6**
+- pure Agent-centered: **2 of 7**
   - `/research/agent-trace-evidence-budget/`
   - `/research/parallel-agent-effect-serializability/`
-- adjacent systems: **0 of 6**
+- adjacent systems: **0 of 7**
 
-The current io_uring report is eBPF-centered. After it merges, the archive becomes **5 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 7**. The two pure-Agent reports already consume the intended Agent budget, so continue to favor eBPF and adjacent systems. The active series remains **eBPF Runtime, Extensibility, and Composition**.
+The current heterogeneous-placement report is eBPF-centered. After it merges, the archive becomes **6 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 8**. This stays within the editorial policy. It also brings the Runtime, Extensibility, and Composition series to its normal six-report boundary, so the repository roadmap advances the next run to **eBPF Observability and Profiling** rather than extending the current series indefinitely.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-16 07:51 UTC`
-- Homepage: reachable with HTTP 200 in the current operating brief
+- Repository-generated public-safe operating brief: refreshed `2026-08-17 08:05 UTC`
+- Homepage: HTTP 200 in the current operating brief, observed in **192 ms**
 - `robots.txt`: reachable; sitemap: reachable
-- Sitemap entries observed: **660**
+- Sitemap entries observed: **664**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories and 9,752 stars across the portfolio snapshot
+- Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories, 9,756 stars, 1,275 forks, and 278 open issue/PR records across the portfolio snapshot
+- DEV publication surface: 59 articles, 43 public reactions, and 4 comments in the current public-safe brief
 - Public web and primary-source evidence: available
 - Google Analytics 4: two adjacent weekly Drive organic landing-page exports available and finalized through `2026-08-09`
 - Google Search Console: two adjacent weekly export sets available; current date rows still end on `2026-08-08`
-- Newer weekly Google export beginning `2026-08-10`: not found on `2026-08-16`
+- Newer weekly Google export beginning `2026-08-10`: not found in the configured Drive folder on `2026-08-17`
 - Cloudflare: disabled by repository configuration
 
-The Google exports are usable historical evidence but stale relative to today. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the source does not provide both complete adjacent windows; the required 28-day comparison is also unavailable rather than inferred.
+The Google exports remain usable historical evidence but are stale relative to today. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the source does not provide both complete adjacent windows; the required 28-day comparison is also unavailable rather than inferred.
 
 The valid common-duration GSC comparison remains **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. Clicks are about **16.9% higher** and impressions about **49.1% higher**. Weighted CTR moved from about **0.883%** to **0.692%**, and impression-weighted average position from about **8.18** to **9.42**. `2026-08-05` contributes **24,516 impressions**, about **35.5%** of the newer slice, and still cannot be attributed to one page or query without date-by-page or date-by-query evidence.
 
-The finalized GA4 comparison remains **991 sessions** at about **44.90%** session-weighted engagement for `2026-08-03` through `2026-08-09`, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. `(not set)` fell from 157 to 116 sessions; excluding it, sessions increased slightly from 864 to 875. These are directional measurement signals, not evidence for an unrelated content or SEO rewrite.
+The finalized GA4 comparison remains **991 sessions** at about **44.90%** session-weighted engagement for `2026-08-03` through `2026-08-09`, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. `(not set)` fell from 157 to 116 sessions; excluding it, sessions increased slightly from 864 to 875. These remain directional measurement signals, not evidence for an unrelated content or SEO rewrite.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through `Deploy Static App`.
 
-The `2026-08-16` evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect. The correct site change for this run is the mandatory new Daily Report rather than an unrelated SEO patch.
+The August 17 operating evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect. The current homepage, robots, sitemap, and canonical checks are healthy in the public-safe operating brief. The correct public site change for this run is therefore the mandatory new Daily Report and its directly coupled bilingual index/navigation entries, not an unrelated technical SEO patch.
 
-The io_uring research remains current after revalidation against Linux primary source on August 16: `IORING_REGISTER_BPF_FILTER` is a per-opcode classic-BPF admission mechanism, while `io_uring_bpf_ops` is an eBPF `struct_ops` execution-control interface with io_uring-specific kfuncs and bounded ring-region access. Static restrictions and LSM authority remain separate control layers. The report develops a typed capability contract, versioned ring policy generations, explicit provenance/resource accounting, and a comparative control-boundary benchmark.
+Today's research separates backend compatibility from execution placement. RFC 9669 provides ISA conformance groups, Linux verifier and hardware-offload code show that context/helper/offload semantics remain target-specific, and primary systems work such as hXDP, gpu_ext, and fabric_ext demonstrates both the value and the specialization cost of moving BPF execution toward NIC, GPU, and fabric-side events. The report therefore develops a placement-aware target manifest, generation-scoped state ownership and migration, and a ground-truth placement/provenance benchmark rather than duplicating the earlier portable-runtime-contract thesis.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream remains at `f42128a3f05c73cf10c786a2711c488bb3a14839`; the consuming repository still names interfaces from the pinned layout, so a pointer-only upgrade is not made.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream is now at `f42128a3f05c73cf10c786a2711c488bb3a14839` and includes a newer operating layout plus off-site visibility collection. This repository still names interfaces from the pinned layout, so an unrelated pointer-only submodule bump is not made in the current daily PR.
 
 ## Current focus
 
-1. Complete the `2026-08-16` io_uring BPF programmability Daily Report through final CI, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
-2. Continue the active series with the next question: where eBPF execution should live across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets, including state placement, verifier assumptions, memory visibility, coordination, and observability/control tradeoffs.
+1. Complete the `2026-08-17` heterogeneous eBPF execution-placement Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
+2. Start the next run inside the active **eBPF Observability and Profiling** series, with page-level memory attribution as the preferred first question unless evidence rejects it.
 3. Keep required GSC 7-day and 28-day comparisons unavailable until complete source history exists; never treat missing exports as zero.
 4. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.
 5. Investigate GA4 `(not set)` only with richer source-native dimensions before making a measurement or content change.

--- a/docs/research/heterogeneous-ebpf-execution-placement.md
+++ b/docs/research/heterogeneous-ebpf-execution-placement.md
@@ -1,0 +1,258 @@
+---
+date: 2026-08-17
+title: "Where Should eBPF Run in a Heterogeneous System?"
+description: "eBPF can now run in kernels, userspace, SmartNICs, and GPUs. The missing problem is choosing placement without changing state, safety, or effect semantics."
+tags:
+  - Daily Report
+  - eBPF
+  - Heterogeneous Systems
+  - SmartNIC
+  - GPU
+  - Runtime Systems
+  - Offload
+research_question: "What mechanism should choose whether an eBPF policy runs in the kernel, userspace, NIC/DPU, GPU-adjacent, or device-side runtime when several targets are possible, and how can state, authority, verifier assumptions, memory visibility, and observability remain correct if placement changes?"
+source_cutoff: 2026-08-17
+status: daily-report
+---
+
+# Where Should eBPF Run in a Heterogeneous System?
+
+Suppose one service receives packets on a SmartNIC, parses requests in userspace, moves tensors to a GPU, and keeps part of its working set behind a CXL fabric. An operator wants one policy to reject malformed traffic, account for expensive memory movement, and react when a GPU-side queue becomes congested.
+
+There are now several plausible places to execute BPF logic. A packet policy can run in the Linux kernel or on a programmable NIC. A hot application hook can run in a userspace runtime such as [bpftime](https://github.com/eunomia-bpf/bpftime). GPU policy can run at host-side driver hooks or inside a device-side runtime such as the one explored by [gpu_ext](https://arxiv.org/abs/2512.12615). Recent work such as [fabric_ext](https://arxiv.org/abs/2607.26335) goes further and lowers one policy across GPU, driver/runtime, DPU/NIC, and CXL-side targets.
+
+The obvious rule is to put computation close to the event. That rule is incomplete.
+
+A policy may observe a packet most cheaply on the NIC but depend on state owned by the host. A GPU-side policy may avoid a host round trip but lose access to helpers, maps, or authority that exist only in the kernel. Moving one program can also move the meaning of a pointer, the visibility of a map update, the timing of a side effect, and the evidence available after a failure.
+
+<!-- more -->
+
+This report argues that **heterogeneous eBPF needs an execution-placement layer distinct from both the BPF ISA and a single-backend runtime contract**. The first question is whether a target can execute a program with the semantics it requires. The next question is where an eligible program should execute, which target should own its state and effects, and how a placement change can happen without silently changing behavior.
+
+The safest first design is not transparent runtime migration. It is a static or slowly changing planner that makes placement constraints explicit, chooses among valid targets, and records why. Dynamic migration should be added only if measurements show that workload phases make static placement materially suboptimal.
+
+This is the sixth report in the current [eBPF Runtime, Extensibility, and Composition series](https://eunomia.dev/research/). The first report in the series asked what a [portable userspace eBPF runtime contract](https://eunomia.dev/research/userspace-ebpf-runtime-contract/) must expose. This report starts one layer above that contract: if several backends satisfy it, which backend should own execution now?
+
+## Portable instructions do not imply portable execution environments
+
+The BPF instruction set is becoming more portable than the environment around it. [RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html) defines the BPF ISA and named conformance groups. A runtime must support the base group and can advertise additional groups, which gives compilers and runtimes a way to discover instruction capabilities.
+
+That is useful, but an instruction group does not say which events a target can observe, which context fields a program may read, which helpers it may call, which memory it can reach, or which effects it may cause.
+
+Linux itself demonstrates this separation. The [eBPF verifier documentation](https://docs.kernel.org/bpf/verifier.html) describes program-type-specific context access through `is_valid_access()` and program-type-specific function availability through `get_func_proto()`. A socket program and a tracing program can execute the same ISA while receiving different context and helper surfaces. The host environment is part of the semantics.
+
+Hardware offload narrows the point further. Current Linux [`kernel/bpf/offload.c`](https://github.com/torvalds/linux/blob/master/kernel/bpf/offload.c) binds hardware-offloaded programs and maps to registered network devices and device operations. The device-bound program initialization path accepts `SCHED_CLS` and `XDP` program types, not an arbitrary BPF program plus a generic heterogeneous target. Linux therefore has real offload machinery, but it is intentionally tied to a specific subsystem and attachment model.
+
+A generic placement layer cannot begin with "this device speaks eBPF." It needs a richer answer:
+
+| Question | ISA conformance can answer it? | Placement needs it? |
+| --- | --- | --- |
+| Can this target execute the required instructions? | yes | yes |
+| Can it observe the required event and context? | no | yes |
+| Can it call the required helpers or kfunc-like operations? | no | yes |
+| Where does the policy state live? | no | yes |
+| Which memory domains are directly visible? | no | yes |
+| Can the program deny, mutate, schedule, or only observe? | no | yes |
+| Who authorizes the effect? | no | yes |
+| How much crossing cost does the placement introduce? | no | yes |
+
+The previous runtime-contract report proposed making backend capabilities testable. Placement adds an optimization and ownership problem over those capabilities. A target can be compatible and still be the wrong place to run a particular policy.
+
+## Existing systems already show why target choice matters
+
+The case for heterogeneous placement is not hypothetical. Different systems have already made different placement choices because event locality changes what is practical.
+
+### hXDP moves XDP execution onto an FPGA NIC
+
+[hXDP](https://www.usenix.org/conference/osdi20/presentation/brunella) showed that real XDP programs could execute on an FPGA NIC rather than on the host CPU. Its design used an optimizing compiler, an extended BPF ISA, a soft processor, and FPGA support for XDP maps and helpers. In its OSDI 2020 evaluation, the prototype used about 15% of FPGA resources, matched the packet-processing throughput of a high-end CPU core, and reported 10x lower packet-forwarding latency.
+
+The result is not evidence that every BPF program belongs on a NIC. It shows the benefit of specialization when the event, state path, and required execution environment can be reproduced near the packet stream. hXDP had to build that environment explicitly. The target was valuable because the policy and event source were a good fit.
+
+### Userspace execution removes a different boundary
+
+A userspace runtime solves another locality problem. [bpftime](https://github.com/eunomia-bpf/bpftime) can execute BPF programs around userspace functions and other application-local events without routing every event through a kernel probe path. Its attach, map, helper, verifier, and compatibility machinery makes it more than an instruction interpreter.
+
+That placement has access to application-local control points that a NIC does not have, but it also changes what the program can safely assume. Kernel-only helpers and kernel object access do not automatically exist in a userspace backend. A lower event cost does not make the host process a semantic substitute for the kernel.
+
+### gpu_ext places policy inside the GPU boundary
+
+[gpu_ext](https://arxiv.org/abs/2512.12615) starts from a failure of host-only placement. Its paper argues that host-side eBPF cannot observe several device-side events that matter for GPU memory placement, scheduling, and observability. The design exposes GPU-driver hooks and adds a device-side eBPF runtime so verified policy code can execute in GPU kernels. The paper reports throughput improvements of up to 4.8x and tail-latency reductions of up to 2x on its evaluated workloads.
+
+The important systems point is not the maximum speedup. It is that the placement changes the available event boundary. A host program can be perfectly safe and still arrive too late or observe too little to implement the intended policy.
+
+Together, these systems make a simple rule impossible. Kernel, userspace, NIC, and GPU execution are not interchangeable implementations of one abstract machine. Each target creates a different combination of event locality, memory visibility, verifier assumptions, state cost, and effect authority.
+
+## "Run near the data" is only half of the objective
+
+Moving a program closer to its event can reduce crossings, but the event is only one input to a policy decision. A useful placement model has at least five forms of locality.
+
+**Event locality** asks where the trigger first becomes visible. Packet arrival favors the NIC or network stack. GPU allocation and queue events may favor the driver or device. A userspace function call favors the process itself.
+
+**State locality** asks where the maps, tables, counters, sketches, or learned policy state already live. A per-queue counter can be device-local. A tenant policy table shared by networking, storage, and GPU work may need a host authority or an explicit replica protocol.
+
+**Memory locality** asks which address spaces and memory domains are directly readable. Host virtual addresses, device global memory, NIC SRAM, and CXL-attached memory do not have one uniform coherence model. A pointer that is valid for one target can be meaningless for another.
+
+**Effect locality** asks where a decision can actually be enforced. Observing a packet on the host is less useful if the intended effect must happen before DMA. Observing a GPU queue from userspace is less useful if the policy needs to affect device scheduling at a finer boundary.
+
+**Authority locality** asks which target is allowed to make that effect. A device-local policy should not quietly grant an operation that host security would deny. Conversely, a host controller that delegates a bounded scheduling choice should not have to handle every fast-path event synchronously.
+
+These localities can point in different directions. Consider a tenant-aware GPU service with a shared quota table on the host. Queue events are device-local, but the quota policy is host-owned. Three placements are plausible:
+
+1. keep the entire decision on the host and pay for event crossings;
+2. copy the quota table to the device and accept a consistency protocol;
+3. split the policy so the device enforces a locally valid budget while the host periodically changes the budget generation.
+
+The third option is often more realistic than pretending that one target should own everything. A placement layer therefore needs to choose both **where code runs** and **where authoritative state remains**.
+
+## The strongest adjacent design already spans several devices
+
+A serious placement proposal has to account for [fabric_ext](https://arxiv.org/abs/2607.26335), not claim that cross-device eBPF compilation is unexplored.
+
+fabric_ext targets GPU-CXL fabrics. Its central abstraction is a semantic movement graph that describes data movement using properties such as source and destination, bytes, stride, reuse, ordering, ownership, and transformations. The compiler lowers the graph into per-device eBPF programs, verifier obligations, consistency-classed BPF maps, and backend artifacts. It can place pieces of one policy at GPU hooks, driver/runtime hooks, DPU/NIC hooks, CXL switches, or near-memory targets.
+
+That design is strong evidence that one source policy can be decomposed across heterogeneous execution sites while keeping state and verification in the compiler model. It also narrows the remaining gap.
+
+The question in this report is broader in one dimension and deliberately less ambitious in another. It asks about **placement of arbitrary event-driven BPF policy across eligible targets**, not only data-movement transformations in a GPU-CXL fabric. At the same time, it does not assume that the system can automatically split any program. A first implementation can require explicit policy boundaries and choose among whole-program or developer-declared components.
+
+The useful comparison is therefore:
+
+- fabric_ext asks how a semantic data-movement graph should be lowered across a known fabric topology;
+- this report asks what target contract, objective function, state ownership rule, and evidence are needed to choose execution placement for BPF policies whose events may come from networking, application code, GPU runtime, driver, or device.
+
+If the fabric_ext abstraction turns out to generalize cleanly to those event classes, then a separate placement abstraction is unnecessary. That is a good falsifier, not a problem to hide.
+
+## Placement changes can become semantic changes
+
+The difficult part begins when a policy moves after deployment.
+
+Imagine a program that increments a map counter and denies an operation after a threshold. On the host, the map update may be immediately visible to other host programs. On a NIC or GPU, the same logical map could be local, mirrored, cached, or accessed through a host round trip. Moving the program without specifying the map's ownership can change when the threshold becomes visible.
+
+The same problem appears with time and ordering. A host-side event may be observed after a device has already accepted work. A device-side policy may act before host tracing records enough context to explain the decision. An asynchronous queue can reorder observations even when each target is internally correct.
+
+This is why transparent migration is a dangerous first goal. A system should not advertise "move BPF anywhere" until it can define what must remain invariant.
+
+A practical invariant set is smaller:
+
+- each policy generation names the target that owns execution;
+- each state object names its authoritative owner and permitted replicas;
+- each target proves the required context, helper, memory, and effect capabilities before activation;
+- a placement transition has a generation boundary, so old and new state are not mixed accidentally;
+- observability records the placement and generation that produced each externally relevant decision.
+
+This connects directly to the earlier report on [transactional eBPF upgrades](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/). Placement migration is an upgrade where the new generation also changes execution domain. The transition therefore needs at least as much care as replacing programs and maps on one host.
+
+## Where current work is still weak
+
+### There is no general placement objective for BPF policy
+
+Existing systems tend to choose a target first and optimize inside that target. Linux hardware offload starts from XDP or classifier semantics on a network device. hXDP starts from FPGA NIC execution. gpu_ext starts from GPU policy. fabric_ext starts from a GPU-CXL movement graph.
+
+What is missing is a common way to express that a policy has several valid homes and to compare them using the same constraints. "Closest to the data" does not capture shared-state traffic, authority boundaries, verifier differences, or the cost of losing observability.
+
+A useful objective would not collapse everything into one weighted score. It should first reject semantically invalid placements, then compare valid placements on a small Pareto set such as event crossing cost, state crossing cost, latency, throughput, host load, and evidence completeness.
+
+### Cross-target state has no common failure model
+
+BPF maps are a familiar programming model, but a map on a GPU, NIC, userspace process, and Linux kernel does not automatically mean one coherent object. Replicating every update can destroy the performance gain that motivated offload. Keeping all state local can make a split policy incorrect.
+
+The missing contract is state-specific rather than runtime-wide: which target is authoritative, which replicas may be stale, which updates commute, when a generation fence is required, and what happens when a device disappears during migration.
+
+This is an area where the right answer may be deliberately limited. Many useful policies could be built from target-local counters plus a small host-authoritative configuration table. If that covers most real workloads, a general distributed-map system would be unnecessary complexity.
+
+### Current evaluations rarely answer the placement question directly
+
+An accelerator paper usually compares its chosen target with a host baseline. That establishes whether the accelerator is useful for its intended workload. It does not establish whether a different target would have been better, or which workload property predicts the winner.
+
+A placement mechanism needs a benchmark in which the **same logical policy and expected effects** can run in more than one location. Without that, a planner can optimize its own cost model without evidence that it chooses the right system design.
+
+### Observability becomes part of the placement contract
+
+Offloading policy also offloads part of the explanation. If a device makes a deny, scheduling, memory-placement, or transformation decision, an operator needs enough evidence to identify the policy version, target, input class, and resulting effect.
+
+Shipping every event back to the host defeats fast-path placement. Keeping only local device logs makes cross-target incidents hard to reconstruct. The placement problem therefore needs an evidence budget, not only an execution budget.
+
+## Promising directions with academic and production value
+
+### 1. A target manifest and placement planner
+
+**Gap.** A runtime can report that it supports BPF, while leaving the planner to infer event support, helper availability, memory domains, authority, and crossing costs from documentation.
+
+**Mechanism.** Give each target a machine-readable manifest. It advertises instruction conformance groups, supported event and attach classes, context versions, helper or kfunc-like capabilities, map/state classes, readable memory domains, permitted effects, authority constraints, and a measured cost model for event and state crossings. A policy separately declares required events, state, effects, and latency bounds. The planner first filters for semantic validity, then chooses among valid placements using measured costs.
+
+The first version should place whole programs or explicitly declared components. Automatic arbitrary program partitioning is a later problem.
+
+**Delta.** The earlier userspace-runtime contract answers whether one backend can satisfy required semantics. This planner compares several satisfying backends. Unlike fabric_ext's movement graph, the target manifest is intended to cover event-driven policy outside one fabric domain.
+
+**Artifact.** A schema plus adapters for Linux kernel BPF, bpftime-style userspace execution, one NIC/FPGA target, and one GPU-side target; a small constraint solver; and a tool that explains why placements were rejected or selected.
+
+**Evaluation.** Run policy workloads that have at least two legitimate placements: packet filtering/accounting, a hot userspace service hook, GPU memory or scheduling control, and one cross-device policy. Compare manual expert placement, always-host, always-near-event, and planner output. Measure semantic-invalid placements rejected, event and state boundary crossings, p50/p99 decision latency, throughput, host CPU cost, device utilization, and planner overhead. Compare with fabric_ext where a workload fits its movement-graph model.
+
+**Academic value.** The experiment tests whether a compact target contract can predict the Pareto frontier across execution domains instead of encoding one accelerator's assumptions.
+
+**Production value.** Operators get a pre-deployment answer to "where should this policy run here?" together with an explanation rather than a backend-specific feature checklist.
+
+**Failure condition.** If useful target manifests become unrelated per-backend catalogs, or static expert placement matches the planner across workloads, the general planner adds little value.
+
+### 2. Generation-scoped state ownership and migration
+
+**Gap.** Moving execution can change map visibility and update ordering even when the program code remains unchanged.
+
+**Mechanism.** Every state object declares an owner and one of a small number of consistency modes, for example target-local, host-authoritative, device-authoritative, or replicated read-mostly. A placement transition creates a new policy generation. The controller verifies the new target, transfers or reinitializes only state permitted by the declared mode, establishes a fence, then activates the new generation. Rollback retains the previous generation and its authoritative state until the new placement is committed.
+
+This mechanism should avoid pretending that all maps are globally coherent. State that cannot be migrated safely simply makes a placement ineligible.
+
+**Delta.** Transactional eBPF upgrade already needs generation boundaries for programs, links, and maps. Heterogeneous migration adds explicit memory-domain ownership and crossing semantics to that transition.
+
+**Artifact.** A generation controller, a state-description schema, and state bridges for a small set of map classes shared between host and one device backend.
+
+**Evaluation.** Use counters, sketches, quota tables, and read-mostly policy tables under network and GPU workloads. Inject device reset, controller crash, stale replica, and mid-transition failure. Measure lost or duplicated updates, stale-read rate, transition pause, transfer bandwidth, rollback correctness, and the performance difference between local, host-authoritative, and replicated state.
+
+**Academic value.** The design asks which state semantics are both useful and implementable across heterogeneous BPF runtimes without building a general distributed shared-memory system.
+
+**Production value.** A policy can move only when its state contract says the transition is safe, which turns migration failure from an implicit correctness risk into a rejected operation.
+
+**Failure condition.** If most useful BPF state is naturally target-local or cheaply host-authoritative, cross-target migration may be too rare to justify a generic mechanism. In that case the planner should keep state immobile and move only stateless policy components.
+
+### 3. A ground-truth placement and provenance benchmark
+
+**Gap.** Current evaluations show that individual offload targets can work well, but there is little common evidence for when each target is the right one.
+
+**Mechanism.** Build benchmark workloads around an event graph, state objects, expected externally visible effects, and a set of eligible targets. For every run, record the placement generation, boundary crossings, state movement, and the reason for each placement decision. A ground-truth checker validates the final effects independently of the runtime's own logs.
+
+The benchmark should include both stable and phase-changing workloads. The latter matters because it can tell us whether runtime re-placement is worth implementing at all.
+
+**Artifact.** A harness with reference policies for packet processing, userspace function control, GPU resource policy, and one cross-fabric data-movement case; adapters to the same target set used by the planner.
+
+**Evaluation.** Compare throughput, p99 latency, host CPU, device utilization, transferred bytes, state staleness, failed semantic checks, and observability completeness across placements. Then test whether planner decisions predict the best valid placement and whether phase changes create enough benefit to justify switching generations.
+
+**Academic value.** The benchmark turns "run near the data" from a slogan into a falsifiable systems hypothesis and exposes which workload features actually determine placement.
+
+**Production value.** Teams gain a regression suite for target selection before they enable offload or migration in production.
+
+**Failure condition.** If policies are so target-specific that the same logical effect cannot be expressed across at least two backends, a generic placement benchmark is the wrong abstraction. Target-specific evaluation should remain the norm.
+
+## What I would build first
+
+I would not start with a distributed eBPF scheduler that moves programs continuously among CPU, NIC, and GPU. That design combines too many unknowns: runtime compatibility, state transfer, cost prediction, target failure, and explanation.
+
+A smaller first system would do three things:
+
+1. describe target capabilities and policy requirements in a machine-readable form;
+2. reject invalid placements and choose one placement before activation;
+3. record placement generation, state owner, and measured crossing costs so the decision can be replayed later.
+
+Then run the same workload in several placements. If the best target changes across stable workload phases and the benefit is larger than transition cost, add generation-scoped migration for the small set of state types that can move safely. If the winner is stable, keep placement static and spend the complexity budget elsewhere.
+
+That sequencing matters. Heterogeneous eBPF already has enough evidence that specialized placement can deliver real performance and new control points. What it does not yet have is evidence that transparent dynamic movement is broadly necessary.
+
+## What would change this conclusion?
+
+The argument for a general placement layer becomes weaker under three results.
+
+First, if target-specific systems cover almost all useful deployments and policies rarely have two semantically valid execution homes, then a generic planner has little to choose. Better backend-specific tooling would be enough.
+
+Second, if fabric_ext's semantic movement graph or a similar existing abstraction can represent networking, userspace, GPU policy, device effects, and their state contracts without losing important semantics, then that abstraction should be generalized rather than creating a competing placement model.
+
+Third, if cross-target state and evidence traffic dominate the cost in realistic workloads, then moving policy close to the event may save less than it costs. The right architecture would keep authority and state on the host and use devices only for narrow stateless predicates or pre-processing.
+
+The current evidence supports a narrower conclusion: **eBPF does not have one best execution location. The missing mechanism is a testable placement decision over targets whose event, state, memory, authority, and verifier semantics differ.** Start with explicit static placement and measured evidence. Earn dynamic migration with benchmarks rather than assuming it.

--- a/docs/research/heterogeneous-ebpf-execution-placement.zh.md
+++ b/docs/research/heterogeneous-ebpf-execution-placement.zh.md
@@ -1,0 +1,260 @@
+---
+date: 2026-08-17
+title: "异构系统里的 eBPF 到底应该运行在哪里？"
+description: "eBPF 已能运行在内核、用户态、SmartNIC 与 GPU 上。真正缺少的是执行放置机制：跨目标选择和迁移时，状态、安全、权限与效果语义必须保持可解释且可验证。"
+tags:
+  - Daily Report
+  - eBPF
+  - Heterogeneous Systems
+  - SmartNIC
+  - GPU
+  - Runtime Systems
+  - Offload
+research_question: "当同一 eBPF 策略可以运行在内核、用户态、NIC/DPU、GPU 邻近或设备侧运行时时，系统应如何选择执行位置；如果放置发生变化，又该怎样保持状态、权限、verifier 假设、内存可见性与可观测性语义不变？"
+source_cutoff: 2026-08-17
+status: daily-report
+---
+
+# 异构系统里的 eBPF 到底应该运行在哪里？
+
+设想一个服务：数据包先到 SmartNIC，应用在用户态解析请求，张量随后进入 GPU，其中一部分工作集又放在 CXL fabric 后面。现在希望部署一条统一策略：入口处拒绝异常流量，运行过程中统计昂贵的数据搬运，并在 GPU 队列拥塞时调整执行方式。
+
+今天已经不止一个位置可以运行 BPF 逻辑。网络策略可以留在 Linux 内核，也可以下沉到可编程 NIC；高频应用函数可以由 [bpftime](https://github.com/eunomia-bpf/bpftime) 一类用户态运行时直接插桩；GPU 策略既可以放在 host driver 一侧，也可以像 [gpu_ext](https://arxiv.org/abs/2512.12615) 那样进入设备侧运行时；更近期的 [fabric_ext](https://arxiv.org/abs/2607.26335) 甚至把一条策略拆到 GPU、driver/runtime、DPU/NIC 与 CXL 侧执行。
+
+一个很自然的答案是：离事件越近越好。
+
+问题是，策略不只依赖事件。
+
+某个 packet 在 NIC 上最早可见，但策略表可能由 host 统一维护；GPU 侧执行可以省掉一次 host 往返，却未必拥有内核 helper、map 或系统安全权限；程序一旦移动，pointer 的含义、map 更新何时可见、side effect 的时序，以及故障后能留下多少证据，都可能一起改变。
+
+<!-- more -->
+
+本文的结论是：**异构 eBPF 需要一个独立于 BPF ISA、也独立于单个 backend runtime contract 的执行放置层。** 第一层问题是“这个目标能不能按要求运行程序”；放置层要回答的是“多个目标都能运行时，应该由谁执行、由谁持有状态和效果，以及位置变化时怎样避免语义悄悄变化”。
+
+第一版不应该直接追求 CPU、NIC、GPU 之间的透明动态迁移。更稳妥的实现是静态或低频变化的 planner：先把约束写清楚，只在语义有效的目标中选择，并记录为什么这么选。只有 benchmark 证明 workload phase 会让静态放置长期吃亏，才值得加入运行时迁移。
+
+这是当前 **eBPF Runtime, Extensibility, and Composition** 系列的第六篇。系列第一篇讨论了[用户态 eBPF 的可移植运行时契约](https://eunomia.dev/zh/research/userspace-ebpf-runtime-contract/)；那篇回答一个 backend 是否提供程序依赖的 attach、capability、state 与 lifecycle 语义。本文向上再走一层：如果好几个 backend 都满足契约，今天到底应该让谁来执行？
+
+## 指令可以兼容，执行环境仍然可能完全不同
+
+BPF ISA 已经比它周围的运行环境更容易移植。[RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html) 定义了 BPF 指令集与 conformance group。runtime 至少实现基础组，也可以声明更多组，compiler 因此能够知道目标支持哪些指令能力。
+
+但 instruction group 无法告诉我们这个目标能看到哪些事件、ctx 中哪些字段可读、哪些 helper 能调用、哪些内存可访问，也无法回答程序究竟能 deny、修改、调度还是只能观察。
+
+Linux 自身就是很好的反例。内核的 [eBPF verifier 文档](https://docs.kernel.org/bpf/verifier.html)明确说明，不同程序类型会通过 `is_valid_access()` 限制不同的 context 访问，并通过 `get_func_proto()` 暴露不同函数集合。socket program 与 tracing program 可以执行同一套指令，却拥有完全不同的上下文和能力。host environment 本身就是程序语义的一部分。
+
+硬件 offload 更能说明这个边界。当前 Linux [`kernel/bpf/offload.c`](https://github.com/torvalds/linux/blob/master/kernel/bpf/offload.c) 把 offloaded program 与 map 绑定到注册的 network device 和 device ops；device-bound 初始化路径围绕 `SCHED_CLS` 与 `XDP` 工作，而不是接受任意 BPF 程序和任意异构设备。Linux 已经有真正的 hardware offload，但这个模型有明确的网络子系统边界。
+
+所以，一个通用 placement layer 不能只问“设备会不会跑 eBPF”。它至少还要回答下面这些问题：
+
+| 问题 | ISA 能回答吗？ | 放置决策需要吗？ |
+| --- | --- | --- |
+| 目标能否执行所需指令 | 能 | 需要 |
+| 能否看到所需事件与 context | 不能 | 需要 |
+| 是否提供所需 helper / kfunc 类能力 | 不能 | 需要 |
+| 策略状态实际放在哪里 | 不能 | 需要 |
+| 哪些 memory domain 可直接访问 | 不能 | 需要 |
+| 程序能 deny、修改、调度还是只能观察 | 不能 | 需要 |
+| 哪个主体授权这些 effect | 不能 | 需要 |
+| 这个位置会引入多少 event/state crossing | 不能 | 需要 |
+
+前一篇 runtime-contract 报告强调 backend capability 应该可以被机器验证。放置问题则是在这些 capability 之上再做一次选择：一个 backend 即使兼容，也不一定是这条策略最合适的执行位置。
+
+## 现有系统已经在用不同的答案
+
+异构 placement 并不是未来才会出现的问题。已有系统之所以选择不同位置，正是因为 event locality 会直接决定什么机制做得出来。
+
+### hXDP 把 XDP 放到 FPGA NIC 上
+
+[hXDP](https://www.usenix.org/conference/osdi20/presentation/brunella) 展示了真实 XDP 程序可以直接在 FPGA NIC 上执行，而不是继续占用 host CPU。系统包含优化 compiler、扩展 BPF ISA、soft processor，以及 FPGA 上的 XDP map/helper 支持。OSDI 2020 论文报告其原型约占 15% FPGA 资源，在测试中达到高端 CPU 单核相当的 packet-processing throughput，同时把 packet forwarding latency 降低约 10 倍。
+
+这个结果并不意味着所有 BPF 程序都应该搬到 NIC。它真正说明的是：当 event、state path 与 execution environment 都适合设备侧执行时，specialization 可以带来很大收益。为了做到这一点，hXDP 仍然需要显式重建目标所需的 map、helper 与执行语义。
+
+### 用户态运行解决的是另一种 locality
+
+用户态 eBPF 处理的是不同的问题。[bpftime](https://github.com/eunomia-bpf/bpftime) 可以在应用函数等用户态事件附近执行 BPF，不必让每一个 hot event 都走一次内核 probe 路径。它还包含 attach、map、helper、verification 与兼容层，因此不是一个单纯的 bytecode interpreter。
+
+这种 placement 能直接接触应用自己的控制点，但也改变了程序可以假设的环境。kernel-only helper 与内核对象访问不会因为 ISA 一样就自动出现在用户态。event path 更短，并不意味着 process runtime 在语义上等价于 kernel。
+
+### gpu_ext 把策略推进 GPU 边界以内
+
+[gpu_ext](https://arxiv.org/abs/2512.12615) 的出发点就是 host-only placement 的盲区。论文指出，host-side eBPF 看不到一部分与 GPU memory placement、scheduling 和 observability 直接相关的 device-side event。它因此在 GPU driver 暴露 hook，并加入 device-side eBPF runtime，让经过验证的 policy logic 可以在 GPU kernel 内执行。论文在其 workload 上报告最高 4.8 倍 throughput 提升，以及最高 2 倍 tail-latency 改善。
+
+这里更值得关注的是 event boundary，而不是最大加速数字。host 上的策略可以很安全，也可以很快，但如果它看见事件时已经太晚，就实现不了原本的控制目标。
+
+把这几个系统放在一起看，会发现“一个抽象机器、多个等价 backend”这个模型并不成立。kernel、userspace、NIC 与 GPU 分别提供不同的 event locality、memory visibility、verifier 假设、state cost 与 effect authority。
+
+## “靠近数据”只解决了放置目标的一半
+
+把程序放到事件附近可以减少 crossing，但事件只是一次策略决策的一个输入。实际 placement 至少同时面对五种 locality。
+
+**事件 locality**：触发点在哪里最早可见。packet arrival 更靠近 NIC 或 network stack；GPU allocation 和 queue event 更靠近 driver/device；用户态函数调用显然更靠近 process。
+
+**状态 locality**：map、counter、sketch、policy table 或 learned state 现在由谁持有。per-queue counter 可以完全 device-local，但同时服务 networking、storage 和 GPU 的 tenant policy table 往往需要 host authority，或者至少需要明确的 replica protocol。
+
+**内存 locality**：程序能直接看到哪个 address space。host virtual address、GPU global memory、NIC SRAM 与 CXL-attached memory 并没有统一的一致性模型。在一个目标上合法的 pointer，换个目标可能毫无意义。
+
+**效果 locality**：真正的控制动作在哪里发生。若目标是在 DMA 前拒绝 packet，那么 host 上晚到的 observation 帮助有限；若策略要影响 GPU device scheduling，粗粒度用户态 event 也可能不够。
+
+**权限 locality**：谁有权产生这个效果。device-local policy 不应该悄悄放宽 host security 已经拒绝的操作；反过来，host 可以把一小段 bounded scheduling choice 委托给设备，却没有必要同步处理每一个 fast-path event。
+
+这几种 locality 经常指向不同位置。
+
+例如一个多租户 GPU service，把共享 quota table 放在 host，却希望根据 device queue event 限流。至少有三种放置方式：
+
+1. 全部决策留在 host，接受频繁 event crossing；
+2. quota table 复制到 device，再承担 consistency protocol；
+3. host 只维护并发布 budget generation，device 在一个 generation 内执行局部有效的 fast-path 限制。
+
+第三种往往比“所有东西都应该在一个地方”更现实。因此 placement layer 不只决定**代码运行在哪里**，还要决定**authoritative state 留在哪里**。
+
+## 最接近这个问题的工作已经能够跨多个设备
+
+讨论 placement 时不能绕开 [fabric_ext](https://arxiv.org/abs/2607.26335)，也不能声称跨设备 eBPF lowering 还没人研究。
+
+fabric_ext 面向 GPU-CXL fabric。它用 semantic movement graph 描述 source/destination、bytes、stride、reuse、ordering、ownership 和数据变换，再由 compiler 生成多个设备上的 eBPF program、verifier obligation、按 consistency 分类的 BPF map，以及对应 backend artifact。一条策略可以分布到 GPU hook、driver/runtime、DPU/NIC、CXL switch 或 near-memory target。
+
+这已经证明了一个很重要的事实：只要 source policy 暴露足够的语义，compiler 可以把执行拆到不同硬件位置，同时把 state 与 verification 纳入 lowering 过程。
+
+因此，本文剩下的问题必须更具体，而不是重新发明“跨设备 eBPF”。这里关注的是**任意 event-driven BPF policy 在多个 eligible target 之间的执行放置**，而不只限于 GPU-CXL data movement transformation。与此同时，第一版也不假定 arbitrary program 可以自动 partition。开发者显式标出 component boundary，planner 在 whole-program 或这些 boundary 之间选位置，就已经足够形成一个可验证系统。
+
+两者可以这样区分：
+
+- fabric_ext 研究一个 semantic data-movement graph 如何根据已知 fabric topology 做 lowering；
+- 本文研究 BPF policy 面对 networking、application、GPU runtime、driver、device 等不同 event source 时，需要什么 target contract、placement objective、state ownership 和 evidence，才能选择执行位置。
+
+如果后续实验发现 fabric_ext 的 graph 很自然地就能覆盖这些 event class 和 effect contract，那么没有必要再造一个 placement abstraction。那会直接否定本文的一部分设计假设，反而是很好的结果。
+
+## 移动程序很容易顺手改变语义
+
+真正危险的情况发生在部署以后改变 placement。
+
+假设一个程序不断增加 map counter，超过 threshold 后拒绝某类操作。在 host 上，这个 update 也许立刻对其他 host program 可见；到了 NIC 或 GPU，同一个“逻辑 map”可能变成 device-local、mirror、cache，或者每次访问都绕回 host。程序代码完全没变，threshold 何时生效却变了。
+
+时间与 ordering 同样如此。host-side event 可能在设备已经接收 work 之后才被看到；device-side policy 可以更早做决定，但 host trace 未必及时拥有足够 context 来解释原因。每个 target 单独都正确，并不保证跨 target 的 observation 顺序仍然表达同一件事。
+
+因此，透明 migration 不是好的第一目标。系统先要明确哪些属性必须保持不变：
+
+- 每个 policy generation 明确记录执行 target；
+- 每个 state object 明确记录 authoritative owner 与允许存在的 replica；
+- 新 target 激活前必须证明所需 context、helper、memory 和 effect capability；
+- placement transition 有 generation boundary，避免旧状态和新状态意外混用；
+- 任何对外有意义的 decision 都可以追溯到当时的 placement 与 generation。
+
+这和之前的[有状态 eBPF 事务化升级](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/)直接相关。placement migration 本质上也是 upgrade，只不过新 generation 同时换了 execution domain。既然单机内替换 program/map 都需要处理 prepare、commit 与 rollback，跨 memory domain 的迁移更不能靠“把 bytecode 再 load 一次”解决。
+
+## 现有工作还缺什么
+
+### 缺少一个通用的 BPF placement objective
+
+现有系统通常先选目标，再在目标内部优化。Linux hardware offload 从 network device 上的 XDP/classifier 语义出发；hXDP 从 FPGA NIC 出发；gpu_ext 从 GPU policy 出发；fabric_ext 从 GPU-CXL movement graph 出发。
+
+缺少的是：当一条 policy 同时有两个以上合法执行位置时，如何用同一组约束比较它们。“离数据最近”没有计算 shared-state traffic、authority boundary、verifier difference，也没有计算丢失诊断证据的成本。
+
+这个 objective 也不应该把所有东西硬塞成一个加权总分。更可靠的方法是先排除语义非法的 placement，再对剩余目标比较一个小的 Pareto set，例如 event crossing、state crossing、latency、throughput、host load 与 evidence completeness。
+
+### 跨 target 状态没有共同的故障语义
+
+BPF map 是熟悉的编程模型，但 kernel、GPU、NIC 与用户态里的“map”不会自动变成一份 coherent object。所有 update 都同步，可能把 offload 带来的性能收益抵消掉；所有 state 都 local，又可能让 split policy 直接出错。
+
+这里真正需要的不是“大一统 distributed map”，而是每个 state object 自己说明：authoritative owner 是谁、哪些 replica 可以 stale、哪些 update 可交换、什么时候必须建立 generation fence、设备在迁移中消失时如何恢复。
+
+这个问题也可能有一个刻意简单的答案。大量实际 policy 或许只需要 device-local counter 加一张很小的 host-authoritative config table。如果这已经覆盖大多数 workload，就不值得构建复杂的全局一致 map system。
+
+### 现有 evaluation 很少直接回答“应该放在哪里”
+
+accelerator paper 通常把自己选择的 target 与 host baseline 比较。这足以证明某种加速方式有没有用，却无法回答另一个 target 会不会更好，也无法解释什么 workload property 决定赢家。
+
+placement mechanism 需要一类不同 benchmark：**同一条 logical policy 与同一组 expected effect** 必须至少能在两个位置执行。否则 planner 只能证明自己的 cost model 自洽，而不能证明它做出了更好的系统设计。
+
+### 可观测性也是 placement contract 的一部分
+
+policy offload 也会把一部分“解释权”下放到设备。device 负责 deny、schedule、memory placement 或 transformation 后，operator 至少需要知道当时是哪一版 policy、在哪个 target、对哪类 input、产生了什么 effect。
+
+所有 event 都同步回 host 会破坏 fast path；所有证据只留在 device 又很难重建跨 target incident。因此 placement 不仅需要 execution budget，还需要 evidence budget。
+
+## 值得继续实现和验证的方向
+
+### 1. Target manifest 与 placement planner
+
+**缺口。** runtime 可以告诉用户“支持 BPF”，却把 event、helper、memory domain、authority 与 crossing cost 都留在文档里，让上层自己猜。
+
+**机制。** 每个 target 提供机器可读 manifest，声明 instruction conformance group、可用 event/attach class、context version、helper/kfunc 类能力、map/state class、可读 memory domain、允许产生的 effect、authority constraint，以及测得的 event/state crossing cost。policy 另一侧声明需要的 event、state、effect 和 latency bound。planner 先做语义筛选，再从合法 placement 中按实际成本选择。
+
+第一版只放置 whole program 或开发者显式声明的 component，不尝试自动切 arbitrary bytecode。
+
+**与现有工作的差异。** 前一篇 userspace-runtime contract 判断一个 backend 是否满足语义；这里要在多个满足条件的 backend 之间做选择。相对 fabric_ext，这个 manifest 面向超出单一 fabric data-movement domain 的 event-driven policy。
+
+**产物。** 一份 schema，Linux kernel BPF、bpftime 用户态、NIC/FPGA 与 GPU-side target 的 adapter，一个小型 constraint solver，以及能够解释“为什么这个位置不合法/为什么选这里”的命令行工具。
+
+**评测。** 选择至少有两个合法 placement 的 workload，例如 packet filtering/accounting、用户态 hot function policy、GPU memory/scheduling control 和一条 cross-device policy。比较 expert manual placement、always-host、always-near-event 和 planner。测量非法 placement 拦截率、event/state crossing、p50/p99 decision latency、throughput、host CPU、device utilization 与 planner overhead；对适用的 data-movement workload，再和 fabric_ext 的 placement 做比较。
+
+**学术价值。** 验证一份紧凑 target contract 是否真的能够预测跨 execution domain 的 Pareto frontier，而不是把某个 accelerator 的假设写死进去。
+
+**生产价值。** 部署前可以得到“这条 policy 在这台机器上应该放哪里”的机器可检查答案，而且能够解释选择原因。
+
+**失败条件。** 如果 manifest 最后只是互不相干的 backend feature catalog，或者人工静态 placement 在所有 workload 上都和 planner 一样好，这个通用 planner 就没有足够价值。
+
+### 2. 以 generation 为边界的状态归属和迁移
+
+**缺口。** 代码不变，只要 execution location 改变，map visibility 和 update ordering 就可能改变。
+
+**机制。** 每个 state object 显式声明 owner，并限制在少量 consistency mode 中，例如 target-local、host-authoritative、device-authoritative、replicated read-mostly。迁移时创建新 policy generation：先验证新 target，只搬运该 mode 允许迁移的 state，建立 fence，然后激活新 generation。在 commit 前，旧 generation 与它的 authoritative state 保留，用于 rollback。
+
+这个方案刻意不承诺“所有 map 全局 coherent”。无法安全迁移的 state 直接让某个 placement 变成 ineligible。
+
+**与现有工作的差异。** transactional eBPF upgrade 已经需要 program/link/map generation boundary；异构迁移在此基础上加入 memory-domain ownership 与 crossing semantics。
+
+**产物。** generation controller、state-description schema，以及少量 host/device map class 的 state bridge。
+
+**评测。** 用 counter、sketch、quota table 和 read-mostly policy table 跑 network/GPU workload，并注入 device reset、controller crash、stale replica 与 transition 中断。测 lost/duplicated update、stale-read rate、迁移 pause、transfer bandwidth、rollback correctness，以及 local、host-authoritative、replicated 三种方式的性能差异。
+
+**学术价值。** 找出哪些 state semantics 能跨 heterogeneous BPF runtime 实现，同时又不退化成一个通用 distributed shared-memory system。
+
+**生产价值。** 只有 state contract 明确允许时 policy 才能移动，迁移失败从隐蔽 correctness risk 变成一个可以在 activation 前拒绝的操作。
+
+**失败条件。** 如果大多数有用 BPF state 天然就是 target-local，或者 host-authoritative state 的成本已经很低，那么 generic cross-target migration 可能根本不值得做。planner 应该让 state 保持不动，只迁移 stateless component。
+
+### 3. 带 ground truth 的 placement 与 provenance benchmark
+
+**缺口。** 现有 evaluation 能证明某个 offload target 很有效，却很难回答“什么时候应该选它”。
+
+**机制。** benchmark 把 workload 写成 event graph、state object、expected externally visible effect 与 eligible target。每一次执行都记录 placement generation、boundary crossing、state movement，以及 planner 的选择原因。独立 ground-truth checker 根据最终 effect 判断正确性，而不是相信 runtime 自己的日志。
+
+benchmark 同时包含 stable workload 与 phase-changing workload。后者尤其重要，因为它能直接回答动态 re-placement 有没有实现价值。
+
+**产物。** 一套 harness，至少包含 packet processing、用户态函数控制、GPU resource policy 和一个 cross-fabric data-movement case，并复用 planner 所支持的 target adapter。
+
+**评测。** 跨 placement 比较 throughput、p99 latency、host CPU、device utilization、transfer bytes、state staleness、semantic check failure 与 observability completeness，再检查 planner 是否能预测最佳合法位置，以及 phase change 带来的收益是否大于 generation switching cost。
+
+**学术价值。** 把“靠近数据执行”从经验口号变成可证伪的系统假设，找到真正决定 placement 的 workload 特征。
+
+**生产价值。** 在生产环境开启 offload 或 migration 之前，可以用同一套 suite 做 target selection regression test。
+
+**失败条件。** 如果不同 target 上的 policy 语义差异太大，同一 logical effect 根本无法在两个 backend 表达，那么 generic placement benchmark 本身就是错误抽象，应该回到 target-specific evaluation。
+
+## 我会先做哪个版本
+
+我不会一开始就做一个在 CPU、NIC 与 GPU 之间不断搬程序的 distributed eBPF scheduler。那样一次性叠加了 runtime compatibility、state transfer、cost prediction、target failure 和 explainability，失败时很难知道问题出在哪一层。
+
+更小的第一版只做三件事：
+
+1. 用机器可读形式描述 target capability 与 policy requirement；
+2. 排除非法位置，在 activation 前选择一个 placement；
+3. 记录 placement generation、state owner 与实际 crossing cost，让决策之后可以 replay。
+
+然后把同一个 workload 放到几个合法位置实际跑。如果稳定 workload 的赢家基本不变，就保持 static placement；如果不同 phase 的最佳 target 经常变化，而且收益明显高于 transition cost，再为少数可以安全搬运的 state type 加 generation-scoped migration。
+
+这样的顺序更容易验证。现有系统已经足以说明 specialization 与设备附近的 control point 有真实价值，但还没有足够证据证明透明动态迁移是大多数 workload 都需要的功能。
+
+## 什么证据会改变这个结论？
+
+有三类结果会削弱“需要通用 placement layer”的判断。
+
+第一，如果绝大多数 policy 从一开始就只有一个语义合法 target，target-specific system 已经覆盖实际部署，那么 planner 没有真正的选择空间，做好 backend-specific tooling 就够了。
+
+第二，如果 fabric_ext 的 semantic movement graph 或类似已有抽象可以自然表达 networking、userspace、GPU policy、device effect 与 state contract，就应该直接扩展那套 abstraction，而不是另外再做一个竞争的 placement model。
+
+第三，如果真实 workload 中 cross-target state 和 evidence traffic 的成本始终高于 offload 节省的 event cost，那么“靠近事件”并没有想象中划算。更合适的架构会把 authority 与 state 留在 host，只把很窄的 stateless predicate 或 preprocessing 下沉到设备。
+
+当前证据支持一个更克制的结论：**eBPF 没有唯一最佳执行位置。真正缺少的是一套可以验证的 placement decision，用来处理 event、state、memory、authority 与 verifier semantics 都不同的多个 target。** 先把静态 placement 做成可检查机制，再用 benchmark 决定是否值得获得动态迁移能力。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Where Should eBPF Run in a Heterogeneous System?](https://eunomia.dev/research/heterogeneous-ebpf-execution-placement/)
+
+Kernel, userspace, SmartNIC, and GPU-side runtimes can all be valid homes for eBPF logic, but they do not expose the same events, state, memory, authority, or verifier environment. This report develops a placement-aware target manifest, generation-scoped state ownership, and a ground-truth benchmark for choosing execution location without silently changing policy semantics.
+
 ### [How Far Can eBPF Programmability Move Into io_uring?](https://eunomia.dev/research/io-uring-bpf-programmability/)
 
 Current Linux has both per-opcode io_uring BPF request filtering and an eBPF `struct_ops` execution path. This report separates the cBPF admission gate from the eBPF ring-loop control surface, then asks how restrictions, LSM authority, policy generations, provenance, and resource accounting should compose as io_uring absorbs FUSE, zero-copy networking, ublk, and other registered I/O resources.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [异构系统里的 eBPF 到底应该运行在哪里？](https://eunomia.dev/zh/research/heterogeneous-ebpf-execution-placement/)
+
+内核、用户态、SmartNIC 与 GPU-side runtime 都可能是 eBPF 的合法执行位置，但它们暴露的事件、状态、内存、权限与 verifier 环境并不相同。本文提出 placement-aware target manifest、以 generation 为边界的状态归属，以及用于选择执行位置并检查语义是否保持一致的 ground-truth benchmark。
+
 ### [eBPF 可编程能力能在 io_uring 里面走多远？](https://eunomia.dev/zh/research/io-uring-bpf-programmability/)
 
 当前 Linux 的 io_uring 同时出现了按 opcode 的 BPF 请求过滤和 eBPF `struct_ops` 执行路径。本文区分 cBPF admission gate 与 eBPF ring-loop control surface，并进一步分析 restriction、LSM 权限、policy generation、provenance 和资源归属怎样组合，尤其是在 io_uring 开始承载 FUSE、zero-copy networking、ublk 等注册 I/O 资源之后。


### PR DESCRIPTION
## Summary

- publish exactly one new bilingual Daily Report on where eBPF execution should live across kernel, userspace, NIC/DPU, GPU-adjacent, and device-side targets
- separate backend compatibility from execution placement instead of duplicating the earlier userspace-runtime-contract report
- develop three testable mechanisms: a placement-aware target manifest, generation-scoped state ownership/migration, and a ground-truth placement/provenance benchmark
- treat fabric_ext as strong adjacent prior work and state the falsifier if its movement-graph abstraction generalizes to the broader event-policy problem
- refresh the 2026-08-17 analytics, technical SEO, previous-run closeout, editorial mix, and series state
- record the six-report boundary for eBPF Runtime, Extensibility, and Composition and make eBPF Observability and Profiling the preferred next series to promote on the next run
- make no unrelated technical SEO implementation change because today's audit did not establish a new defect

## Research

English: `/research/heterogeneous-ebpf-execution-placement/`

Chinese: `/zh/research/heterogeneous-ebpf-execution-placement/`

Primary evidence includes RFC 9669, current Linux verifier and BPF offload behavior, hXDP, gpu_ext, fabric_ext, and current bpftime/runtime evidence. The report's core claim is narrower than “eBPF should run near the data”: placement must first preserve event, state, memory, authority, effect, and verifier semantics, then optimize crossing cost and latency. It recommends static or slowly changing placement first; dynamic migration is conditional on benchmark evidence.

## Analytics / SEO state

- no Google export beginning `2026-08-10` was present in the configured Drive folder today; newest GSC date rows still end on `2026-08-08`, and finalized GA4 coverage ends on `2026-08-09`
- valid equal-duration GSC comparison remains 478 clicks / 69,053 impressions vs 409 / 46,327; full adjacent GSC 7-day and required 28-day comparisons remain unavailable rather than inferred
- finalized GA4 comparison remains 991 sessions at about 44.90% engagement vs 1,021 at about 46.72%; `(not set)` fell from 157 to 116 sessions
- Cloudflare remains disabled by repository configuration
- the current public-safe operating brief reports homepage 200, robots and sitemap reachable, 664 sitemap entries, and the correct homepage canonical
- the technical audit did not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect
- previous daily PR #160 is now recorded as fully complete: squash `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`, validation run `31958113036`, deployment run `31958113001`, one closeout conversation comment

## Editorial state

Before this PR: 5 eBPF-centered / 2 pure Agent / 0 adjacent reports out of 7.

After merge: 6 eBPF-centered / 2 pure Agent / 0 adjacent out of 8. The runtime/extensibility series reaches its normal six-report boundary; the next scheduled run should promote eBPF Observability and Profiling before selecting its report, beginning with page-level memory attribution unless primary evidence rejects that candidate.

## Validation contract

Per `DAILY_TASK.md`, this PR must pass all expected/required CI, receive a complete diff and generated-output self-review, squash merge, deploy the exact squash commit, verify both public language routes including canonical/hreflang/navigation/internal-link and report-content boundaries, and receive exactly one merged-PR closeout comment. No second closeout PR.