### PR TITLE
Daily: connect eBPF memory attribution to page activity

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -18,19 +18,20 @@ already configured and enabled; it is not a blocker.
 ## Current data-history constraint
 
 Google Drive access is verified and is not a blocker. The configured folder now
-contains two adjacent weekly Search Console and GA4 export sets: `2026-07-27`
-through `2026-08-02` and `2026-08-03` through `2026-08-09`. The newest Search
-Console date export currently has rows through `2026-08-08`; under the configured
-three-day finalization lag, those rows are usable on `2026-08-11`.
+contains three adjacent weekly Search Console and GA4 export sets beginning
+`2026-07-27`, `2026-08-03`, and `2026-08-10`. The newest Search Console date file
+has rows through `2026-08-15`, which is finalized under the configured three-day
+lag on `2026-08-18`.
 
-A complete latest-7-days versus previous-7-days comparison is still unavailable.
-The latest complete finalized seven-day GSC window is `2026-08-02` through
-`2026-08-08`, while its preceding window begins on `2026-07-26`, one day before
-the available history. The 28-day comparison also remains unavailable. The
-newest GA4 landing-page export includes `2026-08-09` and has no date dimension,
-so it cannot be cleanly restricted to the finalized period. GA4 is also limited
-to organic landing-page rows and does not by itself provide complete acquisition,
-conversion, or outbound behavior coverage.
+A complete latest-7-days versus previous-7-days Search Console comparison remains
+unavailable because the `2026-08-09` date row is absent across the adjacent
+weekly exports. The available data supports an equal-duration six-day comparison
+for `2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
+The 28-day comparison also remains unavailable because the export history is not
+long enough. GA4 landing-page files are weekly aggregates without a date
+dimension, so they are compared only at their source-native weekly granularity.
+They also do not provide complete acquisition, conversion, or outbound behavior
+coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use
 the available Google exports, live-site evidence, public GitHub evidence, and

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -28,10 +28,15 @@ unavailable because the `2026-08-09` date row is absent across the adjacent
 weekly exports. The available data supports an equal-duration six-day comparison
 for `2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
 The 28-day comparison also remains unavailable because the export history is not
-long enough. GA4 landing-page files are weekly aggregates without a date
-dimension, so they are compared only at their source-native weekly granularity.
-They also do not provide complete acquisition, conversion, or outbound behavior
-coverage by themselves.
+long enough.
+
+GA4 landing-page files are weekly aggregates without a date dimension. On
+`2026-08-18`, the newest `2026-08-10` through `2026-08-16` file still includes an
+unfinalized day under the configured three-day lag and cannot be trimmed. Its
+figures may be used only as provisional directional evidence. The latest fully
+finalized GA4 weekly comparison remains `2026-08-03` through `2026-08-09` versus
+`2026-07-27` through `2026-08-02`. GA4 landing-page exports also do not provide
+complete acquisition, conversion, or outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use
 the available Google exports, live-site evidence, public GitHub evidence, and

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -89,7 +89,19 @@ provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
    benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
    migration.
 
+After this report, the archive is **7 eBPF-centered / 2 pure Agent / 0 adjacent
+out of 9**. The next published report will create the first full ten-report
+window. It therefore must be an **adjacent-systems report that is not classified
+as eBPF-centered or pure Agent**, producing 7 eBPF / 2 Agent / 1 adjacent out of
+10. Do not force an active-series question into the adjacent bucket merely to
+satisfy the ratio. If the strongest next Observability and Profiling candidate
+still has eBPF as an essential mechanism, defer it for one run and select a real
+adjacent-systems question from the approved roadmap.
+
 ### Preferred next questions
+
+These remain the preferred questions inside this active series once the rolling
+mix permits another eBPF-centered report:
 
 1. sampling theory for profilers: phase locking, randomized sampling, bias, and
    confidence intervals;
@@ -100,6 +112,11 @@ provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 4. causal profiling for GPU host-side bottlenecks and megakernel execution;
 5. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
+
+For the immediate ten-report boundary, sampling theory may be selected only if
+its actual central question is a general adjacent profiling problem and eBPF is
+not essential to the mechanism. Otherwise use another approved adjacent-systems
+question and return to this list afterward.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -39,16 +39,10 @@ that candidate and continue research on another question in the approved roadmap
 until one passes. Prefer changing the question over padding weak evidence or
 inventing novelty.
 
-A daily report must still provide:
-
-- a concrete reader problem;
-- primary-source evidence;
-- a non-trivial gap or unresolved mechanism;
-- a reasoned technical conclusion;
-- a small number of implementable research directions with academic and
-  production value;
-- a discriminating evaluation or evidence that would change the conclusion;
-- a thesis that does not duplicate an existing report.
+A daily report must still provide a concrete reader problem, primary-source
+evidence, a non-trivial gap or unresolved mechanism, a reasoned technical
+conclusion, implementable research directions, and a discriminating evaluation
+or evidence that would change the conclusion.
 
 ## Series rules
 
@@ -70,88 +64,72 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Active series — eBPF Runtime, Extensibility, and Composition
-
-Working question: **What mechanisms are still missing if eBPF is treated as a
-programmable runtime substrate rather than only a kernel observability feature?**
-
-This series connects kernel and userspace execution, composition, state,
-upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
-execution placement. The `2026-08-17` report reaches the normal six-report series
-boundary. The next scheduled run should promote eBPF Observability and Profiling
-to active before selecting its report rather than extending this sequence by
-default.
-
-### Published progress
-
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
-   first-class userspace eBPF needs explicit attachment, capability, state,
-   lifetime, and attribution contracts above ISA compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
-   multi-program problem beyond dispatch and ordering to effect visibility,
-   outcome resolution, shared-state ownership, and versioned hook composition.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
-   object-level replacement from application-level upgrade and developed an
-   explicit prepare / migrate / commit / retire generation protocol for programs,
-   links, maps, pinned state, controller recovery, and rollback.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
-   execution from logical-work causality and developed typed, lifetime-aware
-   handoff edges, an edge-versus-context measurement budget, and a ground-truth
-   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
-   application-defined resources.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
-   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
-   path, then developed a typed capability contract, versioned ring policy
-   generations, explicit provenance, and a comparative control-boundary benchmark.
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed a target manifest,
-   generation-scoped state ownership, and a ground-truth placement/provenance
-   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
-
-The Daily Report index already exposes the sequence. Report-level acquisition and
-navigation evidence is still too young to justify a dedicated public series hub.
-Revisit that decision only when evidence shows a retrieval benefit.
-
-## Queued series — eBPF Observability and Profiling
+## Active series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 
-This is the preferred next series after the runtime/extensibility sequence reaches
-six reports. Its preferred first question is **page-level memory attribution**:
-how to distinguish allocation from pages that were actually touched, faulted,
-reclaimed, migrated, or responsible for memory bandwidth while preserving
-provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
+The `2026-08-18` report starts this series with **page-level memory attribution**.
+It distinguishes allocator intent, resident memory, working-set evidence, page
+lifecycle, and sampled memory cost, then asks how provenance can survive
+`mmap`/`brk`, allocator boundaries, page reuse, reclaim, migration, shared
+mappings, and hardware-dependent sampling.
 
-Candidate topics:
+### Published progress
 
-1. page-level memory attribution: RSS, touched versus untouched allocation,
-   `mmap`/`brk` provenance, page faults, reclaim, migration, and memory bandwidth;
-2. sampling theory for profilers: phase locking, randomized sampling, bias, and
-   confidence intervals;
-3. always-on semantic compression that preserves diagnostic evidence instead of
+1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` develops a
+   lifetime-aware allocation-to-page provenance ledger, access-weighted
+   attribution with explicit confidence, and a ground-truth benchmark spanning
+   reserve-versus-touch, COW, THP, reclaim, refault, and NUMA migration.
+
+### Preferred next questions
+
+1. sampling theory for profilers: phase locking, randomized sampling, bias,
+   variance, and confidence intervals;
+2. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
-4. application-defined resource profiling that combines static discovery,
+3. application-defined resource profiling that combines static discovery,
    runtime eBPF evidence, and online validation;
-5. causal profiling for GPU host-side bottlenecks and megakernel execution;
-6. revisit async and syscall causal profiling only when new mechanism or
-   evaluation evidence materially extends the published causal-profiler report.
+4. causal profiling for GPU host-side bottlenecks and megakernel execution;
+5. revisit async or syscall causal profiling only when a new mechanism or
+   evaluation materially extends the published causal-profiler report.
+
+## Completed series — eBPF Runtime, Extensibility, and Composition
+
+Working question: **What mechanisms are still missing if eBPF is treated as a
+programmable runtime substrate rather than only a kernel observability feature?**
+
+This series reached its normal six-report boundary on `2026-08-17`:
+
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established explicit
+   attachment, capability, state, lifetime, and attribution contracts above ISA
+   compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` developed effect
+   visibility, outcome resolution, state ownership, and versioned composition.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` developed
+   generation-based prepare / migrate / commit / retire semantics.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` developed typed
+   lifetime-aware handoff edges and a causal-attribution benchmark.
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated cBPF request
+   admission from eBPF `io_uring_bpf_ops` execution control and developed a
+   versioned ring policy model.
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
+   backend compatibility from execution placement and developed target manifests
+   and generation-scoped state ownership across kernel, userspace, NIC/DPU, and
+   GPU-side targets.
+
+The Daily Report index already exposes this sequence. A dedicated public series
+hub remains evidence-gated rather than cadence-driven.
 
 ## Queued series — eBPF Networking and Security
 
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-Candidate topics:
-
-1. transactional policy updates across programs, maps, links, and control planes;
-2. multi-tenant network-policy composition and conflict resolution;
-3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
-   userspace eBPF;
-4. information-flow enforcement across process, file, socket, and encrypted
-   application boundaries;
-5. verifier and runtime interfaces for richer stateful policies;
-6. portable policy execution between kernel, userspace, NIC, and DPU targets.
+Candidate topics include transactional policy updates, multi-tenant policy
+composition, zero-copy programmable I/O across XDP/AF_XDP/io_uring/DPDK,
+information-flow enforcement, richer stateful verifier/runtime interfaces, and
+portable policy execution across kernel, userspace, NIC, and DPU targets.
 
 ## Queued series — GPU and Heterogeneous Runtime Systems
 
@@ -168,17 +146,11 @@ runtime is central to the mechanism being evaluated.
 
 ## Queued series — Agent Systems (limited)
 
-Pure Agent systems work is intentionally a minority topic. Use this series only
-for questions with unusually strong systems consequences that are not better
-framed through eBPF, Linux, runtime, observability, or security mechanisms.
-
-Existing anchors:
-
-- `/research/agent-trace-evidence-budget/`
-- `/research/parallel-agent-effect-serializability/`
-
-Because these already occupy the pure-Agent budget in the current small archive,
-do not schedule another pure Agent report until the rolling mix is compliant.
+Pure Agent systems work is intentionally a minority topic. Existing anchors are
+`/research/agent-trace-evidence-budget/` and
+`/research/parallel-agent-effect-serializability/`. Because these already occupy
+the pure-Agent budget in the current small archive, do not schedule another pure
+Agent report until the rolling mix is compliant.
 
 Future Agent reports should preferentially connect back to eBPF or systems
 infrastructure, for example OS-level effect tracing, eBPF policy enforcement,

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -39,10 +39,16 @@ that candidate and continue research on another question in the approved roadmap
 until one passes. Prefer changing the question over padding weak evidence or
 inventing novelty.
 
-A daily report must still provide a concrete reader problem, primary-source
-evidence, a non-trivial gap or unresolved mechanism, a reasoned technical
-conclusion, implementable research directions, and a discriminating evaluation
-or evidence that would change the conclusion.
+A daily report must still provide:
+
+- a concrete reader problem;
+- primary-source evidence;
+- a non-trivial gap or unresolved mechanism;
+- a reasoned technical conclusion;
+- a small number of implementable research directions with academic and
+  production value;
+- a discriminating evaluation or evidence that would change the conclusion;
+- a thesis that does not duplicate an existing report.
 
 ## Series rules
 
@@ -69,67 +75,87 @@ or evidence that would change the conclusion.
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 
-The `2026-08-18` report starts this series with **page-level memory attribution**.
-It distinguishes allocator intent, resident memory, working-set evidence, page
-lifecycle, and sampled memory cost, then asks how provenance can survive
-`mmap`/`brk`, allocator boundaries, page reuse, reclaim, migration, shared
-mappings, and hardware-dependent sampling.
+The `2026-08-18` report starts this series with **page-level memory attribution**:
+how to distinguish allocation from pages that were actually touched, faulted,
+reclaimed, migrated, or responsible for sampled memory cost while preserving
+provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
 ### Published progress
 
-1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` develops a
-   lifetime-aware allocation-to-page provenance ledger, access-weighted
-   attribution with explicit confidence, and a ground-truth benchmark spanning
-   reserve-versus-touch, COW, THP, reclaim, refault, and NUMA migration.
+1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` separates
+   allocation intent, residency, working-set evidence, page lifecycle, and
+   sampled memory cost, then develops a lifetime-aware provenance ledger,
+   access-weighted attribution with explicit confidence, and a ground-truth
+   benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
+   migration.
 
 ### Preferred next questions
 
-1. sampling theory for profilers: phase locking, randomized sampling, bias,
-   variance, and confidence intervals;
+1. sampling theory for profilers: phase locking, randomized sampling, bias, and
+   confidence intervals;
 2. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
 3. application-defined resource profiling that combines static discovery,
    runtime eBPF evidence, and online validation;
 4. causal profiling for GPU host-side bottlenecks and megakernel execution;
-5. revisit async or syscall causal profiling only when a new mechanism or
-   evaluation materially extends the published causal-profiler report.
+5. revisit async and syscall causal profiling only when new mechanism or
+   evaluation evidence materially extends the published causal-profiler report.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
 Working question: **What mechanisms are still missing if eBPF is treated as a
 programmable runtime substrate rather than only a kernel observability feature?**
 
-This series reached its normal six-report boundary on `2026-08-17`:
+This series connected kernel and userspace execution, composition, state,
+upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
+execution placement. It reached the normal six-report series boundary on
+`2026-08-17` and is no longer the default topic source for scheduled publication.
 
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established explicit
-   attachment, capability, state, lifetime, and attribution contracts above ISA
-   compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` developed effect
-   visibility, outcome resolution, state ownership, and versioned composition.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` developed
-   generation-based prepare / migrate / commit / retire semantics.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` developed typed
-   lifetime-aware handoff edges and a causal-attribution benchmark.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated cBPF request
-   admission from eBPF `io_uring_bpf_ops` execution control and developed a
-   versioned ring policy model.
+### Published progress
+
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
+   first-class userspace eBPF needs explicit attachment, capability, state,
+   lifetime, and attribution contracts above ISA compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
+   multi-program problem beyond dispatch and ordering to effect visibility,
+   outcome resolution, shared-state ownership, and versioned hook composition.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
+   object-level replacement from application-level upgrade and developed an
+   explicit prepare / migrate / commit / retire generation protocol for programs,
+   links, maps, pinned state, controller recovery, and rollback.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
+   execution from logical-work causality and developed typed, lifetime-aware
+   handoff edges, an edge-versus-context measurement budget, and a ground-truth
+   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
+   application-defined resources.
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
+   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
+   path, then developed a typed capability contract, versioned ring policy
+   generations, explicit provenance, and a comparative control-boundary benchmark.
 6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed target manifests
-   and generation-scoped state ownership across kernel, userspace, NIC/DPU, and
-   GPU-side targets.
+   backend compatibility from execution placement and developed a target manifest,
+   generation-scoped state ownership, and a ground-truth placement/provenance
+   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
 
-The Daily Report index already exposes this sequence. A dedicated public series
-hub remains evidence-gated rather than cadence-driven.
+The Daily Report index already exposes the sequence. Report-level acquisition and
+navigation evidence is still too young to justify a dedicated public series hub.
+Revisit that decision only when evidence shows a retrieval benefit.
 
 ## Queued series — eBPF Networking and Security
 
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-Candidate topics include transactional policy updates, multi-tenant policy
-composition, zero-copy programmable I/O across XDP/AF_XDP/io_uring/DPDK,
-information-flow enforcement, richer stateful verifier/runtime interfaces, and
-portable policy execution across kernel, userspace, NIC, and DPU targets.
+Candidate topics:
+
+1. transactional policy updates across programs, maps, links, and control planes;
+2. multi-tenant network-policy composition and conflict resolution;
+3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
+   userspace eBPF;
+4. information-flow enforcement across process, file, socket, and encrypted
+   application boundaries;
+5. verifier and runtime interfaces for richer stateful policies;
+6. portable policy execution between kernel, userspace, NIC, and DPU targets.
 
 ## Queued series — GPU and Heterogeneous Runtime Systems
 
@@ -146,11 +172,17 @@ runtime is central to the mechanism being evaluated.
 
 ## Queued series — Agent Systems (limited)
 
-Pure Agent systems work is intentionally a minority topic. Existing anchors are
-`/research/agent-trace-evidence-budget/` and
-`/research/parallel-agent-effect-serializability/`. Because these already occupy
-the pure-Agent budget in the current small archive, do not schedule another pure
-Agent report until the rolling mix is compliant.
+Pure Agent systems work is intentionally a minority topic. Use this series only
+for questions with unusually strong systems consequences that are not better
+framed through eBPF, Linux, runtime, observability, or security mechanisms.
+
+Existing anchors:
+
+- `/research/agent-trace-evidence-budget/`
+- `/research/parallel-agent-effect-serializability/`
+
+Because these already occupy the pure-Agent budget in the current small archive,
+do not schedule another pure Agent report until the rolling mix is compliant.
 
 Future Agent reports should preferentially connect back to eBPF or systems
 infrastructure, for example OS-level effect tracing, eBPF policy enforcement,

--- a/.github/seo-data/daily/2026-08-18.md
+++ b/.github/seo-data/daily/2026-08-18.md
@@ -1,0 +1,119 @@
+# SEO operations — 2026-08-18
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md`: analyze every enabled evidence source, audit technical SEO/GEO behavior, calculate the rolling Daily Report mix, research inside the active series, and publish exactly one new bilingual Daily Report.
+
+The completed Runtime, Extensibility, and Composition sequence reached six reports on August 17, so this run promotes **eBPF Observability and Profiling** to active as the roadmap requires. The selected first question is page-level memory attribution: how to connect application allocation provenance with pages that are actually touched, resident, reclaimed, migrated, or responsible for sampled memory cost.
+
+No unrelated technical SEO implementation change is included because today's evidence does not establish a new crawl, canonical, language-alternate, metadata, structured-data, redirect, rendering, accessibility, performance, or deployment defect.
+
+## Data window
+
+This run used every source currently enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | weekly Drive exports through the set named `2026-08-10_to_2026-08-16_gsc_*.csv`; date, page, query, country, device, and search-appearance dimensions inspected | available; finalized date rows through `2026-08-15` |
+| Google Analytics 4 | weekly organic landing-page export `2026-08-10_to_2026-08-16_ga4_organic_landing_pages.csv` plus the preceding weekly file | available at source-native weekly granularity |
+| Public GitHub | current repository state plus the public-safe portfolio snapshot refreshed on `2026-08-18` | available |
+| Live site | current public homepage plus repository-generated homepage/robots/sitemap/canonical evidence | available |
+| Public web / primary research sources | current Linux `/proc`, Idle Page Tracking, DAMON, page_owner, VM tracepoints, and perf memory-sampling evidence | available |
+| Cloudflare | disabled in repository configuration | not collected by design |
+
+The weekly export beginning `2026-08-10` is new relative to the previous daily run. Missing or delayed analytics are not treated as zero.
+
+With the configured three-day finalization lag, Search Console rows through `2026-08-15` are usable. A complete latest-seven-days versus previous-seven-days comparison is still unavailable because the `2026-08-09` date row is absent across the adjacent weekly exports. The required 28-day comparison is also unavailable because the available history is not long enough. The valid equal-duration comparison is therefore `2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
+
+## Evidence collected
+
+### Search and traffic evidence
+
+For `2026-08-10` through `2026-08-15`, Search Console reports **393 clicks** and **66,510 impressions**, weighted CTR about **0.591%**, and impression-weighted average position about **9.91**. The comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks**, **69,053 impressions**, **0.692%** CTR, and position about **9.42**.
+
+Clicks are about **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage points lower**, and average position about **0.49 positions worse**. The older slice contains the unusual `2026-08-05` day with **24,516 impressions**, so the week-to-week movement is not treated as proof that one page, query family, or technical change caused the decline. Weekly page and query aggregates show mixed movement rather than one site-wide failure. Homepage and branded discovery are softer, while several tutorial and GPU-related pages gain traffic or impressions. Exact private query strings and raw rows remain outside Git.
+
+The GA4 organic landing-page export for `2026-08-10` through `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted engagement. The preceding `2026-08-03` through `2026-08-09` export contains **991 sessions** at about **44.90%** engagement. Sessions are about **2.1% lower** while engagement is effectively flat. `(not set)` increases from **116** to **134 sessions**; excluding that row, sessions decline from **875** to **836**, about **4.5%**. Small landing-page gains and losses are directional signals only. The exported `keyEvents` rows do not provide evidence for a site-outcome conclusion, so no conversion claim is made.
+
+### Public-safe GitHub and technical-site evidence
+
+The repository's public-safe operating brief was refreshed at `2026-08-18 07:59 UTC`. It reports the homepage reachable with HTTP 200 in **227 ms**, `robots.txt` and sitemap reachable, **668** sitemap entries, and canonical homepage `https://eunomia.dev/`. Its portfolio snapshot contains **97 active non-fork repositories**, **9,764 stars**, **1,280 forks**, and **282 open issue/PR records**. The public DEV surface contains 60 observed articles, 43 reactions, and 4 comments. These are operating context, not a blended SEO score.
+
+A fresh public homepage inspection also succeeds and exposes the Daily Report navigation together with the repository's eBPF/runtime, tutorial, and project surfaces. The technical audit found no evidence-backed crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect that warrants an unrelated site patch. Legacy `/en/` traffic remains a monitoring question because the repository intentionally emits redirect compatibility behavior and the current evidence does not demonstrate measurable harm from it.
+
+### Previous-run closeout promoted into current state
+
+PR `#161`, the heterogeneous eBPF execution-placement report, is fully complete. It squash-merged as `78e27707fc63065afa7fa19a25f363a39fcba20a`. Its closeout records successful repository validation, exact production deployment, and bilingual production verification. The report brought the completed archive to **6 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 8** and closed the six-report Runtime, Extensibility, and Composition sequence.
+
+### Rolling Daily Report mix
+
+Before today's publication, the completed archive contains eight reports: **6 eBPF-centered / 2 pure Agent / 0 adjacent systems**. The two pure-Agent reports already occupy the intended minority budget, so today's report remains eBPF-centered.
+
+After the page-level memory-attribution report merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 9**. This remains consistent with the eBPF-first editorial policy.
+
+### Research selection
+
+The broad framing "build a better eBPF memory profiler" was rejected as too vague. Linux and existing eBPF tools already trace allocations, working sets, memory maps, page behavior, and sampled memory accesses in several useful ways.
+
+The narrower question passes the gap gate because those mechanisms observe different identities. The existing Eunomia memleak path records allocator address, size, and stack. Linux `/proc` exposes virtual and resident accounting. Idle Page Tracking can estimate which user pages were referenced. DAMON samples access frequency and age using regions to bound overhead. page_owner records kernel physical-page allocation provenance. `mm_page_alloc`, vmscan, and migration tracepoints expose parts of the page lifecycle. perf memory sampling can observe expensive data accesses on supported hardware.
+
+What is not provided as one stable interface is an application-allocation-to-page provenance chain that survives address reuse, reclaim, copy-on-write, sharing, THP transitions, migration, and sampled access evidence without pretending that every physical page has one unique application owner.
+
+The report therefore develops three testable directions:
+
+1. a lifetime-aware allocation-to-page provenance ledger with explicit virtual-region and page/folio generations;
+2. access-weighted attribution that fuses DAMON and hardware memory samples while preserving sampling confidence and unsupported fields;
+3. a ground-truth benchmark covering reserve-versus-touch, free/reuse, file sharing, COW, THP, reclaim/refault, and NUMA migration.
+
+The report explicitly allows VMA-level provenance plus DAMON to win if page-level lineage does not materially improve real diagnoses. It also keeps shared/file-cache resources multi-owned or resource-owned rather than forcing them into a heap-stack owner.
+
+### Skill and series contract
+
+The repository remains pinned to SEO skill commit `516e9e2dcf012506a677a749049d64c5914643e9`. The consuming repository still names interfaces from that pinned layout, so the submodule is not advanced in isolation.
+
+The previous validation workflow encoded the now-completed Runtime, Extensibility, and Composition series as the required active heading. Because `content-series.md` explicitly instructed the next run to promote eBPF Observability and Profiling, this daily change advances that validation assertion together with the series roadmap rather than leaving the repository contract internally inconsistent.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in this delivery:
+
+- English: `/research/page-level-ebpf-memory-attribution/`
+- Chinese: `/zh/research/page-level-ebpf-memory-attribution/`
+
+Both Daily Report indexes are updated. `content-series.md` promotes eBPF Observability and Profiling to active and records page-level memory attribution as its first report. `plan.md`, `status.md`, `site.md`, and `block.md` are refreshed for the new weekly Google coverage and current series state. The SEO validation workflow is updated only to advance its active-series assertion from the completed series to the newly authoritative active series.
+
+No unrelated technical SEO implementation change is made.
+
+## Validation and self-review contract
+
+- No raw analytics rows, private search queries, Drive IDs, account/property identifiers, credentials, private URLs, or personal information are added to Git.
+- Search Console arithmetic uses equal finalized-duration slices and does not manufacture the missing `2026-08-09` row.
+- GA4 is compared only at its source-native weekly landing-page granularity; zero `keyEvents` rows are not converted into a conversion claim.
+- The current click/CTR decline is monitored rather than converted into a speculative title, navigation, or content rewrite.
+- Central memory claims were checked against current Linux primary documentation/source for `/proc`, Idle Page Tracking, DAMON, page_owner, VM tracepoints, and perf memory sampling.
+- The report distinguishes allocation provenance, residency, working-set evidence, page lifecycle, and sampled access cost instead of calling them one memory metric.
+- Shared pages, COW, address reuse, reclaim, THP, and migration are explicit correctness cases.
+- English and Chinese pages share evidence and conclusions while using language-specific prose.
+- The intended change is limited to one bilingual report, both Daily Report indexes, the active-series validation transition, and directly coupled operating state.
+
+Repository CI remains authoritative for the data validator, Daily Report checks, generated content, static build, links, metadata, and deployment readiness. After CI is green, the complete final PR diff and generated output must receive a clean final self-review before squash merge. The exact squash commit must then pass production `Deploy Static App`, both public language routes must be verified, and one compact closeout comment must be added to the merged PR.
+
+## Delivery
+
+- Branch: `daily/2026-08-18-page-memory-attribution`
+- Pull request: to be opened as one non-draft daily PR
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after expected CI succeeds and the final diff/generated output passes self-review
+- Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, deployment, bilingual verification, source coverage, series classification, and remaining uncertainty; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Complete and verify today's page-level eBPF memory-attribution report through the exact merge/deployment/public-page contract.
+2. Continue **eBPF Observability and Profiling** with profiler sampling theory unless that question fails the evidence or novelty gate.
+3. Keep another pure-Agent report out of the current small rolling window.
+4. Keep the complete GSC 7-day and 28-day comparisons unavailable until source coverage supports them.
+5. Monitor the Search Console click/CTR decline across another finalized period before changing titles, copy, or navigation.
+6. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+7. Investigate GA4 `(not set)` and legacy `/en/` traffic only with richer source-native evidence.
+8. Migrate the consuming SEO contract before advancing the pinned SEO-skill submodule.
+9. Add Cloudflare evidence only when repository configuration enables a supported read-only source.

--- a/.github/seo-data/daily/2026-08-18.md
+++ b/.github/seo-data/daily/2026-08-18.md
@@ -101,7 +101,7 @@ Repository CI remains authoritative for the data validator, Daily Report checks,
 ## Delivery
 
 - Branch: `daily/2026-08-18-page-memory-attribution`
-- Pull request: to be opened as one non-draft daily PR
+- Pull request: `#162`
 - Production target: GitHub Pages through `Deploy Static App`
 - Merge policy: squash merge only after expected CI succeeds and the final diff/generated output passes self-review
 - Closeout policy: one compact comment on the merged daily PR records the exact squash commit, CI, deployment, bilingual verification, source coverage, series classification, and remaining uncertainty; no second closeout PR

--- a/.github/seo-data/daily/2026-08-18.md
+++ b/.github/seo-data/daily/2026-08-18.md
@@ -15,7 +15,7 @@ This run used every source currently enabled by `.github/seo-data/site.md`.
 | Source | Coverage used | State |
 | --- | --- | --- |
 | Google Search Console | weekly Drive exports through the set named `2026-08-10_to_2026-08-16_gsc_*.csv`; date, page, query, country, device, and search-appearance dimensions inspected | available; finalized date rows through `2026-08-15` |
-| Google Analytics 4 | weekly organic landing-page export `2026-08-10_to_2026-08-16_ga4_organic_landing_pages.csv` plus the preceding weekly file | available at source-native weekly granularity |
+| Google Analytics 4 | weekly organic landing-page export `2026-08-10_to_2026-08-16_ga4_organic_landing_pages.csv` plus the preceding weekly file | available, but the newest weekly aggregate is provisional because it includes `2026-08-16` and has no date dimension for trimming the unfinalized day |
 | Public GitHub | current repository state plus the public-safe portfolio snapshot refreshed on `2026-08-18` | available |
 | Live site | current public homepage plus repository-generated homepage/robots/sitemap/canonical evidence | available |
 | Public web / primary research sources | current Linux `/proc`, Idle Page Tracking, DAMON, page_owner, VM tracepoints, and perf memory-sampling evidence | available |
@@ -25,6 +25,8 @@ The weekly export beginning `2026-08-10` is new relative to the previous daily r
 
 With the configured three-day finalization lag, Search Console rows through `2026-08-15` are usable. A complete latest-seven-days versus previous-seven-days comparison is still unavailable because the `2026-08-09` date row is absent across the adjacent weekly exports. The required 28-day comparison is also unavailable because the available history is not long enough. The valid equal-duration comparison is therefore `2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
 
+The newest GA4 file cannot be reduced to the same finalized boundary because it is a weekly landing-page aggregate without a date column. Since it includes `2026-08-16`, which is still inside the configured three-day lag on `2026-08-18`, its week-over-week numbers are reported only as provisional directional evidence. The latest fully finalized GA4 weekly comparison remains the preceding `2026-08-03` through `2026-08-09` export against `2026-07-27` through `2026-08-02`.
+
 ## Evidence collected
 
 ### Search and traffic evidence
@@ -33,7 +35,7 @@ For `2026-08-10` through `2026-08-15`, Search Console reports **393 clicks** and
 
 Clicks are about **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage points lower**, and average position about **0.49 positions worse**. The older slice contains the unusual `2026-08-05` day with **24,516 impressions**, so the week-to-week movement is not treated as proof that one page, query family, or technical change caused the decline. Weekly page and query aggregates show mixed movement rather than one site-wide failure. Homepage and branded discovery are softer, while several tutorial and GPU-related pages gain traffic or impressions. Exact private query strings and raw rows remain outside Git.
 
-The GA4 organic landing-page export for `2026-08-10` through `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted engagement. The preceding `2026-08-03` through `2026-08-09` export contains **991 sessions** at about **44.90%** engagement. Sessions are about **2.1% lower** while engagement is effectively flat. `(not set)` increases from **116** to **134 sessions**; excluding that row, sessions decline from **875** to **836**, about **4.5%**. Small landing-page gains and losses are directional signals only. The exported `keyEvents` rows do not provide evidence for a site-outcome conclusion, so no conversion claim is made.
+The provisional GA4 organic landing-page export for `2026-08-10` through `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted engagement. The preceding finalized `2026-08-03` through `2026-08-09` export contains **991 sessions** at about **44.90%** engagement. Directionally, the weekly aggregate is about **2.1% lower** in sessions while engagement is effectively flat. `(not set)` increases from **116** to **134 sessions**; excluding that row, sessions are **836** versus **875**, about **4.5% lower**. Because the newer file contains an unfinalized day and cannot be trimmed, these figures are not treated as a finalized week-over-week trend. Small landing-page gains and losses are directional signals only. The exported `keyEvents` rows do not provide evidence for a site-outcome conclusion, so no conversion claim is made.
 
 ### Public-safe GitHub and technical-site evidence
 
@@ -88,7 +90,7 @@ No unrelated technical SEO implementation change is made.
 
 - No raw analytics rows, private search queries, Drive IDs, account/property identifiers, credentials, private URLs, or personal information are added to Git.
 - Search Console arithmetic uses equal finalized-duration slices and does not manufacture the missing `2026-08-09` row.
-- GA4 is compared only at its source-native weekly landing-page granularity; zero `keyEvents` rows are not converted into a conversion claim.
+- The newest GA4 weekly aggregate is treated as provisional because it contains `2026-08-16` and cannot be trimmed to the finalized boundary; zero `keyEvents` rows are not converted into a conversion claim.
 - The current click/CTR decline is monitored rather than converted into a speculative title, navigation, or content rewrite.
 - Central memory claims were checked against current Linux primary documentation/source for `/proc`, Idle Page Tracking, DAMON, page_owner, VM tracepoints, and perf memory sampling.
 - The report distinguishes allocation provenance, residency, working-set evidence, page lifecycle, and sampled access cost instead of calling them one memory metric.

--- a/.github/seo-data/daily/2026-08-18.md
+++ b/.github/seo-data/daily/2026-08-18.md
@@ -51,7 +51,7 @@ PR `#161`, the heterogeneous eBPF execution-placement report, is fully complete.
 
 Before today's publication, the completed archive contains eight reports: **6 eBPF-centered / 2 pure Agent / 0 adjacent systems**. The two pure-Agent reports already occupy the intended minority budget, so today's report remains eBPF-centered.
 
-After the page-level memory-attribution report merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 9**. This remains consistent with the eBPF-first editorial policy.
+After the page-level memory-attribution report merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 9**. This is the last pre-ten-report state. The next publication creates the first full rolling window and therefore must be a genuine adjacent-systems report that is neither eBPF-centered nor pure Agent, yielding **7 eBPF / 2 Agent / 1 adjacent out of 10**. An eBPF-essential active-series candidate should be deferred for one run rather than reclassified.
 
 ### Research selection
 
@@ -111,7 +111,7 @@ Repository CI remains authoritative for the data validator, Daily Report checks,
 ## Decisions and follow-ups
 
 1. Complete and verify today's page-level eBPF memory-attribution report through the exact merge/deployment/public-page contract.
-2. Continue **eBPF Observability and Profiling** with profiler sampling theory unless that question fails the evidence or novelty gate.
+2. Make the next publication a genuine adjacent-systems report so the first full ten-report window is 7 eBPF / 2 Agent / 1 adjacent. Profiler sampling theory is eligible only if the actual central mechanism is general profiling rather than eBPF; otherwise defer it for one run.
 3. Keep another pure-Agent report out of the current small rolling window.
 4. Keep the complete GSC 7-day and 28-day comparisons unavailable until source coverage supports them.
 5. Monitor the Search Console click/CTR decline across another finalized period before changing titles, copy, or navigation.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,20 +71,24 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Continue the active **eBPF Observability and Profiling** series after the
-   page-level memory attribution report. Prefer the next distinct mechanism
-   question on profiler sampling theory: phase locking, randomized sampling,
-   bias, variance, and confidence intervals. Use always-on semantic compression
-   or application-defined resource profiling if that question fails the evidence
-   or novelty gate.
-2. Keep pure-Agent reports capped while the archive is small. After the current
-   memory-attribution report merges, the rolling archive becomes **7
-   eBPF-centered / 2 pure Agent / 0 adjacent out of 9**, so the next report should
-   remain eBPF-centered or directly adjacent.
+1. Preserve the exact rolling topic mix when the archive reaches ten reports. The
+   current page-level memory-attribution report makes the archive **7
+   eBPF-centered / 2 pure Agent / 0 adjacent out of 9**. The next published report
+   therefore must be a genuine **adjacent-systems** report that is neither
+   eBPF-centered nor pure Agent, yielding 7 / 2 / 1 in the first full ten-report
+   window. Do not relabel an eBPF-essential question merely to satisfy the ratio.
+2. Keep **eBPF Observability and Profiling** as the active series, but defer its
+   next eBPF-essential report for one run if necessary. Profiler sampling theory
+   may be the next report only if the actual central question is a general
+   profiling problem rather than an eBPF mechanism; otherwise select another
+   approved adjacent-systems question, then return to the active series afterward.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   The new `2026-08-10` weekly set is now available. Keep accumulating history
-   until complete previous-7-day and 28-day comparisons can be made without
-   inventing the missing `2026-08-09` Search Console row or earlier history.
+   The new `2026-08-10` weekly set is available, but the newest GA4 weekly
+   aggregate is provisional on `2026-08-18` because it includes `2026-08-16`
+   inside the configured three-day finalization lag and has no date dimension for
+   trimming. Keep accumulating history until complete previous-7-day and 28-day
+   comparisons can be made without inventing the missing `2026-08-09` Search
+   Console row or earlier history.
 4. Obtain or generate date-by-page or date-by-query Search Console evidence before
    attributing the `2026-08-05` impression spike to a specific page or query family.
 5. Monitor the current Search Console click/CTR decline and homepage/branded

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -52,6 +52,9 @@ durable goals and constraints, not duplicated scheduler instructions.
   the Daily Report may not be skipped.
 - Keep the rolling topic mix compliant and classify by the report's actual central
   mechanism, not by superficial keyword mentions.
+- Do not combine unrelated technical SEO and content work when that makes the
+  daily pull request incoherent; put unrelated durable SEO work in this plan for a
+  focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review
   and squash merge.
 - Every daily report is a public change, so the exact squash commit must deploy

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -52,9 +52,6 @@ durable goals and constraints, not duplicated scheduler instructions.
   the Daily Report may not be skipped.
 - Keep the rolling topic mix compliant and classify by the report's actual central
   mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the
-  daily pull request incoherent; put unrelated durable SEO work in this plan for a
-  focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review
   and squash merge.
 - Every daily report is a public change, so the exact squash commit must deploy
@@ -71,32 +68,36 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Start the **eBPF Observability and Profiling** series after completing the
-   six-report Runtime, Extensibility, and Composition sequence. Prefer the next
-   mechanism question on page-level memory attribution: distinguish reserved or
-   allocated memory from pages actually touched, faulted, reclaimed, migrated, or
-   responsible for bandwidth, while preserving `mmap`/`brk`, allocator, runtime,
-   and process provenance.
+1. Continue the active **eBPF Observability and Profiling** series after the
+   page-level memory attribution report. Prefer the next distinct mechanism
+   question on profiler sampling theory: phase locking, randomized sampling,
+   bias, variance, and confidence intervals. Use always-on semantic compression
+   or application-defined resource profiling if that question fails the evidence
+   or novelty gate.
 2. Keep pure-Agent reports capped while the archive is small. After the current
-   heterogeneous-placement report merges, the rolling archive becomes 6
-   eBPF-centered / 2 pure Agent / 0 adjacent out of 8, so the next report should
-   remain eBPF-centered or directly adjacent rather than add another pure-Agent
-   report.
-3. Use both verified weekly Search Console and GA4 Drive export sets in every run.
-   Keep accumulating history until a complete previous-7-day and 28-day comparison
-   can be made without inventing missing dates.
+   memory-attribution report merges, the rolling archive becomes **7
+   eBPF-centered / 2 pure Agent / 0 adjacent out of 9**, so the next report should
+   remain eBPF-centered or directly adjacent.
+3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
+   The new `2026-08-10` weekly set is now available. Keep accumulating history
+   until complete previous-7-day and 28-day comparisons can be made without
+   inventing the missing `2026-08-09` Search Console row or earlier history.
 4. Obtain or generate date-by-page or date-by-query Search Console evidence before
    attributing the `2026-08-05` impression spike to a specific page or query family.
-5. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as technical SEO
-   evidence rather than letting those issues distort content selection.
-6. Add Cloudflare coverage when a supported read-only route is available.
-7. Use search behavior, GitHub activity, primary research, kernel changes, and
+5. Monitor the current Search Console click/CTR decline and homepage/branded
+   softness across another finalized period before changing titles, copy, or site
+   structure; the current movement is not uniform enough to justify a speculative
+   SEO patch.
+6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as measurement
+   and technical SEO evidence rather than letting them distort content selection.
+7. Add Cloudflare coverage when a supported read-only route is available.
+8. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside the approved eBPF and adjacent
    systems series.
-8. Revisit a dedicated public hub for the completed eBPF runtime series only after
+9. Revisit a dedicated public hub for the completed eBPF runtime series only after
    report-level acquisition or navigation evidence shows that it would improve
    retrieval beyond the existing Daily Report index.
-9. Migrate the consuming SEO contract before moving the pinned `seo-skills`
-   submodule to a newer upstream layout that removed interfaces this repository
-   still calls. Upstream movement alone is not evidence that a pointer-only bump
-   is safe.
+10. Migrate the consuming SEO contract before moving the pinned `seo-skills`
+    submodule to a newer upstream layout that removed interfaces this repository
+    still calls. Upstream movement alone is not evidence that a pointer-only bump
+    is safe.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,7 +32,7 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified export window: `2026-07-27` through `2026-08-09`; the newest Search Console date export currently has rows through `2026-08-08`
+- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
 The Drive folder is discovered by its configured name. Do not store its folder ID,
@@ -50,16 +50,18 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-Search Console and GA4 exports provide two adjacent weekly export sets,
-`2026-07-27` through `2026-08-02` and `2026-08-03` through `2026-08-09`. As of
-`2026-08-12`, the full GA4 weekly export through `2026-08-09` is beyond the
-configured three-day finalization lag and can be compared with the preceding
-weekly export. Search Console date rows still stop at `2026-08-08`; its complete
-latest-7-days versus previous-7-days comparison remains unavailable because the
-required preceding period begins on `2026-07-26`, one day before the available
-history. The 28-day comparison is also unavailable. Public repository and
-live-site data supplement these exports but do not replace their source-native
-meanings.
+Search Console and GA4 exports now provide weekly sets for `2026-07-27` through
+`2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
+`2026-08-16`. With the three-day finalization lag on `2026-08-18`, Search Console
+rows through `2026-08-15` are usable. The `2026-08-09` Search Console date row is
+still absent across the adjacent files, so a complete latest-7-days versus
+previous-7-days comparison remains unavailable. A valid equal-duration six-day
+comparison is `2026-08-10` through `2026-08-15` versus `2026-08-03` through
+`2026-08-08`. The 28-day comparison is also unavailable because the export
+history is not long enough. GA4 weekly landing-page exports can be compared at
+their source-native weekly granularity but have no date dimension for trimming a
+partial day within a file. Public repository and live-site data supplement these
+exports but do not replace their source-native meanings.
 
 ## Deployment
 

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,7 +32,7 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`
+- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`; the newest GA4 weekly aggregate includes `2026-08-16` and is provisional on `2026-08-18`
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
 The Drive folder is discovered by its configured name. Do not store its folder ID,
@@ -58,10 +58,17 @@ still absent across the adjacent files, so a complete latest-7-days versus
 previous-7-days comparison remains unavailable. A valid equal-duration six-day
 comparison is `2026-08-10` through `2026-08-15` versus `2026-08-03` through
 `2026-08-08`. The 28-day comparison is also unavailable because the export
-history is not long enough. GA4 weekly landing-page exports can be compared at
-their source-native weekly granularity but have no date dimension for trimming a
-partial day within a file. Public repository and live-site data supplement these
-exports but do not replace their source-native meanings.
+history is not long enough.
+
+GA4 weekly landing-page exports have no date dimension for trimming a partial or
+unfinalized day within a file. On `2026-08-18`, the newest `2026-08-10` through
+`2026-08-16` aggregate therefore remains provisional because `2026-08-16` is
+inside the configured three-day finalization lag. It may be used as directional
+source-native evidence, but not as a finalized week-over-week comparison. The
+latest fully finalized GA4 weekly comparison remains `2026-08-03` through
+`2026-08-09` versus `2026-07-27` through `2026-08-02`. Public repository and
+live-site data supplement these exports but do not replace their source-native
+meanings.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -35,6 +35,12 @@ merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent system
 out of 9**. The repository has promoted **eBPF Observability and Profiling** to
 the active series; page-level memory attribution is its first report.
 
+The next publication will create the first full ten-report window. It must be a
+genuine adjacent-systems report that is neither eBPF-centered nor pure Agent, so
+the resulting window is **7 eBPF / 2 Agent / 1 adjacent out of 10**. An
+eBPF-essential active-series question must be deferred for that one run rather
+than relabeled.
+
 ## Current signals
 
 - Repository-generated public-safe operating brief: refreshed `2026-08-18 07:59 UTC`
@@ -106,7 +112,7 @@ the daily change.
 ## Current focus
 
 1. Complete the `2026-08-18` page-level memory-attribution Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
-2. Continue the active **eBPF Observability and Profiling** series with profiler sampling theory unless that candidate fails the evidence or novelty gate.
+2. For the next publication, select a real adjacent-systems question that keeps the first full ten-report window at 7 eBPF / 2 Agent / 1 adjacent. Use profiler sampling theory only if its central mechanism is genuinely general profiling rather than eBPF; otherwise defer the active-series question for one run.
 3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Monitor the current click/CTR decline across another finalized period before changing search-facing titles, copy, or navigation.
 5. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -8,7 +8,7 @@
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
 - Last completed daily run: `2026-08-17`
-- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page export through `2026-08-16`
+- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16` with the newest aggregate provisional under the three-day finalization lag
 - Latest daily record: `2026-08-18`
 - Last completed public-change pull request: `#161`
 - Last verified production deployment from a daily run: `Deploy Static App` run `32043791981` for squash commit `78e27707fc63065afa7fa19a25f363a39fcba20a`
@@ -45,7 +45,7 @@ the active series; page-level memory attribution is its first report.
 - Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories, 9,764 stars, 1,280 forks, and 282 open issue/PR records across the portfolio snapshot
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments in the current public-safe brief
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`
+- Google Analytics 4: weekly organic landing-page files are available through `2026-08-16`; the newest `2026-08-10` through `2026-08-16` aggregate is provisional on `2026-08-18` because it includes a day inside the configured finalization lag and has no date dimension for trimming
 - Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
 - Cloudflare: disabled by repository configuration
 
@@ -65,14 +65,17 @@ unavailable because the `2026-08-09` date row is absent across the adjacent
 weekly files. The required 28-day comparison is also unavailable rather than
 inferred.
 
-The GA4 organic landing-page export for `2026-08-10` through `2026-08-16`
+The newest GA4 organic landing-page file for `2026-08-10` through `2026-08-16`
 contains **970 sessions** at about **44.95%** session-weighted engagement, versus
-**991 sessions** at about **44.90%** for `2026-08-03` through `2026-08-09`.
-Sessions are about **2.1% lower** while engagement is effectively flat. `(not
-set)` increased from **116** to **134 sessions**; excluding it, sessions declined
-from **875** to **836**, about **4.5%**. This remains a measurement-quality and
-traffic-mix signal, not sufficient evidence for a speculative title, copy, or
-site-structure change.
+**991 sessions** at about **44.90%** in the preceding `2026-08-03` through
+`2026-08-09` export. `(not set)` is **134 versus 116 sessions**; excluding it,
+sessions are **836 versus 875**. These newest figures are directional only, not a
+finalized week-over-week trend, because `2026-08-16` is still inside the
+configured three-day lag and the file has no date dimension for removing that
+day. The latest fully finalized weekly GA4 comparison therefore remains
+`2026-08-03` through `2026-08-09` versus `2026-07-27` through `2026-08-02`.
+None of this is sufficient evidence for a speculative title, copy, measurement,
+or site-structure change.
 
 ## Current technical baseline
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -6,19 +6,20 @@
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
+- Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
 - Last completed daily run: `2026-08-17`
 - Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page export through `2026-08-16`
 - Latest daily record: `2026-08-18`
 - Last completed public-change pull request: `#161`
-- Last verified production deployment from a daily run: `Deploy Static App` for squash commit `78e27707fc63065afa7fa19a25f363a39fcba20a`
+- Last verified production deployment from a daily run: `Deploy Static App` run `32043791981` for squash commit `78e27707fc63065afa7fa19a25f363a39fcba20a`
 - Current daily branch: `daily/2026-08-18-page-memory-attribution`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
 PR `#161` is fully closed out. It squash-merged as
-`78e27707fc63065afa7fa19a25f363a39fcba20a`; its exact commit passed the
-repository validation and production `Deploy Static App` workflow, and the
-merged-PR closeout records bilingual production verification. The published
-heterogeneous-placement report completed the six-report **eBPF Runtime,
+`78e27707fc63065afa7fa19a25f363a39fcba20a`; exact-commit `Validate SEO Operations`
+run `32043791965` and production `Deploy Static App` run `32043791981` succeeded,
+and the merged-PR closeout records bilingual production verification. The
+published heterogeneous-placement report completed the six-report **eBPF Runtime,
 Extensibility, and Composition** sequence.
 
 ## Current Daily Report mix

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -6,75 +6,108 @@
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
-- Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-16`
-- Last verified data window: Search Console rows through `2026-08-08`; finalized GA4 weekly export through `2026-08-09`
-- Latest daily record: `2026-08-17`
-- Last completed public-change pull request: `#160`
-- Last verified production deployment from a daily run: `Deploy Static App` run `31958113001` for squash commit `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`
-- Current daily branch: `daily/2026-08-17-heterogeneous-ebpf-placement`
+- Last completed daily run: `2026-08-17`
+- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page export through `2026-08-16`
+- Latest daily record: `2026-08-18`
+- Last completed public-change pull request: `#161`
+- Last verified production deployment from a daily run: `Deploy Static App` for squash commit `78e27707fc63065afa7fa19a25f363a39fcba20a`
+- Current daily branch: `daily/2026-08-18-page-memory-attribution`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#160` is fully closed out. It squash-merged as `d72d4d4ed89ec4945e0447e3bb1fc079ca4251b0`; the exact commit passed `Validate SEO Operations` run `31958113036` and `Deploy Static App` run `31958113001`. The merged pull request has one conversation comment and no review comments, consistent with the repository's one-closeout-comment contract.
-
-The published io_uring report moved the archive to seven reports and completed the fifth eBPF-centered entry. The current August 17 branch begins from the latest default branch after that closeout and adds the sixth, final report in the Runtime, Extensibility, and Composition series.
+PR `#161` is fully closed out. It squash-merged as
+`78e27707fc63065afa7fa19a25f363a39fcba20a`; its exact commit passed the
+repository validation and production `Deploy Static App` workflow, and the
+merged-PR closeout records bilingual production verification. The published
+heterogeneous-placement report completed the six-report **eBPF Runtime,
+Extensibility, and Composition** sequence.
 
 ## Current Daily Report mix
 
-Before the current change, the completed archive contains seven reports:
+Before the current change, the completed archive contains eight reports:
 
-- eBPF-centered: **5 of 7**
-  - `/research/io-uring-bpf-programmability/`
-  - `/research/async-ebpf-causal-profiler/`
-  - `/research/stateful-ebpf-transactional-upgrade/`
-  - `/research/ebpf-hook-composition-contract/`
-  - `/research/userspace-ebpf-runtime-contract/`
-- pure Agent-centered: **2 of 7**
-  - `/research/agent-trace-evidence-budget/`
-  - `/research/parallel-agent-effect-serializability/`
-- adjacent systems: **0 of 7**
+- eBPF-centered: **6 of 8**
+- pure Agent-centered: **2 of 8**
+- adjacent systems: **0 of 8**
 
-The current heterogeneous-placement report is eBPF-centered. After it merges, the archive becomes **6 eBPF-centered / 2 pure Agent / 0 adjacent systems out of 8**. This stays within the editorial policy. It also brings the Runtime, Extensibility, and Composition series to its normal six-report boundary, so the repository roadmap advances the next run to **eBPF Observability and Profiling** rather than extending the current series indefinitely.
+The current page-level memory-attribution report is eBPF-centered. After it
+merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent systems
+out of 9**. The repository has promoted **eBPF Observability and Profiling** to
+the active series; page-level memory attribution is its first report.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-17 08:05 UTC`
-- Homepage: HTTP 200 in the current operating brief, observed in **192 ms**
+- Repository-generated public-safe operating brief: refreshed `2026-08-18 07:59 UTC`
+- Homepage: HTTP 200 in the current operating brief, observed in **227 ms**
 - `robots.txt`: reachable; sitemap: reachable
-- Sitemap entries observed: **664**
+- Sitemap entries observed: **668**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories, 9,756 stars, 1,275 forks, and 278 open issue/PR records across the portfolio snapshot
-- DEV publication surface: 59 articles, 43 public reactions, and 4 comments in the current public-safe brief
+- Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories, 9,764 stars, 1,280 forks, and 282 open issue/PR records across the portfolio snapshot
+- DEV publication surface: 60 articles, 43 public reactions, and 4 comments in the current public-safe brief
 - Public web and primary-source evidence: available
-- Google Analytics 4: two adjacent weekly Drive organic landing-page exports available and finalized through `2026-08-09`
-- Google Search Console: two adjacent weekly export sets available; current date rows still end on `2026-08-08`
-- Newer weekly Google export beginning `2026-08-10`: not found in the configured Drive folder on `2026-08-17`
+- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`
+- Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
 - Cloudflare: disabled by repository configuration
 
-The Google exports remain usable historical evidence but are stale relative to today. A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the source does not provide both complete adjacent windows; the required 28-day comparison is also unavailable rather than inferred.
+The newest Google weekly export is now available and materially changes the
+operating evidence. For the valid equal-duration Search Console comparison,
+`2026-08-10` through `2026-08-15` reports **393 clicks / 66,510 impressions**,
+weighted CTR about **0.591%**, and impression-weighted average position about
+**9.91**. The comparable `2026-08-03` through `2026-08-08` slice reports **478
+clicks / 69,053 impressions**, **0.692%** CTR, and position about **9.42**. Clicks
+are about **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101
+percentage points lower**, and average position about **0.49 positions worse**.
+The old comparison includes the unusual `2026-08-05` impression spike, so this
+movement is monitored rather than attributed to one page or content change.
 
-The valid common-duration GSC comparison remains **478 clicks / 69,053 impressions** for `2026-08-03` through `2026-08-08`, versus **409 / 46,327** for `2026-07-28` through `2026-08-02`. Clicks are about **16.9% higher** and impressions about **49.1% higher**. Weighted CTR moved from about **0.883%** to **0.692%**, and impression-weighted average position from about **8.18** to **9.42**. `2026-08-05` contributes **24,516 impressions**, about **35.5%** of the newer slice, and still cannot be attributed to one page or query without date-by-page or date-by-query evidence.
+A complete latest-seven-days versus previous-seven-days GSC comparison remains
+unavailable because the `2026-08-09` date row is absent across the adjacent
+weekly files. The required 28-day comparison is also unavailable rather than
+inferred.
 
-The finalized GA4 comparison remains **991 sessions** at about **44.90%** session-weighted engagement for `2026-08-03` through `2026-08-09`, versus **1,021 sessions** at about **46.72%** for `2026-07-27` through `2026-08-02`. `(not set)` fell from 157 to 116 sessions; excluding it, sessions increased slightly from 864 to 875. These remain directional measurement signals, not evidence for an unrelated content or SEO rewrite.
+The GA4 organic landing-page export for `2026-08-10` through `2026-08-16`
+contains **970 sessions** at about **44.95%** session-weighted engagement, versus
+**991 sessions** at about **44.90%** for `2026-08-03` through `2026-08-09`.
+Sessions are about **2.1% lower** while engagement is effectively flat. `(not
+set)` increased from **116** to **134 sessions**; excluding it, sessions declined
+from **875** to **836**, about **4.5%**. This remains a measurement-quality and
+traffic-mix signal, not sufficient evidence for a speculative title, copy, or
+site-structure change.
 
 ## Current technical baseline
 
-The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and HTTP audit artifacts. Production deploys through `Deploy Static App`.
+The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
+structured data, legacy redirect stubs, and HTTP audit artifacts. Production
+deploys through `Deploy Static App`.
 
-The August 17 operating evidence does not establish a new crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect. The current homepage, robots, sitemap, and canonical checks are healthy in the public-safe operating brief. The correct public site change for this run is therefore the mandatory new Daily Report and its directly coupled bilingual index/navigation entries, not an unrelated technical SEO patch.
+The August 18 public-safe operating brief and live homepage inspection do not
+establish a new crawl, canonical, hreflang, structured-data, redirect,
+broken-link, rendering, accessibility, performance, or deployment defect. The
+correct public site change for this run is therefore the mandatory new bilingual
+Daily Report and directly coupled index/series updates, not an unrelated
+technical SEO patch.
 
-Today's research separates backend compatibility from execution placement. RFC 9669 provides ISA conformance groups, Linux verifier and hardware-offload code show that context/helper/offload semantics remain target-specific, and primary systems work such as hXDP, gpu_ext, and fabric_ext demonstrates both the value and the specialization cost of moving BPF execution toward NIC, GPU, and fabric-side events. The report therefore develops a placement-aware target manifest, generation-scoped state ownership and migration, and a ground-truth placement/provenance benchmark rather than duplicating the earlier portable-runtime-contract thesis.
+Today's research separates allocation intent, residency, working-set evidence,
+page lifecycle, and sampled access cost. Linux `/proc`, Idle Page Tracking,
+DAMON, page_owner, VM tracepoints, and perf memory sampling each expose a useful
+slice but do not provide one stable application-allocation-to-page provenance
+chain. The report develops a lifetime-aware provenance ledger, access-weighted
+attribution with explicit confidence, and a ground-truth memory-attribution
+benchmark.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream is now at `f42128a3f05c73cf10c786a2711c488bb3a14839` and includes a newer operating layout plus off-site visibility collection. This repository still names interfaces from the pinned layout, so an unrelated pointer-only submodule bump is not made in the current daily PR.
+The SEO skill submodule remains pinned at
+`516e9e2dcf012506a677a749049d64c5914643e9`. The consuming repository still
+names interfaces from that pinned layout, so no pointer-only bump is included in
+the daily change.
 
 ## Current focus
 
-1. Complete the `2026-08-17` heterogeneous eBPF execution-placement Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
-2. Start the next run inside the active **eBPF Observability and Profiling** series, with page-level memory attribution as the preferred first question unless evidence rejects it.
-3. Keep required GSC 7-day and 28-day comparisons unavailable until complete source history exists; never treat missing exports as zero.
-4. Obtain date-by-page or date-by-query Search Console evidence before attributing the `2026-08-05` impression spike.
-5. Investigate GA4 `(not set)` only with richer source-native dimensions before making a measurement or content change.
-6. Migrate the consuming SEO contract before updating the skill submodule pointer.
-7. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.
+1. Complete the `2026-08-18` page-level memory-attribution Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
+2. Continue the active **eBPF Observability and Profiling** series with profiler sampling theory unless that candidate fails the evidence or novelty gate.
+3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
+4. Monitor the current click/CTR decline across another finalized period before changing search-facing titles, copy, or navigation.
+5. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
+7. Migrate the consuming SEO contract before updating the skill submodule pointer.
+8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.
 
 Detailed history belongs in `.github/seo-data/daily/` and the merged daily pull requests.

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -85,7 +85,7 @@ jobs:
           # Topic mix is a repository-enforced editorial contract.
           assert "5–7 of 10" in series_flat
           assert "Pure AI-agent topics are capped at 1–2 of 10" in series_flat
-          assert "Active series — eBPF Runtime, Extensibility, and Composition" in series_flat
+          assert "Active series — eBPF Observability and Profiling" in series_flat
           PY
 
       - name: Set up Python

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can eBPF Attribute Memory to the Pages That Actually Matter?](https://eunomia.dev/research/page-level-ebpf-memory-attribution/)
+
+Allocation stacks, RSS, page hotness, reclaim, migration, and hardware memory samples describe different parts of memory cost. This report develops a lifetime-aware provenance chain from application allocations to virtual-region generations and page activity, access-weighted attribution with explicit confidence, and a ground-truth benchmark for deciding when page-level lineage is worth its overhead.
+
 ### [Where Should eBPF Run in a Heterogeneous System?](https://eunomia.dev/research/heterogeneous-ebpf-execution-placement/)
 
 Kernel, userspace, SmartNIC, and GPU-side runtimes can all be valid homes for eBPF logic, but they do not expose the same events, state, memory, authority, or verifier environment. This report develops a placement-aware target manifest, generation-scoped state ownership, and a ground-truth benchmark for choosing execution location without silently changing policy semantics.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 能把内存开销归因到真正使用的页面吗？](https://eunomia.dev/zh/research/page-level-ebpf-memory-attribution/)
+
+分配调用栈、RSS、页面热度、回收、迁移和硬件内存采样描述的是不同层次的成本。本文提出从应用分配到虚拟区间 generation 和页面活动的生命周期 provenance、带明确置信度的访问加权归因，以及用于判断逐页 lineage 是否值得其开销的 ground-truth benchmark。
+
 ### [异构系统里的 eBPF 到底应该运行在哪里？](https://eunomia.dev/zh/research/heterogeneous-ebpf-execution-placement/)
 
 内核、用户态、SmartNIC 与 GPU-side runtime 都可能是 eBPF 的合法执行位置，但它们暴露的事件、状态、内存、权限与 verifier 环境并不相同。本文提出 placement-aware target manifest、以 generation 为边界的状态归属，以及用于选择执行位置并检查语义是否保持一致的 ground-truth benchmark。

--- a/docs/research/page-level-ebpf-memory-attribution.md
+++ b/docs/research/page-level-ebpf-memory-attribution.md
@@ -1,0 +1,225 @@
+---
+date: 2026-08-18
+title: "Can eBPF Attribute Memory to the Pages That Actually Matter?"
+description: "Memory allocation, RSS, and page hotness answer different questions. This report asks how eBPF can connect allocation provenance to the pages actually used."
+tags:
+  - Daily Report
+  - eBPF
+  - Memory Profiling
+  - Linux Memory Management
+  - Observability
+  - Performance
+research_question: "How can an eBPF-based memory profiler connect application allocation provenance to the virtual and physical pages that are actually touched, faulted, reclaimed, migrated, or responsible for memory traffic without pretending that every page has one stable owner?"
+source_cutoff: 2026-08-18
+status: daily-report
+---
+
+# Can eBPF Attribute Memory to the Pages That Actually Matter?
+
+A service reserves a 64 GiB virtual arena at startup. During a normal request burst it touches only 3 GiB, keeps 2 GiB resident, faults some cold pages back in, shares file-backed pages with helper processes, and periodically moves pages between NUMA nodes. A heap profiler says which call sites requested bytes. `/proc/<pid>/smaps` says how much of each mapping is resident. DAMON can estimate which address ranges are hot. Hardware sampling can show expensive memory accesses.
+
+Those answers are all useful, but they answer different questions.
+
+When an operator sees high RSS, reclaim pressure, or memory bandwidth, the question is often more specific: **which application allocation or logical resource is responsible for the pages that the machine is actually paying for now?** An allocation stack may reserve bytes that are never touched. A resident page may have been faulted by a different thread than the one that created the region. A physical page can move, split, become shared through copy-on-write, or belong to the page cache. A sampled load can identify an address without explaining which allocator object or runtime resource created that address.
+
+<!-- more -->
+
+This report argues that eBPF memory profiling needs a provenance layer between allocation tracing and page activity. The useful unit is not simply "bytes allocated" or "pages resident." It is a **lifetime-aware chain from an application allocation to a virtual-region generation, then to page or folio generations and observed access or lifecycle events**.
+
+Linux already exposes most of the ingredients separately. The missing mechanism is a reliable join across them, plus an evaluation that distinguishes exact attribution from sampling and inference.
+
+This is the first report in the **eBPF Observability and Profiling** series. It builds on the existing [eBPF memleak tutorial](https://eunomia.dev/tutorials/16-memleak/), which traces allocation and free call sites, but asks a different question: after memory is allocated, which part of it becomes real working-set cost?
+
+## Allocation, residency, and use are different measurements
+
+An allocation tracer observes intent. The Eunomia `memleak` example uses uprobes around `malloc`, `calloc`, `realloc`, `mmap`, and their release paths, records addresses and sizes, and groups outstanding allocations by stack. That is a good way to find leaked or unreleased allocations.
+
+It cannot tell whether all those bytes were faulted into memory.
+
+Linux exposes residency from another layer. The [`/proc` documentation](https://docs.kernel.org/filesystems/proc.html) distinguishes virtual size from `VmRSS`, and `smaps` provides per-mapping memory accounting. The same documentation notes that ordinary RSS accounting is asynchronous and that scanning `smaps` can provide a more precise snapshot at higher cost. Residency therefore answers "what is mapped into the resident set now," not "which allocation site made these pages hot" or "which page caused bandwidth."
+
+Linux also has mechanisms that observe use rather than allocation. [Idle page tracking](https://docs.kernel.org/admin-guide/mm/idle_page_tracking.html) marks pages idle and clears that state when the kernel observes references; it can estimate a workload's working-set size. [DAMON](https://docs.kernel.org/mm/damon/design.html) samples access frequency and age, grouping neighboring pages into regions so overhead stays bounded. DAMON explicitly trades spatial precision for controllable cost, and its documentation warns that region-based sampling loses quality when pages grouped into one region do not share the same access pattern.
+
+At the hardware level, `perf mem` and memory-mode reporting can sample data addresses, memory latency, TLB and cache information, and on supported configurations physical data addresses. These samples get closer to the cost of actual loads and stores, but remain samples and are architecture-dependent.
+
+The resulting measurement stack looks like this:
+
+| Layer | Useful question | What it does not establish by itself |
+| --- | --- | --- |
+| allocator / `mmap` tracing | Who requested this address range and size? | whether the bytes became resident or hot |
+| `/proc/<pid>/smaps` | Which mappings are resident and how are they accounted? | allocation-site provenance and access intensity |
+| idle page tracking | Which pages were referenced during an interval? | which application allocation or object should own the cost |
+| DAMON | Which address regions are frequently or recently accessed? | exact per-page provenance under every access pattern |
+| `perf mem` / PMU sampling | Which sampled accesses were expensive and where? | complete coverage or a stable allocation identity |
+| page lifecycle tracepoints | What did the kernel allocate, reclaim, or migrate? | the application object that ultimately caused the lifecycle |
+
+A profiler that reports only one column from this table will mislead some workloads.
+
+## Physical page identity is not application ownership
+
+It is tempting to join everything by PFN. Linux exposes PFNs through several diagnostic interfaces, and the `mm_page_alloc` tracepoint records a PFN for page allocation. The kernel's [page_owner](https://docs.kernel.org/mm/page_owner.html) facility can store the stack and allocation metadata for physical pages.
+
+But page-owner information describes who allocated the **kernel page**, not necessarily which userspace `malloc` call should receive the cost. A file-backed page can be shared by several processes. Anonymous memory can be shared after `fork` until copy-on-write. Transparent huge pages combine many base pages into a folio and can later split. Reclaim can remove a resident page and a later fault can create a different physical backing for the same virtual address. Migration can move data to another page while the application allocation remains the same.
+
+Current tracepoints expose parts of those transitions but not one universal identity stream. [`mm_page_alloc`](https://github.com/torvalds/linux/blob/master/include/trace/events/kmem.h) reports PFN, order, GFP flags, and migration type. [`mm_vmscan_write_folio`](https://github.com/torvalds/linux/blob/master/include/trace/events/vmscan.h) exposes a folio PFN during reclaim writeback, while other reclaim events are aggregate. [`mm_migrate_pages`](https://github.com/torvalds/linux/blob/master/include/trace/events/migrate.h) reports counts, mode, and reason for a migration batch rather than a per-page old-to-new mapping.
+
+So a useful attribution model should not make PFN the root identity. The stable application-side identity is closer to:
+
+```text
+(process or address-space identity,
+ allocation or mapping identity,
+ generation,
+ virtual interval)
+```
+
+Physical backing is an edge attached to that identity for a bounded lifetime.
+
+This matters for correctness. If a profiler says "allocation stack A owns 8 GiB of bandwidth" because a sampled physical address once belonged to A, it can silently misattribute after unmap, reuse, copy-on-write, or migration. Generation boundaries are not bookkeeping detail; they prevent stale identities from surviving address reuse.
+
+## The join should preserve ambiguity instead of inventing ownership
+
+Memory can have more than one legitimate consumer. Shared libraries, shared memory, page cache, deduplicated pages, and copy-on-write all break the idea that every page has one owner.
+
+A better model is a small provenance graph:
+
+```text
+allocation / resource
+        |
+        v
+virtual interval generation
+        |
+        +---- exact mapping/fault edge ----> page or folio generation
+        |                                    |
+        |                                    +---- reclaim / migration lifecycle
+        |
+        +---- sampled access edge ---------> access weight / latency / bandwidth
+```
+
+Edges should carry their evidence type. An allocator uprobe can establish an exact address interval at one instant. A page fault hook can establish that a virtual address acquired backing. DAMON can contribute sampled access weight for a region. PMU memory sampling can contribute sampled loads or stores. A shared mapping can attach one page generation to several virtual intervals rather than force a single owner.
+
+The final report can then distinguish:
+
+- **reserved bytes**, attributed to allocation or mapping intent;
+- **resident bytes**, attributed to current mappings;
+- **touched working-set bytes**, based on access evidence over a time window;
+- **reclaim and migration activity**, attached to page lifecycle;
+- **sampled memory cost**, such as latency or access weight;
+- **unattributed or multiply attributed cost**, kept explicit when evidence is incomplete.
+
+This is more useful than forcing every metric into a single "memory usage" total.
+
+## Where current work is still weak
+
+### Allocation profilers stop before the VM lifecycle
+
+Heap and eBPF allocation profilers can explain outstanding allocations very well. Their natural key is an address plus size and stack. Once a page is faulted, reclaimed, migrated, remapped, or shared, that allocation record is no longer enough to explain machine cost.
+
+The missing capability is a maintained relation between allocation intervals and VM/page lifecycle. The relation has to survive address reuse and represent shared backing without inventing one owner.
+
+A direct test is a reserve-versus-touch workload: reserve tens of gigabytes, touch a controlled subset, reclaim part of it, then reuse the virtual range for a different allocation. A correct profiler should keep reserved, resident, touched, and later-reused bytes separate.
+
+### Page activity tools lack application allocation provenance
+
+Idle page tracking and DAMON answer important working-set questions. DAMON in particular gives a tunable overhead/accuracy trade-off and can observe access frequency and age over address regions. These tools intentionally focus on memory behavior, not the userspace call site or logical runtime object that created each byte.
+
+For production debugging, the missing join is often the important part. "This 2 GiB region is hot" is less actionable than "this hot region came from cache shard creation at stack X, and 70% of its touched pages belong to shards that have not served a request in ten minutes."
+
+The test is whether adding allocator/runtime provenance changes an optimization decision compared with DAMON-only region statistics. If it does not, the extra tracing is unnecessary.
+
+### Reclaim and migration evidence is not a complete per-page lineage API
+
+Linux tracepoints provide valuable VM events, but they were not designed as one normalized page-lineage protocol. Some events carry PFNs, some carry aggregate counts, and internal hooks can change across kernel versions.
+
+An eBPF profiler can attach to additional BTF-visible functions when necessary, but a production design must label those hooks by stability level and degrade gracefully when exact lineage is unavailable. Otherwise a profiler that works on one kernel may silently produce a different attribution model on another.
+
+The discriminating test is cross-version replay: run the same memory workload across supported kernels and require the profiler to report either comparable attribution or an explicit loss of evidence, never a fabricated exact result.
+
+### Memory bandwidth attribution is sampled and hardware-dependent
+
+Hardware memory sampling is powerful because it observes actual accesses rather than allocation intent. It is also incomplete by construction. Supported load/store events, physical-address availability, sampling skid, and memory-source fields vary by architecture.
+
+A useful profiler therefore needs confidence and coverage metadata for bandwidth attribution. A sampled byte or latency weight should not be presented as an exact counter unless the underlying event provides exact accounting.
+
+The test is to compare sampled attribution with a controlled memory generator whose address ranges and access counts are known, across sequential, random, NUMA-local, and NUMA-remote patterns.
+
+## Promising directions with academic and production value
+
+### 1. A lifetime-aware allocation-to-page provenance ledger
+
+**Gap.** Existing tools observe allocation, residency, and VM events separately.
+
+**Mechanism.** Build an eBPF collector plus a userspace join engine. Uprobes or runtime probes record allocator objects and their virtual intervals. System-call and VM hooks record `mmap`, `brk`, `munmap`, faults, and relevant mapping transitions. Every virtual interval receives a generation so address reuse creates a new identity. When exact physical backing is observable, the join engine creates a bounded page/folio-generation edge. Shared and copy-on-write mappings create multiple or successor edges instead of overwriting ownership.
+
+The data model should distinguish evidence that is exact from evidence that is inferred or sampled. It should also expire page identities aggressively after unmap, migration, reclaim, and process exit.
+
+**Delta.** This extends allocation tracing beyond "allocated but not freed" without trying to replace DAMON or page_owner. DAMON remains the access monitor; page_owner remains useful for kernel page-allocation provenance. The new artifact is the cross-layer join that attaches those facts back to application allocations.
+
+**Artifact.** An open schema, a CO-RE BPF collector for stable tracepoints and selected BTF hooks, allocator adapters for glibc and one managed runtime, and a userspace reconstruction library that outputs folded stacks or pprof labels for reserved, resident, touched, reclaimed, and migrated bytes.
+
+**Evaluation.** Use deterministic microbenchmarks for reserve-versus-touch, `malloc` arenas, file mappings, `fork` plus copy-on-write, transparent huge pages, reclaim, swap, and NUMA migration. Compare against allocation-only eBPF tracing, `smaps`, page_owner, and DAMON. Measure attribution precision/recall against ground truth, event loss, CPU overhead, BPF-map memory, and reconstruction cost.
+
+**Academic value.** The general question is how to maintain correct resource provenance when virtual identity is stable longer than physical backing.
+
+**Production value.** An SRE could move from "this process has high RSS" to the allocator stack or logical cache/resource that produced the working set.
+
+**Failure condition.** If DAMON regions plus ordinary allocation stacks make the same decisions with much lower overhead across realistic workloads, a page-lineage ledger is not worth operating.
+
+### 2. Access-weighted attribution with explicit confidence
+
+**Gap.** Residency assigns equal weight to a cold page and a page generating millions of memory accesses.
+
+**Mechanism.** Join the provenance ledger with access evidence from DAMON and architecture-supported `perf mem` sampling. DAMON contributes region-level frequency and age. PMU samples contribute address, latency, memory-source, or physical-address information when available. The join engine attributes weights to allocation/resource identities while carrying sampling rate, unsupported fields, lost samples, and ambiguity.
+
+The output should be a distribution, not false precision. For example, "cache shard allocation stack X accounts for 31% of sampled remote-NUMA load latency, with the corresponding sampling uncertainty" is a better contract than "X used 31% of memory bandwidth" when only sampled loads were observed.
+
+**Delta.** Conventional heap profiles weight by allocated bytes. DAMON weights address regions by observed access. `perf mem` weights sampled data accesses. The new part is provenance-preserving fusion with explicit coverage semantics.
+
+**Artifact.** A DAMON adapter, a perf-event/BPF sampling adapter, and a profiler view that can pivot the same logical allocation by reserved bytes, resident bytes, access frequency, sampled latency, and NUMA locality.
+
+**Evaluation.** Use STREAM-like bandwidth workloads, random pointer chasing, mixed hot/cold caches, and NUMA placement workloads. Compare attribution against known address-range generators and hardware counters where they provide a suitable aggregate baseline. Vary sampling rates and DAMON region limits to draw accuracy-overhead curves.
+
+**Academic value.** This creates a measurable model for when sampled access evidence changes memory attribution enough to justify its cost.
+
+**Production value.** It can separate a large cold cache from a smaller hot structure that is actually causing remote-memory or bandwidth pressure.
+
+**Failure condition.** If sampling bias or missing hardware support makes attribution unstable across machines, the system should fall back to region-level working-set reporting rather than claim portable bandwidth attribution.
+
+### 3. A ground-truth benchmark for memory attribution
+
+**Gap.** Memory profilers are usually evaluated on overhead and whether a known leak or hot region appears. That is not enough to compare provenance accuracy across allocation, residency, access, reclaim, and migration.
+
+**Mechanism.** Build workloads that expose the true mapping from logical resource to virtual interval and controlled page activity. The harness records a private oracle while the profiler sees only normal tracing interfaces. Cases should include untouched reservation, sparse touch, free/reuse, shared file mappings, `fork` and copy-on-write, THP split/collapse, reclaim/refault, NUMA migration, and mixed resources in one allocator arena.
+
+**Artifact.** A reproducible benchmark suite and trace corpus with a common output schema for allocation identity, page-state transitions, and attributed cost.
+
+**Evaluation.** Score byte-level or page-level precision and recall where exact ground truth exists; for sampled access metrics, score estimation error and interval coverage. Include event-loss injection and kernel-version variation. The simplest baselines should be allocation-only tracing, `smaps`, idle-page working-set measurement, and DAMON.
+
+**Academic value.** The benchmark turns "better memory attribution" into a falsifiable systems property rather than a more detailed visualization.
+
+**Production value.** Profiling tools can state which workloads they attribute correctly and where they degrade to estimates.
+
+**Failure condition.** If the benchmark shows that page-level lineage adds little diagnostic accuracy beyond VMA-level provenance plus DAMON, future work should optimize the cheaper VMA-level design instead.
+
+## The first implementation should avoid tracking every page all the time
+
+A naive design would record every allocation, every fault, every reclaim decision, every migration, and every memory sample. That would recreate the observability problem inside the profiler.
+
+A practical first implementation should keep exact metadata at coarse semantic boundaries and spend page-level budget only where evidence says it matters:
+
+1. track allocation and mapping generations continuously because they define provenance;
+2. use `smaps`, DAMON, or pressure signals to identify interesting regions;
+3. enable finer page/fault/access capture for those regions or during a bounded diagnostic window;
+4. preserve lost-event and sampling metadata in the result;
+5. retire fine-grained state when the region cools or the investigation ends.
+
+This follows the same principle as the earlier [async causal profiling report](https://eunomia.dev/research/async-ebpf-causal-profiler/): topology-defining evidence deserves a different budget from expensive context. Here the topology is allocation-to-region identity; page activity is the expensive detail.
+
+## What would change this conclusion?
+
+The strongest counterargument is that Linux already exposes enough at VMA granularity. If allocator stacks can be joined to VMAs and DAMON region statistics, and that combination diagnoses real memory incidents as well as per-page lineage, then page-level provenance is unnecessary complexity.
+
+Another counterexample is a workload dominated by file cache or globally shared memory. There may be no useful single application allocation to charge. In those cases the right identity may be inode, memcg, shared-memory object, or another resource rather than an allocator stack. A general system must allow those identities instead of forcing heap ownership.
+
+Finally, hardware access sampling may be too platform-specific for portable bandwidth attribution. The core provenance ledger still has value if it can explain reserved, resident, touched, reclaimed, and migrated memory, but sampled bandwidth should remain an optional evidence source with an explicit support matrix.
+
+The proposal is worth building only if a ground-truth benchmark shows that the cross-layer join changes diagnoses or optimization decisions enough to justify its overhead. Until then, the right design is incremental: preserve allocation and mapping identity first, attach page-level evidence when it is available, and keep uncertainty visible.

--- a/docs/research/page-level-ebpf-memory-attribution.zh.md
+++ b/docs/research/page-level-ebpf-memory-attribution.zh.md
@@ -1,0 +1,225 @@
+---
+date: 2026-08-18
+title: "eBPF 能把内存开销归因到真正使用的页面吗？"
+description: "内存分配量、RSS 和页面热度回答的是不同问题。本报告分析 eBPF 如何把 mmap、malloc 等分配来源，与真正被访问、缺页、回收、迁移和消耗带宽的页面关联起来。"
+tags:
+  - Daily Report
+  - eBPF
+  - 内存分析
+  - Linux 内存管理
+  - 可观测性
+  - 性能分析
+research_question: "eBPF 内存分析器如何把应用的分配来源，与真正被访问、缺页、回收、迁移或产生内存访问开销的虚拟页和物理页关联起来，同时避免假设每个页面始终只有一个稳定所有者？"
+source_cutoff: 2026-08-18
+status: daily-report
+---
+
+# eBPF 能把内存开销归因到真正使用的页面吗？
+
+一个服务启动时预留了 64 GiB 虚拟地址空间。正常流量下，它真正访问的只有 3 GiB，常驻集大约 2 GiB；一部分冷页会被回收后再次缺页载入，一部分文件页与辅助进程共享，NUMA 平衡还会周期性迁移页面。堆分析器能告诉我们哪些调用栈申请了内存，`/proc/<pid>/smaps` 能告诉我们各个映射当前常驻多少，DAMON 能估计哪些地址区间更热，硬件采样还能找到代价较高的内存访问。
+
+这些数字都对，但它们并不是同一个问题。
+
+当机器出现高 RSS、回收压力或内存带宽瓶颈时，工程师通常真正想问的是：**现在机器正在为哪些应用分配、缓存对象或运行时资源付出物理内存和访问成本？** 一个调用栈申请的内存可能从未被触碰；真正触发缺页的线程可能并不是创建映射的线程；一个物理页可能发生迁移、拆分、共享或写时复制；一次硬件采样可以给出访问地址，却不一定知道这个地址最初属于哪个分配对象。
+
+<!-- more -->
+
+本报告的判断是，eBPF 内存分析还缺一层位于“分配追踪”和“页面活动”之间的来源关联。更合适的分析单位不是单纯的“已分配字节”或“常驻页面”，而是**从应用分配开始，经过带生命周期的虚拟区间，再连接到页面或 folio 的生命周期以及访问证据**。
+
+Linux 已经分别提供了其中大部分信息。真正缺的是跨层关联方式，以及一套能区分精确归因、采样估计和无法确定结果的评测方法。
+
+这是 **eBPF Observability and Profiling** 系列的第一篇。站内已有的 [eBPF memleak 教程](https://eunomia.dev/zh/tutorials/16-memleak/) 会追踪分配和释放调用栈；这里继续追问下一层：内存申请完成以后，哪些部分最终变成了真实工作集和机器成本？
+
+## 分配量、常驻量和实际使用量是三种不同测量
+
+分配追踪观察的是应用意图。Eunomia 的 `memleak` 示例会用 uprobe 追踪 `malloc`、`calloc`、`realloc`、`mmap` 以及对应的释放路径，记录地址、大小和调用栈，并按尚未释放的分配做汇总。这非常适合定位泄漏或长期未释放对象。
+
+但是它无法仅凭分配记录判断这些字节是否真正进入了物理内存。
+
+Linux 从另一层提供常驻信息。[`/proc` 文档](https://docs.kernel.org/filesystems/proc.html) 区分虚拟内存大小和 `VmRSS`，`smaps` 还能按映射给出更细的内存统计。文档同时说明，普通 RSS 统计为了扩展性会异步维护，而扫描 `smaps` 可以获得更精确、但成本更高的快照。因此，常驻集回答的是“现在有哪些映射占用了常驻内存”，它本身并不会告诉我们“哪个分配调用栈让这些页面变热”或者“哪个页面正在制造带宽压力”。
+
+Linux 也有直接观察页面使用情况的机制。[Idle Page Tracking](https://docs.kernel.org/admin-guide/mm/idle_page_tracking.html) 可以标记页面为空闲，并在内核观察到引用后清除空闲状态，因此能估计工作集大小。[DAMON](https://docs.kernel.org/mm/damon/design.html) 会采样访问频率和访问模式持续时间，并把相邻页面合并成区域来限制开销。DAMON 明确在空间精度与可控开销之间做权衡；当一个区域中的页面并没有相似访问模式时，区域采样会降低结果质量。
+
+再往下，`perf mem` 和 perf 的 memory mode 可以在硬件支持时采样数据地址、访问延迟、TLB 和缓存信息，有些平台还能记录物理数据地址。这更接近真实 load/store 的成本，但它仍然是采样，而且依赖具体硬件。
+
+因此，内存分析实际上包含几层不同事实：
+
+| 层次 | 最适合回答的问题 | 单独使用时缺少什么 |
+| --- | --- | --- |
+| allocator / `mmap` 追踪 | 谁申请了这个地址区间和大小？ | 这些字节是否常驻或真正被访问 |
+| `/proc/<pid>/smaps` | 哪些映射当前常驻、如何计费？ | 分配调用栈和访问强度 |
+| Idle Page Tracking | 一个时间窗口里哪些页面被引用过？ | 应该把成本归到哪个应用对象 |
+| DAMON | 哪些地址区域经常或最近被访问？ | 所有模式下的精确逐页来源 |
+| `perf mem` / PMU 采样 | 哪些采样访问更昂贵、发生在哪里？ | 完整覆盖以及稳定的分配身份 |
+| 页面生命周期 tracepoint | 内核何时分配、回收或迁移页面？ | 最终由哪个应用对象触发这段生命周期 |
+
+如果分析器把其中任意一列直接叫成“内存使用”，在一部分工作负载上就会产生误导。
+
+## 物理页面身份不等于应用所有权
+
+一个直觉做法是用 PFN 把所有数据连接起来。Linux 的一些诊断接口会暴露 PFN，`mm_page_alloc` tracepoint 也记录页面分配时的 PFN。内核的 [page_owner](https://docs.kernel.org/mm/page_owner.html) 还能保存物理页分配时的调用栈、order 等信息。
+
+问题在于，page_owner 描述的是**谁在内核中分配了这个 page**，它并不天然等价于“哪个用户态 `malloc` 应该承担成本”。文件页可以被多个进程共享；`fork` 后的匿名页在写时复制发生前也是共享的；透明大页把多个 base page 组合成 folio，之后还可能拆分；回收会让原来的物理页离开常驻集，后续缺页可能为同一个虚拟地址建立新的物理 backing；NUMA 迁移则会移动数据，而应用看到的分配仍然没变。
+
+现有 tracepoint 能看到这些变化的一部分，但它们不是一个统一的页面 lineage API。[`mm_page_alloc`](https://github.com/torvalds/linux/blob/master/include/trace/events/kmem.h) 提供 PFN、order、GFP flags 和 migratetype；[`mm_vmscan_write_folio`](https://github.com/torvalds/linux/blob/master/include/trace/events/vmscan.h) 在回收写回时能提供 folio PFN，其他一些回收事件则是聚合统计；[`mm_migrate_pages`](https://github.com/torvalds/linux/blob/master/include/trace/events/migrate.h) 提供一批迁移的成功/失败数量、模式和原因，而不是每个页面从旧 PFN 到新 PFN 的完整对应关系。
+
+因此，一个实用归因模型不应该把 PFN 当作根身份。应用侧更稳定的身份更接近：
+
+```text
+(进程或地址空间身份,
+ 分配或映射身份,
+ generation,
+ 虚拟地址区间)
+```
+
+物理 backing 只是挂在这个身份上的、有明确生命周期的边。
+
+这直接关系到正确性。如果分析器因为某个物理地址曾经属于调用栈 A，就一直把后续采样成本算给 A，那么在 unmap、地址复用、写时复制或迁移后都可能产生静默误归因。generation 不是实现细节，它是避免旧身份穿过地址复用的必要边界。
+
+## 关联模型应该保留歧义，而不是虚构唯一所有者
+
+真实内存经常存在多个合理消费者。共享库、共享内存、page cache、写时复制都会打破“一个页面只有一个 owner”的假设。
+
+更合适的模型是一张小型 provenance graph：
+
+```text
+分配 / 逻辑资源
+        |
+        v
+虚拟区间 generation
+        |
+        +---- 精确映射/缺页边 ----> page 或 folio generation
+        |                            |
+        |                            +---- 回收 / 迁移生命周期
+        |
+        +---- 采样访问边 ----------> 访问权重 / 延迟 / 带宽
+```
+
+每条边都要带上证据类型。allocator uprobe 可以在某个时刻精确建立地址区间；页面缺页 hook 可以证明某个虚拟地址获得了 backing；DAMON 可以为区域提供采样访问权重；PMU 内存采样可以提供部分 load/store 证据；共享映射则允许一个 page generation 同时连向多个虚拟区间，而不是强行选一个 owner。
+
+最终报告可以把下面几类成本分开：
+
+- **预留或申请字节**：来自分配、映射意图；
+- **常驻字节**：来自当前映射和页表状态；
+- **被访问的工作集**：来自一个时间窗口内的访问证据；
+- **回收和迁移活动**：来自页面生命周期；
+- **采样内存成本**：例如访问延迟、NUMA 位置或访问权重；
+- **无法归因或多重归因的成本**：证据不足时保持显式，而不是硬分给一个对象。
+
+这比把所有指标压成一个“memory usage”数字更适合故障分析。
+
+## 现有研究还缺什么
+
+### 分配分析通常停在 VM 生命周期之前
+
+堆分析器和 eBPF allocation profiler 很擅长解释尚未释放的分配。它们天然使用“地址 + 大小 + 调用栈”作为 key。页面一旦经历缺页、回收、迁移、重新映射或共享，仅靠原来的分配记录就不足以解释机器正在承担的成本。
+
+缺少的能力，是维护“分配区间”和 VM/page 生命周期之间的关系。这个关系必须能处理地址复用，也必须能表达共享 backing，而不是强行指定一个 owner。
+
+最直接的实验是 reserve-versus-touch：预留几十 GiB，只访问一个可控子集，再让其中一部分被回收，最后把同一个虚拟区间释放并重新用于另一类对象。正确的分析器应该始终把预留、常驻、已访问和地址复用后的新分配区分开。
+
+### 页面热度工具缺少应用分配来源
+
+Idle Page Tracking 和 DAMON 已经能很好地回答工作集问题。DAMON 特别适合在开销和精度之间做可配置权衡，也能按区域观察访问频率和 age。它们的目标本来就是描述内存行为，而不是记录每个字节来自哪个用户态调用栈或运行时对象。
+
+生产排障中，后面的来源关联往往才决定下一步动作。“这个 2 GiB 区域很热”不如“这个热区来自 cache shard 创建路径 X，并且大部分已访问页面属于十分钟没有服务请求的 shard”直接。
+
+关键实验是比较两种方案能否做出不同的优化决策：只用 DAMON 区域统计，和加入 allocator/runtime provenance。如果后者没有带来更好的决策，就没有必要增加这层追踪。
+
+### 回收和迁移事件还不是完整逐页 lineage 接口
+
+Linux tracepoint 暴露了许多有价值的 VM 事件，但它们并不是为了组成一个统一页面 lineage 协议而设计。有的事件带 PFN，有的只给聚合数量；为了补齐信息，eBPF 还可能需要挂到 BTF 可见的内部函数，而这些函数的稳定性与 tracepoint 不同。
+
+因此生产实现必须给 hook 标注稳定性，并在无法获得精确 lineage 时明确降级。否则同一个分析器在两个内核版本上可能使用不同证据，却输出看起来一样精确的结果。
+
+可以用跨版本回放来验证这一点：在多组受支持内核上运行同一套内存 workload，要求分析器要么给出可比较的归因，要么明确报告 evidence loss，不能自动补成“精确结果”。
+
+### 内存带宽归因天然受采样和硬件限制
+
+硬件内存采样的价值在于它看到真实访问，而不是分配意图。但它从定义上就是不完整观测。支持哪些 load/store 事件、能否得到物理地址、采样 skid 和 memory-source 字段，都依赖架构。
+
+因此带宽归因必须同时给出覆盖和置信信息。只观察到采样 load 时，就不能把采样权重包装成精确“带宽占比”。
+
+一个可区分方案好坏的实验，是使用地址区间和访问次数都已知的内存生成器，比较 sequential、random、NUMA local 和 remote 模式下的采样归因误差。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 带生命周期的 allocation-to-page provenance ledger
+
+**缺口。** 现有工具分别观察分配、常驻状态和 VM 事件，却缺少稳定的跨层关系。
+
+**机制。** 用 eBPF collector 加用户态 join engine。uprobes 或运行时探针记录 allocator 对象及其虚拟区间；系统调用和 VM hook 记录 `mmap`、`brk`、`munmap`、缺页以及必要的映射变化。每个虚拟区间都有 generation，地址被释放再复用时必须创建新身份。如果能精确观察物理 backing，再建立有生命周期的 page/folio generation 边。共享和写时复制要产生多个或后继边，不能简单覆盖 owner。
+
+数据模型还要区分 exact、inferred 和 sampled evidence，并在 unmap、迁移、回收和进程退出后及时淘汰旧 page identity。
+
+**与已有工作的差别。** 它不是替代 DAMON 或 page_owner，也不只是把 memleak 做得更复杂。DAMON 继续负责访问行为，page_owner 继续解释内核页面分配；新机制负责把这些事实重新关联到应用分配来源。
+
+**可实现产物。** 一个开放 schema、一组使用稳定 tracepoint 和少量 BTF hook 的 CO-RE BPF collector、glibc 和一个托管运行时的 allocator adapter，以及一个能输出 reserved、resident、touched、reclaimed、migrated 等 profile 的用户态重建库。
+
+**评测。** 使用 reserve-versus-touch、`malloc` arena、文件映射、`fork` + COW、THP、reclaim、swap 和 NUMA migration 等确定性 workload，与 allocation-only eBPF、`smaps`、page_owner 和 DAMON 对比。核心指标不是图是否好看，而是对 ground truth 的 attribution precision/recall、丢事件率、CPU 开销、BPF map 内存和重建成本。
+
+**学术价值。** 它研究的是一个可泛化问题：虚拟身份比物理 backing 活得更久时，资源来源怎样保持正确。
+
+**生产价值。** SRE 可以从“这个进程 RSS 很高”继续定位到真正形成工作集的 allocator stack、缓存或运行时资源。
+
+**失败条件。** 如果现实 workload 中，DAMON region 加普通 allocation stack 已经能以更低成本做出同样诊断，那么逐页 lineage 不值得长期运行。
+
+### 2. 带明确置信度的 access-weighted attribution
+
+**缺口。** RSS 会给一个冷页和一个产生数百万次访问的热页相同权重。
+
+**机制。** 把 provenance ledger 与 DAMON 和硬件支持下的 `perf mem` 采样关联。DAMON 提供区域级访问频率和 age；PMU 样本在可用时提供地址、延迟、memory source 或物理地址。join engine 把这些权重归到 allocation/resource identity，同时保留 sampling rate、缺失字段、lost sample 和歧义。
+
+输出应该是估计分布，而不是假精确。例如，“调用栈 X 对采样到的 remote-NUMA load latency 贡献约 31%，并带有对应采样误差”比“X 使用了 31% 内存带宽”更符合证据。
+
+**与已有工作的差别。** heap profile 主要按 allocated bytes 加权，DAMON 按访问行为加权地址区域，`perf mem` 按采样访问观察硬件成本。这里新增的是保留来源和覆盖语义的跨层融合。
+
+**可实现产物。** DAMON adapter、perf-event/BPF sampling adapter，以及一个可以在 reserved bytes、resident bytes、访问频率、采样延迟和 NUMA locality 之间切换的 profiler 视图。
+
+**评测。** 使用 STREAM 类带宽 workload、random pointer chasing、冷热缓存混合和 NUMA placement workload。与已知地址区间的生成器以及适用的硬件计数器做对照，改变采样率和 DAMON region 上限，画出 accuracy-overhead 曲线。
+
+**学术价值。** 可以量化“加入访问采样以后，内存归因是否真的发生足够大的变化”。
+
+**生产价值。** 能区分“大但冷的缓存”和“体积较小却真正制造远程内存或带宽压力的结构”。
+
+**失败条件。** 如果采样偏差或硬件缺失让不同机器上的结果不稳定，系统应该退回区域级 working-set 分析，而不是宣称可移植的带宽归因。
+
+### 3. 内存归因的 ground-truth benchmark
+
+**缺口。** 内存 profiler 的评测常看运行开销，或者已知 leak/hot region 是否出现在报告里，这不足以比较分配、常驻、访问、回收和迁移之间的来源准确性。
+
+**机制。** 构造能暴露真实“逻辑资源 -> 虚拟区间 -> 可控页面活动”的 workload。测试 harness 私下记录 oracle，profiler 只能使用正常观测接口。案例至少覆盖 untouched reservation、sparse touch、free/reuse、共享文件映射、`fork` + COW、THP split/collapse、reclaim/refault、NUMA migration，以及多个逻辑资源共用一个 allocator arena。
+
+**可实现产物。** 一套可复现 benchmark 和 trace corpus，定义 allocation identity、page-state transition 和 attributed cost 的统一结果 schema。
+
+**评测。** 在存在精确 ground truth 的地方计算 byte/page-level precision 和 recall；对采样访问计算估计误差和置信区间覆盖。额外注入 event loss 并跨内核版本运行。最简单的 baseline 应该包括 allocation-only tracing、`smaps`、Idle Page Tracking 和 DAMON。
+
+**学术价值。** 它把“更好的内存归因”从可视化印象变成可以被证伪的系统性质。
+
+**生产价值。** profiler 可以明确说明哪些 workload 能精确归因，哪些只能退化到估计。
+
+**失败条件。** 如果 benchmark 显示逐页 lineage 相比 VMA-level provenance + DAMON 几乎不增加诊断准确率，后续工作应该优化更便宜的 VMA-level 方案。
+
+## 第一版不应该一直追踪每一个页面
+
+最直接的设计会记录每次分配、每次缺页、每次回收、每次迁移和每个内存样本。这样很容易让 profiler 自己成为新的观测开销来源。
+
+更现实的第一版应该持续保留粗粒度语义身份，只在必要时花逐页预算：
+
+1. 持续追踪 allocation 和 mapping generation，因为它们定义来源拓扑；
+2. 用 `smaps`、DAMON 或内存压力信号找出值得深入分析的区域；
+3. 对这些区域或一个有限诊断窗口开启更细的 page/fault/access 采集；
+4. 在结果里保留 lost-event 和 sampling metadata；
+5. 区域变冷或诊断结束后回收细粒度状态。
+
+这个策略与前面的 [异步 eBPF 因果分析报告](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/) 使用同一个思路：定义拓扑的证据和昂贵上下文应该使用不同预算。这里的拓扑是 allocation-to-region identity，逐页活动才是昂贵细节。
+
+## 哪些结果会改变这个判断？
+
+最强的反例是 Linux 现有的 VMA 粒度已经够用。如果把 allocator stack 关联到 VMA，再结合 DAMON region 统计，就能和逐页 lineage 一样解决真实内存事故，那么逐页来源关联只是增加复杂度。
+
+另一类反例是主要成本来自 page cache 或全局共享内存。这时可能根本没有一个有意义的用户态 allocation owner。更合适的身份可能是 inode、memcg、共享内存对象或其他资源。通用系统必须允许这些身份，而不是强迫所有成本归到 heap stack。
+
+最后，硬件访问采样可能过于依赖平台，无法成为可移植的带宽归因基础。即使如此，如果 provenance ledger 能解释 reserved、resident、touched、reclaimed 和 migrated memory，核心设计仍然有价值；带宽采样则应该保持为带支持矩阵的可选证据。
+
+只有 ground-truth benchmark 证明跨层关联能够显著改变故障诊断或优化决策，而且收益足以覆盖观测成本，这套设计才值得做成持续运行的系统。在此之前，更合理的实现顺序是先保留 allocation 和 mapping identity，再按可用性附加逐页证据，并始终把不确定性留在输出里。


### PR DESCRIPTION
## Evidence

- New weekly Google exports are available through the week ending 2026-08-16. The valid finalized GSC six-day comparison is 393 clicks / 66,510 impressions for Aug 10-15 versus 478 / 69,053 for Aug 3-8; CTR is lower, but movement is mixed and the older slice includes the Aug 5 impression spike.
- The newest GA4 landing-page aggregate covers Aug 10-16 and is **provisional** on Aug 18 because Aug 16 is still inside the configured three-day finalization lag and the file has no date dimension for trimming. Directionally it has 970 sessions versus 991 in Aug 3-9 with engagement effectively flat; `(not set)` increased. The latest fully finalized GA4 weekly comparison remains Aug 3-9 versus Jul 27-Aug 2, and no speculative site rewrite is inferred from the provisional aggregate.
- Current public-safe technical evidence reports HTTP 200 homepage, reachable robots/sitemap, canonical homepage, and 668 sitemap entries. No new technical SEO defect is established.
- The completed Runtime, Extensibility, and Composition series reached six reports, so the repository roadmap promotes eBPF Observability and Profiling.

## Scope

- Publish exactly one new bilingual Daily Report on page-level eBPF memory attribution.
- Update both Daily Report indexes.
- Promote eBPF Observability and Profiling to active and advance the coupled validation assertion.
- Refresh the daily operating record, status, plan, site coverage, and data-history blocker for the new Google weekly set.
- No unrelated technical SEO implementation change.

## Report thesis

Allocation tracing, RSS, page hotness, page lifecycle, and hardware memory sampling expose different facts. The report proposes a lifetime-aware allocation-to-page provenance ledger, access-weighted attribution with explicit confidence, and a ground-truth benchmark covering address reuse, COW, THP, reclaim/refault, and NUMA migration.

## Validation

Repository CI is authoritative for Daily Report structure, SEO-data validation, generated content, links, metadata, static build, and deployment readiness. After CI is green I will self-review the complete final diff/generated output before squash merge.

## Production target and acceptance

- Deployment: exact squash commit through `Deploy Static App` / GitHub Pages.
- Verify both `/research/page-level-ebpf-memory-attribution/` and `/zh/research/page-level-ebpf-memory-attribution/` in production.
- Acceptance includes Daily Report navigation, canonical URL, reciprocal hreflang plus x-default, Article JSON-LD, internal links, the explicit gap section, developed directions, and conclusion-change boundary.
- Add one compact closeout comment to the merged PR with exact CI/deployment/verification evidence.

SEO skill submodule remains pinned; no pointer-only update is included because the consuming contract still depends on the pinned layout.