### PR TITLE
Daily: make profiler sampling uncertainty explicit

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -17,11 +17,11 @@ already configured and enabled; it is not a blocker.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder now
+Google Drive access is verified and is not a blocker. The configured folder
 contains three adjacent weekly Search Console and GA4 export sets beginning
-`2026-07-27`, `2026-08-03`, and `2026-08-10`. The newest Search Console date file
-has rows through `2026-08-15`, which is finalized under the configured three-day
-lag on `2026-08-18`.
+`2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer weekly set was observed on
+`2026-08-19`. The newest Search Console date file has rows through `2026-08-15`,
+which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
 unavailable because the `2026-08-09` date row is absent across the adjacent
@@ -31,12 +31,11 @@ The 28-day comparison also remains unavailable because the export history is not
 long enough.
 
 GA4 landing-page files are weekly aggregates without a date dimension. On
-`2026-08-18`, the newest `2026-08-10` through `2026-08-16` file still includes an
-unfinalized day under the configured three-day lag and cannot be trimmed. Its
-figures may be used only as provisional directional evidence. The latest fully
-finalized GA4 weekly comparison remains `2026-08-03` through `2026-08-09` versus
-`2026-07-27` through `2026-08-02`. GA4 landing-page exports also do not provide
-complete acquisition, conversion, or outbound behavior coverage by themselves.
+`2026-08-19`, the complete `2026-08-10` through `2026-08-16` aggregate is outside
+the configured three-day finalization lag and is usable as a finalized
+source-native weekly comparison against `2026-08-03` through `2026-08-09`. The
+landing-page exports still do not provide complete acquisition, conversion, or
+outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use
 the available Google exports, live-site evidence, public GitHub evidence, and

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -20,9 +20,7 @@ Reports:
   kernels, observability, profiling, networking, security, runtimes, GPU and
   heterogeneous systems, distributed systems, compilers, or storage.
 - Until the archive reaches 10 reports, apply the same proportions to the
-  available set as closely as possible. The two existing Agent-centered reports
-  mean the next reports should strongly favor eBPF before another pure Agent
-  report is considered.
+  available set as closely as possible.
 
 Record the rolling mix in the daily operating record before selecting a topic.
 Do not manipulate classification to satisfy the ratio; classify by the report's
@@ -80,6 +78,12 @@ how to distinguish allocation from pages that were actually touched, faulted,
 reclaimed, migrated, or responsible for sampled memory cost while preserving
 provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
+The `2026-08-19` report is a deliberate one-run **adjacent profiling detour** on
+sampling bias. Its central mechanism is general profiler measurement design, not
+eBPF, so it is classified as adjacent systems. It closes the first ten-report
+window at the intended 7 eBPF / 2 Agent / 1 adjacent mix without relabeling an
+eBPF-essential question.
+
 ### Published progress
 
 1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` separates
@@ -88,35 +92,37 @@ provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
    access-weighted attribution with explicit confidence, and a ground-truth
    benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
    migration.
+2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
+   untrustworthy. It compares randomized sampling history, current Linux perf
+   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
+   develops a sampling-schedule contract with aliasing diagnostics, independent
+   profile epochs with uncertainty and rank stability, and uncertainty-triggered
+   selective instrumentation. Because the mechanism applies to profilers in
+   general and does not require eBPF, this report is adjacent systems rather than
+   eBPF-centered.
 
-After this report, the archive is **7 eBPF-centered / 2 pure Agent / 0 adjacent
-out of 9**. The next published report will create the first full ten-report
-window. It therefore must be an **adjacent-systems report that is not classified
-as eBPF-centered or pure Agent**, producing 7 eBPF / 2 Agent / 1 adjacent out of
-10. Do not force an active-series question into the adjacent bucket merely to
-satisfy the ratio. If the strongest next Observability and Profiling candidate
-still has eBPF as an essential mechanism, defer it for one run and select a real
-adjacent-systems question from the approved roadmap.
+After these reports, the first complete ten-report window is **7 eBPF-centered /
+2 pure Agent / 1 adjacent systems out of 10**. The next normal run may return to
+an eBPF-centered question inside this active series. Continue enforcing the
+rolling 10-report window as the oldest reports age out rather than treating the
+7 / 2 / 1 split as permanent.
 
 ### Preferred next questions
 
-These remain the preferred questions inside this active series once the rolling
-mix permits another eBPF-centered report:
+Sampling theory is now covered by the adjacent report above. The preferred next
+questions inside the active eBPF series are:
 
-1. sampling theory for profilers: phase locking, randomized sampling, bias, and
-   confidence intervals;
-2. always-on semantic compression that preserves diagnostic evidence instead of
+1. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
-3. application-defined resource profiling that combines static discovery,
+2. application-defined resource profiling that combines static discovery,
    runtime eBPF evidence, and online validation;
-4. causal profiling for GPU host-side bottlenecks and megakernel execution;
-5. revisit async and syscall causal profiling only when new mechanism or
+3. causal profiling for GPU host-side bottlenecks and megakernel execution;
+4. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
 
-For the immediate ten-report boundary, sampling theory may be selected only if
-its actual central question is a general adjacent profiling problem and eBPF is
-not essential to the mechanism. Otherwise use another approved adjacent-systems
-question and return to this list afterward.
+The next run should start with these active-series questions and use current
+primary evidence to choose among them. A weak or duplicative candidate should be
+rejected rather than padded.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
@@ -198,8 +204,8 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-Because these already occupy the pure-Agent budget in the current small archive,
-do not schedule another pure Agent report until the rolling mix is compliant.
+These occupy the pure-Agent budget in the current rolling window. Do not schedule
+another pure Agent report until the rolling mix permits it.
 
 Future Agent reports should preferentially connect back to eBPF or systems
 infrastructure, for example OS-level effect tracing, eBPF policy enforcement,

--- a/.github/seo-data/daily/2026-08-19.md
+++ b/.github/seo-data/daily/2026-08-19.md
@@ -1,0 +1,244 @@
+# SEO operations — 2026-08-19
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md`: read all enabled
+analytics and public evidence first, audit technical SEO/GEO behavior, calculate
+the rolling Daily Report mix before choosing a topic, publish exactly one new
+bilingual Daily Report, and deliver the complete public change through one fresh
+branch and one non-draft pull request.
+
+The completed archive contains nine reports before today's publication: **7
+eBPF-centered / 2 pure Agent / 0 adjacent systems**. The next publication creates
+the first full ten-report window, so today's report must be a genuine
+adjacent-systems report that is neither eBPF-centered nor pure Agent.
+
+The selected question is **when sampling profilers become structurally biased and
+how a profiler can expose whether its own estimates are trustworthy**. This is a
+general profiling problem. The proposed mechanisms apply to `perf`, PMU,
+runtime, mobile, and other profilers without requiring eBPF, so the report is
+classified adjacent systems rather than eBPF-centered.
+
+No unrelated technical SEO implementation change is included because today's
+evidence does not establish a new defect.
+
+## Data window
+
+This run used every source enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | weekly Drive export sets through the week ending `2026-08-16`; finalized date rows through `2026-08-15` | available; complete adjacent 7-day comparison still blocked by missing `2026-08-09` date row |
+| Google Analytics 4 | weekly organic landing-page aggregates through `2026-08-16` | available; newest weekly aggregate is finalized on `2026-08-19` under the three-day lag |
+| Public-safe repository collection | `.github/data-analysis/latest.md`, generated `2026-08-19 07:58 UTC` | available |
+| Public GitHub | current repository and public project state | available |
+| Live / generated technical site evidence | homepage, robots, sitemap, canonical, prior exact production export | available |
+| Public web / primary research | sampling literature, Linux perf documentation and current profiling work checked through `2026-08-19` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
+
+The configured Google Drive folder `eunomia.dev SEO Weekly CSV` was resolved by
+name and searched again. The newest observed weekly artifacts still cover
+`2026-08-10` through `2026-08-16`; no newer weekly set was found. Missing or
+delayed source coverage is not treated as zero.
+
+A complete latest-seven-days versus previous-seven-days GSC comparison remains
+unavailable because `2026-08-09` is absent across the adjacent date exports. The
+required 28-day comparison is also unavailable because verified history is too
+short. The valid equal-duration six-day comparison remains `2026-08-10` through
+`2026-08-15` versus `2026-08-03` through `2026-08-08`.
+
+## Evidence collected
+
+### Search Console
+
+For `2026-08-10` through `2026-08-15`, Search Console reports **393 clicks** and
+**66,510 impressions**, weighted CTR about **0.591%**, and
+impression-weighted average position about **9.91**.
+
+The comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks** and
+**69,053 impressions**, **0.692%** CTR, and average position about **9.42**.
+Clicks are therefore about **17.8% lower**, impressions about **3.7% lower**, CTR
+about **0.101 percentage points lower**, and average position about **0.49
+positions worse** in the newer slice.
+
+This does not justify a search-facing rewrite. The older slice contains the
+unusual `2026-08-05` spike of **24,516 impressions**, and the available page and
+query exports do not provide date-by-page or date-by-query joins. The movement
+therefore remains observed but unattributed.
+
+### Google Analytics 4
+
+The `2026-08-10` through `2026-08-16` organic landing-page aggregate is now fully
+outside the configured three-day finalization lag. It contains **970 sessions**
+at about **44.95%** session-weighted engagement. The preceding `2026-08-03`
+through `2026-08-09` aggregate contains **991 sessions** at about **44.90%**
+engagement.
+
+Sessions are about **2.1% lower** and engagement is effectively flat. `(not
+set)` is **134 versus 116 sessions**; excluding that row, sessions are **836
+versus 875**. These remain acquisition and measurement-quality signals rather
+than evidence for a speculative content, title, navigation, or analytics change.
+
+### Public-safe technical and repository evidence
+
+The current public-safe operating brief reports:
+
+- homepage HTTP 200 in **137 ms**;
+- `robots.txt` and sitemap reachable;
+- **672** sitemap entries;
+- canonical homepage `https://eunomia.dev/`;
+- **97** active non-fork repositories in the public GitHub portfolio snapshot;
+- **9,771** stars, **1,279** forks, and **283** open issue/PR records in that snapshot;
+- **60** DEV articles, **43** public reactions, and **4** comments.
+
+These are separate operating observations, not a blended SEO score.
+
+The technical audit does not establish a new crawl, canonical, `hreflang`,
+structured-data, redirect, broken-link, rendering, accessibility, performance,
+or deployment defect. The repository already generates and validates these
+static artifacts. Today's site scope is therefore the mandatory Daily Report and
+its directly coupled bilingual indexes and operating state.
+
+### Previous-run closeout repaired before new publication
+
+The August 18 Daily Report was merged as PR `#162` but its required compact
+merged-PR closeout comment had not been added. This run repaired that omission
+before preparing today's public change.
+
+Verified facts for PR `#162` are:
+
+- squash commit: `36df29128cbe388eaa37dc573e2ad9902c9c1904`;
+- final PR head `fcfa7e3531c7dd7abd8588dee02a67ac80e747b9` passed `Validate SEO Operations` run `32158581620` and PR `Deploy Static App` run `32158581694`;
+- static export commit `a26e10fb68a0d0896dcf77d5a79f74c898517bfc` is explicitly `deploy static app for 36df29128cbe388eaa37dc573e2ad9902c9c1904`;
+- that exact generated export contains both English and Chinese page-level memory-attribution routes with canonical URLs, reciprocal language alternates plus `x-default`, Article JSON-LD, and the expected report metadata.
+
+One compact closeout comment was added to the merged PR. No second closeout pull
+request was created.
+
+## Rolling topic mix and report selection
+
+Before today's report, the public archive is **7 eBPF / 2 pure Agent / 0
+adjacent out of 9**. The active **eBPF Observability and Profiling** roadmap
+explicitly allows sampling theory at this boundary only if its central mechanism
+is general profiling rather than eBPF.
+
+A generic framing such as "use eBPF to improve sampling" was rejected because it
+would be an artificial eBPF classification and would not solve the rolling-mix
+constraint honestly. The selected framing instead asks when sampling itself is a
+biased estimator and how the profiler can diagnose that property.
+
+Existing Daily Reports were searched for overlap. None already covers sampling
+schedule aliasing, phase locking, profiler uncertainty, or sampling-versus-
+instrumentation escalation as its thesis. Existing CUPTI tutorial material uses
+GPU sampling APIs but does not answer this general measurement-design question.
+
+The report is therefore **adjacent systems**. After publication, the first full
+ten-report window becomes **7 eBPF / 2 Agent / 1 adjacent**.
+
+## Research evidence and novelty gate
+
+The report uses primary or authoritative evidence including:
+
+- Steven McCanne and Chris Torek, *A Randomized Sampling Clock for CPU Utilization Estimation and Code Profiling*, USENIX Winter 1993: <https://www.usenix.org/conference/usenix-winter-1993-conference/randomized-sampling-clock-cpu-utilization-estimation-and>
+- Linux `perf_event_open(2)` sampling semantics for `sample_period`, `sample_freq`, timestamps, periods, and loss accounting: <https://man7.org/linux/man-pages/man2/perf_event_open.2.html>
+- Linux kernel Propeller profile-collection guidance, including a recommended large prime hardware event period: <https://docs.kernel.org/dev-tools/propeller.html>
+- Linux kernel perf-event throttling configuration: <https://docs.kernel.org/admin-guide/sysctl/kernel.html>
+- OSDI 2026, *When Sampling Lies: Trustworthy Performance Profiling for Flat Workloads with Blink*: <https://www.usenix.org/conference/osdi26/presentation/devsot>
+
+The old idea "randomize the timer" is not presented as novelty. The remaining
+systems gap is whether modern profiler artifacts preserve enough information to
+**diagnose their own estimator**, express unresolved uncertainty, and escalate to
+selective instrumentation only where evidence is weak.
+
+The report develops three testable directions:
+
+1. a realized sampling-schedule contract with phase/aliasing diagnostics;
+2. independent profile epochs with dependence-aware uncertainty and rank stability;
+3. uncertainty-triggered selective instrumentation under a fixed overhead budget.
+
+The proposed benchmark deliberately includes adversarial sampling workloads:
+fixed periodic phases, phase drift, thousands of short equal-weight routines,
+PMU skid sensitivity, bursty phases, throttling, and selectively instrumented
+ground truth. It measures false confidence and optimization decision error in
+addition to ordinary histogram error and overhead.
+
+The thesis is falsifiable. If current `perf` frequency control and normal period
+choices already give stable, unbiased rankings on these workloads, the richer
+sampling contract is unnecessary. If low-overhead instrumentation is consistently
+cheap enough to dominate sampling, instrumentation is the simpler answer. If
+uncertainty diagnostics fail to predict actual ground-truth error, they should
+not be shipped as confidence indicators.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in this delivery:
+
+- English: `/research/profiler-sampling-bias/`
+- Chinese: `/zh/research/profiler-sampling-bias/`
+
+The report is implemented in:
+
+- `docs/research/profiler-sampling-bias.md`
+- `docs/research/profiler-sampling-bias.zh.md`
+
+Both Daily Report indexes are updated. `content-series.md` records the adjacent
+one-run detour and returns future normal topic selection to the active eBPF
+Observability and Profiling series. `plan.md`, `site.md`, and `status.md` are
+refreshed with the finalized GA4 state, rolling mix, and current priorities.
+
+No unrelated technical SEO implementation change is made.
+
+### SEO skill freshness
+
+The consuming repository remains pinned to SEO skill commit
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` remains
+`f42128a3f05c73cf10c786a2711c488bb3a14839`. The consuming repository still
+names interfaces from the pinned layout, including paths removed or reorganized
+upstream, so a pointer-only submodule bump remains incompatible and is not mixed
+into this daily delivery.
+
+## Validation and self-review contract
+
+- No raw analytics rows, private search queries, Drive IDs, property/account IDs,
+  credentials, personal data, or private URLs are added to Git.
+- Missing Search Console history remains unavailable rather than zero-filled.
+- GA4 `2026-08-10` through `2026-08-16` is treated as finalized only because the
+  entire aggregate is outside the repository's three-day lag on `2026-08-19`.
+- The report is classified adjacent systems because eBPF is not necessary to its
+  mechanism.
+- Primary research claims link to original papers or authoritative Linux
+  documentation.
+- The report explicitly distinguishes random variance from structural sampling
+  bias and does not claim randomized sampling, confidence intervals, or hybrid
+  profiling as inventions.
+- English and Chinese variants share evidence and conclusions while using
+  language-specific prose.
+- The intended branch scope is exactly one bilingual report, two indexes, this
+  daily record, and directly coupled site/status/plan/series state.
+
+Repository CI is authoritative for the SEO-data validator, Daily Report content
+checks, generated metadata, static export, links, and deployment readiness. The
+final PR head must pass every required and expected check. After CI is green, the
+complete final diff and generated output must receive a clean self-review before
+squash merge. The exact squash commit must then deploy through `Deploy Static
+App`, both public language routes must be verified, and exactly one compact
+closeout comment must be added to the merged PR.
+
+## Delivery
+
+- Branch: `daily/2026-08-19-profiler-sampling-bias`
+- Pull request: to be opened as one non-draft daily PR
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after all expected CI succeeds and final self-review is clean
+- Closeout policy: one compact comment on the merged daily PR; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Complete today's profiler-sampling report through final CI, full diff/generated-output review, squash merge, exact production deployment, bilingual verification, and one closeout comment.
+2. Return the next normal report to the active eBPF Observability and Profiling series. Preferred remaining questions are always-on semantic compression, application-defined resource profiling, and GPU host/device causal profiling, subject to fresh evidence and novelty review.
+3. Keep full GSC 7-day and 28-day comparisons unavailable until the missing history exists.
+4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+5. Continue monitoring Search Console click/CTR movement before changing search-facing titles, copy, or navigation.
+6. Investigate GA4 `(not set)` and legacy `/en/` traffic only with richer source-native evidence.
+7. Migrate the consuming SEO contract before moving the pinned SEO-skill submodule.
+8. Add Cloudflare evidence only when repository configuration enables a supported read-only source.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,33 +71,34 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the exact rolling topic mix when the archive reaches ten reports. The
-   current page-level memory-attribution report makes the archive **7
-   eBPF-centered / 2 pure Agent / 0 adjacent out of 9**. The next published report
-   therefore must be a genuine **adjacent-systems** report that is neither
-   eBPF-centered nor pure Agent, yielding 7 / 2 / 1 in the first full ten-report
-   window. Do not relabel an eBPF-essential question merely to satisfy the ratio.
-2. Keep **eBPF Observability and Profiling** as the active series, but defer its
-   next eBPF-essential report for one run if necessary. Profiler sampling theory
-   may be the next report only if the actual central question is a general
-   profiling problem rather than an eBPF mechanism; otherwise select another
-   approved adjacent-systems question, then return to the active series afterward.
+1. Preserve the rolling ten-report mix. The `2026-08-19` general profiler-sampling
+   report is genuinely adjacent systems rather than eBPF-centered, so the first
+   complete ten-report window is **7 eBPF-centered / 2 pure Agent / 1 adjacent**.
+   Recalculate the rolling window on every later run as old reports age out; do
+   not treat this one split as a permanent target.
+2. Return normal topic selection to the active **eBPF Observability and Profiling**
+   series. Sampling theory is now covered as an adjacent measurement-design
+   question. Prefer the remaining active questions on always-on semantic
+   compression, application-defined resource profiling, and GPU host/device
+   causal profiling, subject to fresh primary evidence and novelty checks.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   The new `2026-08-10` weekly set is available, but the newest GA4 weekly
-   aggregate is provisional on `2026-08-18` because it includes `2026-08-16`
-   inside the configured three-day finalization lag and has no date dimension for
-   trimming. Keep accumulating history until complete previous-7-day and 28-day
-   comparisons can be made without inventing the missing `2026-08-09` Search
-   Console row or earlier history.
+   On `2026-08-19`, the `2026-08-10` through `2026-08-16` GA4 weekly aggregate is
+   now outside the configured three-day finalization lag and can be compared as a
+   finalized source-native week against `2026-08-03` through `2026-08-09`.
+   Search Console still lacks the `2026-08-09` date row, so keep the required
+   complete 7-day and 28-day comparisons unavailable until source history really
+   supports them.
 4. Obtain or generate date-by-page or date-by-query Search Console evidence before
    attributing the `2026-08-05` impression spike to a specific page or query family.
 5. Monitor the current Search Console click/CTR decline and homepage/branded
    softness across another finalized period before changing titles, copy, or site
    structure; the current movement is not uniform enough to justify a speculative
    SEO patch.
-6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic as measurement
-   and technical SEO evidence rather than letting them distort content selection.
-7. Add Cloudflare coverage when a supported read-only route is available.
+6. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and
+   technical SEO questions that require richer source-native evidence rather than
+   as reasons to steer report topics.
+7. Add Cloudflare coverage only when a supported read-only route is enabled in
+   repository configuration.
 8. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside the approved eBPF and adjacent
    systems series.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,7 +32,7 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`; the newest GA4 weekly aggregate includes `2026-08-16` and is provisional on `2026-08-18`
+- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`; the newest GA4 weekly aggregate through `2026-08-16` is finalized under the three-day lag on `2026-08-19`
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
 The Drive folder is discovered by its configured name. Do not store its folder ID,
@@ -50,25 +50,23 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-Search Console and GA4 exports now provide weekly sets for `2026-07-27` through
+Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
-`2026-08-16`. With the three-day finalization lag on `2026-08-18`, Search Console
-rows through `2026-08-15` are usable. The `2026-08-09` Search Console date row is
-still absent across the adjacent files, so a complete latest-7-days versus
-previous-7-days comparison remains unavailable. A valid equal-duration six-day
-comparison is `2026-08-10` through `2026-08-15` versus `2026-08-03` through
-`2026-08-08`. The 28-day comparison is also unavailable because the export
-history is not long enough.
+`2026-08-16`; no newer weekly set was observed in the configured Drive folder on
+`2026-08-19`. Search Console rows through `2026-08-15` are usable. The
+`2026-08-09` Search Console date row is still absent across the adjacent files,
+so a complete latest-7-days versus previous-7-days comparison remains
+unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
+`2026-08-15` versus `2026-08-03` through `2026-08-08`. The 28-day comparison is
+also unavailable because the export history is not long enough.
 
 GA4 weekly landing-page exports have no date dimension for trimming a partial or
-unfinalized day within a file. On `2026-08-18`, the newest `2026-08-10` through
-`2026-08-16` aggregate therefore remains provisional because `2026-08-16` is
-inside the configured three-day finalization lag. It may be used as directional
-source-native evidence, but not as a finalized week-over-week comparison. The
-latest fully finalized GA4 weekly comparison remains `2026-08-03` through
-`2026-08-09` versus `2026-07-27` through `2026-08-02`. Public repository and
-live-site data supplement these exports but do not replace their source-native
-meanings.
+unfinalized day within a file. On `2026-08-19`, every day in the newest
+`2026-08-10` through `2026-08-16` aggregate is outside the configured three-day
+finalization lag, so the whole aggregate is now usable as a finalized
+source-native weekly comparison against `2026-08-03` through `2026-08-09`.
+Public repository and live-site data supplement these exports but do not replace
+their source-native meanings.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,81 +7,81 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-17`
-- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16` with the newest aggregate provisional under the three-day finalization lag
-- Latest daily record: `2026-08-18`
-- Last completed public-change pull request: `#161`
-- Last verified production deployment from a daily run: `Deploy Static App` run `32043791981` for squash commit `78e27707fc63065afa7fa19a25f363a39fcba20a`
-- Current daily branch: `daily/2026-08-18-page-memory-attribution`
+- Last completed daily run: `2026-08-18`
+- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`, with the newest weekly aggregate finalized under the three-day lag on `2026-08-19`
+- Latest daily record: `2026-08-19`
+- Last completed public-change pull request: `#162`
+- Last verified production publication from a daily run: static export commit `a26e10fb68a0d0896dcf77d5a79f74c898517bfc` for squash commit `36df29128cbe388eaa37dc573e2ad9902c9c1904`
+- Current daily branch: `daily/2026-08-19-profiler-sampling-bias`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#161` is fully closed out. It squash-merged as
-`78e27707fc63065afa7fa19a25f363a39fcba20a`; exact-commit `Validate SEO Operations`
-run `32043791965` and production `Deploy Static App` run `32043791981` succeeded,
-and the merged-PR closeout records bilingual production verification. The
-published heterogeneous-placement report completed the six-report **eBPF Runtime,
-Extensibility, and Composition** sequence.
+PR `#162` is fully closed out. It squash-merged as
+`36df29128cbe388eaa37dc573e2ad9902c9c1904`; final PR-head `Validate SEO
+Operations` run `32158581620` and `Deploy Static App` run `32158581694`
+succeeded. The production static branch contains commit
+`a26e10fb68a0d0896dcf77d5a79f74c898517bfc` with the exact message `deploy
+static app for 36df29128cbe388eaa37dc573e2ad9902c9c1904`, and its generated English
+and Chinese memory-attribution pages contain the expected canonical URLs,
+reciprocal language alternates plus `x-default`, Article JSON-LD, and report
+metadata. The merged PR now has the required compact closeout comment.
 
 ## Current Daily Report mix
 
-Before the current change, the completed archive contains eight reports:
+Before the current change, the completed archive contains nine reports:
 
-- eBPF-centered: **6 of 8**
-- pure Agent-centered: **2 of 8**
-- adjacent systems: **0 of 8**
+- eBPF-centered: **7 of 9**
+- pure Agent-centered: **2 of 9**
+- adjacent systems: **0 of 9**
 
-The current page-level memory-attribution report is eBPF-centered. After it
-merges, the archive becomes **7 eBPF-centered / 2 pure Agent / 0 adjacent systems
-out of 9**. The repository has promoted **eBPF Observability and Profiling** to
-the active series; page-level memory attribution is its first report.
+Today's profiler-sampling report is a genuine adjacent-systems report. Its
+central mechanisms are sampling-schedule design, phase-locking diagnostics,
+uncertainty estimation, rank stability, and selective instrumentation; they
+apply to `perf`, PMU, runtime, mobile, and other profilers without requiring
+eBPF. After publication the first complete ten-report window becomes **7 eBPF /
+2 pure Agent / 1 adjacent out of 10**, satisfying the repository's rolling mix
+without relabeling an eBPF-essential topic.
 
-The next publication will create the first full ten-report window. It must be a
-genuine adjacent-systems report that is neither eBPF-centered nor pure Agent, so
-the resulting window is **7 eBPF / 2 Agent / 1 adjacent out of 10**. An
-eBPF-essential active-series question must be deferred for that one run rather
-than relabeled.
+Normal topic selection can return to the active **eBPF Observability and
+Profiling** series on the next run, subject to the rolling ten-report window as
+the oldest reports later age out.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-18 07:59 UTC`
-- Homepage: HTTP 200 in the current operating brief, observed in **227 ms**
+- Repository-generated public-safe operating brief: refreshed `2026-08-19 07:58 UTC`
+- Homepage: HTTP 200 in **137 ms** in the current operating brief
 - `robots.txt`: reachable; sitemap: reachable
-- Sitemap entries observed: **668**
+- Sitemap entries observed: **672**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub repository evidence: available; current brief observes 97 active non-fork repositories, 9,764 stars, 1,280 forks, and 282 open issue/PR records across the portfolio snapshot
-- DEV publication surface: 60 articles, 43 public reactions, and 4 comments in the current public-safe brief
+- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,771 stars, 1,279 forks, and 283 open issue/PR records
+- DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly organic landing-page files are available through `2026-08-16`; the newest `2026-08-10` through `2026-08-16` aggregate is provisional on `2026-08-18` because it includes a day inside the configured finalization lag and has no date dimension for trimming
+- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; the newest complete aggregate is finalized on `2026-08-19`
 - Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
 - Cloudflare: disabled by repository configuration
 
-The newest Google weekly export is now available and materially changes the
-operating evidence. For the valid equal-duration Search Console comparison,
-`2026-08-10` through `2026-08-15` reports **393 clicks / 66,510 impressions**,
-weighted CTR about **0.591%**, and impression-weighted average position about
-**9.91**. The comparable `2026-08-03` through `2026-08-08` slice reports **478
-clicks / 69,053 impressions**, **0.692%** CTR, and position about **9.42**. Clicks
-are about **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101
-percentage points lower**, and average position about **0.49 positions worse**.
-The old comparison includes the unusual `2026-08-05` impression spike, so this
-movement is monitored rather than attributed to one page or content change.
+For the valid equal-duration Search Console comparison, `2026-08-10` through
+`2026-08-15` reports **393 clicks / 66,510 impressions**, weighted CTR about
+**0.591%**, and impression-weighted average position about **9.91**. The
+comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks / 69,053
+impressions**, **0.692%** CTR, and position about **9.42**. Clicks are about
+**17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage
+points lower**, and average position about **0.49 positions worse**. The older
+slice includes the unusual `2026-08-05` impression spike, so the movement remains
+monitored rather than attributed to one page, query, or Daily Report.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison remains
 unavailable because the `2026-08-09` date row is absent across the adjacent
 weekly files. The required 28-day comparison is also unavailable rather than
 inferred.
 
-The newest GA4 organic landing-page file for `2026-08-10` through `2026-08-16`
-contains **970 sessions** at about **44.95%** session-weighted engagement, versus
-**991 sessions** at about **44.90%** in the preceding `2026-08-03` through
-`2026-08-09` export. `(not set)` is **134 versus 116 sessions**; excluding it,
-sessions are **836 versus 875**. These newest figures are directional only, not a
-finalized week-over-week trend, because `2026-08-16` is still inside the
-configured three-day lag and the file has no date dimension for removing that
-day. The latest fully finalized weekly GA4 comparison therefore remains
-`2026-08-03` through `2026-08-09` versus `2026-07-27` through `2026-08-02`.
-None of this is sufficient evidence for a speculative title, copy, measurement,
-or site-structure change.
+The finalized GA4 organic landing-page export for `2026-08-10` through
+`2026-08-16` contains **970 sessions** at about **44.95%** session-weighted
+engagement, versus **991 sessions** at about **44.90%** for `2026-08-03` through
+`2026-08-09`. Sessions are about **2.1% lower** while engagement is effectively
+flat. `(not set)` is **134 versus 116 sessions**; excluding it, sessions are
+**836 versus 875**. These are source-native acquisition and measurement signals,
+not evidence for a speculative title, copy, navigation, or site-structure
+change.
 
 ## Current technical baseline
 
@@ -89,33 +89,34 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and HTTP audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The August 18 public-safe operating brief and live homepage inspection do not
-establish a new crawl, canonical, hreflang, structured-data, redirect,
+The `2026-08-19` public-safe operating brief and current repository evidence do
+not establish a new crawl, canonical, hreflang, structured-data, redirect,
 broken-link, rendering, accessibility, performance, or deployment defect. The
-correct public site change for this run is therefore the mandatory new bilingual
-Daily Report and directly coupled index/series updates, not an unrelated
+appropriate public site change today is therefore the mandatory bilingual Daily
+Report and directly coupled report-index/series updates, not an unrelated
 technical SEO patch.
 
-Today's research separates allocation intent, residency, working-set evidence,
-page lifecycle, and sampled access cost. Linux `/proc`, Idle Page Tracking,
-DAMON, page_owner, VM tracepoints, and perf memory sampling each expose a useful
-slice but do not provide one stable application-allocation-to-page provenance
-chain. The report develops a lifetime-aware provenance ledger, access-weighted
-attribution with explicit confidence, and a ground-truth memory-attribution
-benchmark.
+Today's research asks when profiler sampling becomes structurally biased rather
+than merely noisy. Primary evidence spans the 1993 randomized sampling-clock
+work, Linux `perf_event_open()` sampling semantics and current profile-collection
+guidance, and the OSDI 2026 Blink result on flat workloads. The report develops
+a realized sampling-schedule contract with aliasing diagnostics, replicated
+profile epochs with uncertainty and rank stability, and uncertainty-triggered
+selective instrumentation under a fixed overhead budget.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. The consuming repository still
-names interfaces from that pinned layout, so no pointer-only bump is included in
-the daily change.
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream remains at
+`f42128a3f05c73cf10c786a2711c488bb3a14839`, while the consuming repository still
+names interfaces from the pinned layout. A pointer-only update is therefore not
+mixed into this daily delivery.
 
 ## Current focus
 
-1. Complete the `2026-08-18` page-level memory-attribution Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual public verification, and one merged-PR closeout comment.
-2. For the next publication, select a real adjacent-systems question that keeps the first full ten-report window at 7 eBPF / 2 Agent / 1 adjacent. Use profiler sampling theory only if its central mechanism is genuinely general profiling rather than eBPF; otherwise defer the active-series question for one run.
+1. Complete the `2026-08-19` profiler-sampling Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. On the next normal run, return to the active eBPF Observability and Profiling series and evaluate the remaining questions on semantic compression, application-defined resource profiling, and GPU causal profiling.
 3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
-4. Monitor the current click/CTR decline across another finalized period before changing search-facing titles, copy, or navigation.
-5. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+5. Monitor the Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
 6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [When Does Profiler Sampling Become Biased?](https://eunomia.dev/research/profiler-sampling-bias/)
+
+Sampling percentages can be systematically wrong when a sampler phase-locks with periodic work, skids past the event that caused a sample, or repeatedly misses short-lived code. This report develops an explicit sampling-schedule contract with aliasing diagnostics, replicated profile epochs with rank uncertainty, and uncertainty-triggered selective instrumentation under a fixed overhead budget.
+
 ### [Can eBPF Attribute Memory to the Pages That Actually Matter?](https://eunomia.dev/research/page-level-ebpf-memory-attribution/)
 
 Allocation stacks, RSS, page hotness, reclaim, migration, and hardware memory samples describe different parts of memory cost. This report develops a lifetime-aware provenance chain from application allocations to virtual-region generations and page activity, access-weighted attribution with explicit confidence, and a ground-truth benchmark for deciding when page-level lineage is worth its overhead.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [性能分析器的采样什么时候会产生偏差？](https://eunomia.dev/zh/research/profiler-sampling-bias/)
+
+当 sampler 与周期 workload 相位锁定、hardware sample 出现 skid，或者短函数持续被漏采时，profile 百分比可能系统性出错。本文提出带 aliasing 诊断的 sampling-schedule contract、用独立 profile epoch 表达 rank uncertainty，以及在固定 overhead budget 下由 uncertainty 触发 selective instrumentation。
+
 ### [eBPF 能把内存开销归因到真正使用的页面吗？](https://eunomia.dev/zh/research/page-level-ebpf-memory-attribution/)
 
 分配调用栈、RSS、页面热度、回收、迁移和硬件内存采样描述的是不同层次的成本。本文提出从应用分配到虚拟区间 generation 和页面活动的生命周期 provenance、带明确置信度的访问加权归因，以及用于判断逐页 lineage 是否值得其开销的 ground-truth benchmark。

--- a/docs/research/profiler-sampling-bias.md
+++ b/docs/research/profiler-sampling-bias.md
@@ -1,0 +1,249 @@
+---
+date: 2026-08-19
+title: "When Does Profiler Sampling Become Biased?"
+description: "Sampling profiles look precise even when phase locking, skid, and missed short-lived code bias them. This report develops a confidence-aware profiler contract."
+tags:
+  - Daily Report
+  - Profiling
+  - Performance
+  - Sampling
+  - Linux perf
+  - Statistics
+research_question: "How can a sampling profiler detect and quantify phase locking, incomplete coverage, skid, and other systematic sampling errors instead of presenting sample percentages as if they were exact measurements?"
+source_cutoff: 2026-08-19
+status: daily-report
+---
+
+# When Does Profiler Sampling Become Biased?
+
+A profiler records 1000 samples per second from a service with a repeated 1 ms control loop. The report says function A consumes 8.1% of CPU time and function B consumes 5.7%. A second run reverses the order. Raising the sampling frequency changes both percentages again.
+
+Which result should an engineer trust?
+
+The usual answer is to collect more samples. That works when the error is mainly random variance. It does not solve a sampler that repeatedly observes the same phase of a periodic workload, misses short-lived functions, lands after the instruction that caused an event, or is throttled in a workload-dependent way.
+
+<!-- more -->
+
+The central problem is that a sampling profile is an **estimator**, but profiler UIs often present it like a counter. A percentage such as 8.1% hides how samples were scheduled, which code was eligible to be observed, how many samples were lost, whether the interval synchronized with the workload, and whether independent runs agree.
+
+This is not a new observation. Steven McCanne and Chris Torek published [A Randomized Sampling Clock for CPU Utilization Estimation and Code Profiling](https://www.usenix.org/conference/usenix-winter-1993-conference/randomized-sampling-clock-cpu-utilization-estimation-and) in 1993 specifically to reduce synchronization between periodic sampling and program behavior. A later USENIX profiling study noted that DCPI randomized intervals and that unpredictable one-shot timer periods help guard against accidental synchronization. Current Linux kernel documentation for Propeller profile collection still recommends a suitable prime-number event period rather than an arbitrary round value.
+
+The problem is also not only phase locking. The OSDI 2026 operational paper [When Sampling Lies: Trustworthy Performance Profiling for Flat Workloads with Blink](https://www.usenix.org/conference/osdi26/presentation/devsot) reports that flat mobile workloads with thousands of short-lived routines can make sampling profilers systematically wrong because of skid, shadow effects, and incomplete function coverage. Blink uses lightweight instrumentation instead and reports 99.999% accuracy at 1% overhead in its evaluated workloads.
+
+Those results suggest a stronger design goal than "sample faster": **a profiler should expose whether its own estimator is trustworthy for the current workload, and should have a bounded fallback when it is not.**
+
+This report is intentionally an adjacent-systems report rather than an eBPF report. The sampling problem applies to `perf`, PMU profilers, runtime profilers, mobile profilers, GPU profilers, and other periodic or event-driven samplers. eBPF can be one implementation tool, but it is not necessary to the mechanism.
+
+## A sample percentage has hidden assumptions
+
+Linux `perf_event_open()` exposes both `sample_period` and `sample_freq`. With a period, an overflow occurs after a configured number of events. With frequency mode, the kernel adjusts the period to try to maintain the requested rate. Samples can include the current period, timestamp, CPU, instruction pointer, callchain, and lost-sample accounting.
+
+That is enough to build powerful profilers, but the resulting fraction
+
+```text
+samples attributed to X / total samples
+```
+
+is only a good estimator for time or event share when the sampling process observes execution in a sufficiently representative way.
+
+Several assumptions can fail.
+
+### The sampling clock can synchronize with the workload
+
+Suppose a program executes a repeating cycle:
+
+```text
+A for 300 us -> B for 300 us -> C for 400 us -> repeat
+```
+
+A profiler that samples every 1 ms at the same phase can observe almost only one region. Collecting ten times longer does not repair the estimate because the additional observations repeat the same mistake.
+
+This is why randomized sampling is old but still important. The 1993 randomized-clock paper made synchronization a first-class sampling problem. The Linux Propeller documentation gives a modern engineering hint in the same direction by suggesting a large prime sample period, such as `500009`, for hardware-sampled profiles.
+
+A prime period is not a proof of independence, and frequency feedback is not the same as randomized sampling. The useful lesson is that **sample timing is part of the measurement design**, not just an overhead knob.
+
+### Hardware samples can skid
+
+A PMU overflow is not always attributed exactly to the instruction that logically caused the event. Modern hardware and `perf` expose mechanisms such as precise-event support where available, but precision differs by event and architecture.
+
+For broad CPU-time profiling, a small amount of skid may not change the answer. For short functions, flat profiles, or event attribution at instruction granularity, it can change rankings. Blink's OSDI 2026 evaluation treats this as one source of systematic error rather than ordinary sampling variance.
+
+### Short-lived code can have near-zero inclusion probability
+
+A routine that runs for 20 microseconds many times may contribute meaningful total work while rarely being active at the exact instant a sampler interrupts execution. If surrounding code is longer-lived, its apparent share can be inflated even when total sample count is high.
+
+This is different from saying "we need more samples." If the observation process systematically shadows some functions, increasing the duration can converge to the wrong distribution.
+
+### The profiler can change its own sampling process
+
+Sampling has overhead. Linux exposes `perf_cpu_time_max_percent` and can throttle sampling when collection consumes too much CPU time. Frequency mode also adjusts the period to chase a target rate.
+
+Those mechanisms are reasonable, but they mean the effective sampling process can vary over time. A report that preserves only the final symbol histogram loses evidence needed to decide whether the histogram was collected under one stable design.
+
+## Where current work is still weak
+
+### Randomization is treated as a configuration trick, not a measurement contract
+
+Randomized or carefully chosen sample periods are not novel. The gap is that many profiler outputs do not make the realized sampling schedule observable enough to diagnose aliasing after the fact.
+
+A robust profile should be able to answer:
+
+- What distribution generated the next sampling interval?
+- What interval was actually realized?
+- Did the kernel or runtime throttle or retune it?
+- Are sample times clustered at a stable phase relative to a repeating workload signal?
+- Do independent schedules produce the same hot-code ranking?
+
+Without those facts, a user can change `-F` or `-c` and compare screenshots, but the profiler cannot explain why the result moved.
+
+### A high sample count is often mistaken for high confidence
+
+Ten million samples sound convincing. They are not ten million independent observations if the workload is periodic, if many samples share one phase, or if a class of short functions is systematically missed.
+
+Classical confidence intervals based on independent Bernoulli samples can therefore be too optimistic. A profiler needs uncertainty that reflects time structure, repeated collection epochs, and coverage evidence rather than only `sqrt(n)` intuition.
+
+### Profiler UIs rarely distinguish variance from structural bias
+
+Two failure modes require different responses:
+
+1. **random variance:** independent samples disagree because the sample set is small;
+2. **structural bias:** the sampling mechanism systematically sees the wrong parts of execution.
+
+More samples help the first. They can make the second look more confidently wrong.
+
+A useful profiler should label these separately. Rank instability across independent randomized epochs suggests insufficient evidence. Persistent disagreement with selective instrumentation or a known workload oracle suggests structural bias.
+
+### Instrumentation is usually presented as the opposite of sampling
+
+Sampling is low overhead and broadly deployable. Instrumentation can provide much stronger coverage but historically costs more and may perturb execution.
+
+Blink shows that this trade-off is workload- and implementation-dependent. Its reported 1% overhead does not mean full instrumentation is always cheap. It does show that a profiler can use instrumentation as a **targeted oracle** instead of treating the choice as all-sampling or all-instrumentation.
+
+That creates a practical research question: can a profiler spend an instrumentation budget only on regions where sampling evidence is demonstrably weak?
+
+## Promising directions with academic and production value
+
+### 1. A randomized sampling contract with aliasing diagnostics
+
+**Gap.** Existing interfaces configure sample period or target frequency, but the final profile usually does not describe the realized stochastic process well enough to diagnose synchronization or retuning.
+
+**Mechanism.** Define sampling as a first-class schedule with recorded provenance. Each collection epoch specifies a target budget and an interval distribution, for example a bounded exponential or jittered renewal process rather than one fixed period. Each sample records its intended and realized interval, trigger source, current hardware period when available, CPU, timestamp, and any throttle or loss metadata.
+
+The analysis layer then performs an aliasing check. It can compare sample timestamps against dominant workload periods found from scheduler, request, runtime, or application markers. It can also examine the phase distribution modulo candidate periods. A suspiciously concentrated phase distribution is evidence that the sample clock is not exploring execution uniformly.
+
+The sampler should not randomize blindly. Hardware events with strong semantic meaning may require event-count sampling rather than time sampling, and some profilers need deterministic reproducibility. The contract therefore records the schedule and lets the workload choose among fixed, frequency-controlled, randomized, or mixed modes.
+
+**Delta.** Randomized clocks already exist in prior work. The contribution is making the schedule and its realized behavior part of the profile artifact, with an explicit aliasing diagnostic instead of an undocumented tuning trick.
+
+**Artifact.** A `perf`-compatible prototype or standalone collector that emits a sidecar sampling manifest plus a report showing interval distribution, phase concentration, throttling, sample loss, and per-epoch profile differences.
+
+**Evaluation.** Build periodic microbenchmarks whose phase length is known and sweep fixed periods, prime periods, frequency mode, and several randomized schedules under the same overhead budget. Add phase drift, CPU migration, and load changes. Measure per-function estimation error, top-k rank error, aliasing-detection precision/recall, and overhead.
+
+**Academic value.** This makes the relationship between a sampler's stochastic process and profile bias directly measurable.
+
+**Production value.** When a hot-function ranking changes, an engineer can tell whether the workload changed or the sampler synchronized with it.
+
+**Failure condition.** If ordinary `perf` frequency mode or a well-chosen fixed period already eliminates meaningful phase bias across realistic periodic workloads, the extra randomized contract adds complexity without enough benefit.
+
+### 2. Replicated profile epochs with uncertainty and rank stability
+
+**Gap.** Profiler percentages normally have no uncertainty attached, and sample count alone cannot distinguish independent evidence from correlated observations.
+
+**Mechanism.** Divide a collection budget into several independent epochs, each with a separately seeded sampling schedule. For every symbol or stack, keep the per-epoch estimate rather than immediately merging all samples. Report a central estimate plus uncertainty across epochs and a rank-stability score.
+
+For long-running correlated workloads, treat an epoch as the resampling unit rather than pretending every individual sample is independent. A block bootstrap or another dependence-aware estimator can quantify variation without requiring a false IID assumption.
+
+The UI should surface unresolved comparisons. If A is estimated at 8% and B at 7% but their epoch-level intervals overlap heavily, the report should say "ordering unresolved" rather than sorting them with two decimal places. If the top five remain stable across independent schedules, that is stronger evidence than one large merged histogram.
+
+**Delta.** Statistical uncertainty is standard methodology, and this report does not claim to invent confidence intervals. The systems contribution is to carry enough collection structure through the profiler pipeline that uncertainty and rank stability are valid properties of the recorded measurement.
+
+**Artifact.** A profile format extension and analysis tool that preserves epoch identity, effective sample periods, lost samples, per-epoch histograms, uncertainty intervals, and stable/unstable rank groups.
+
+**Evaluation.** Use workloads with known CPU shares, repeated phase changes, and flat short-function distributions. Compare naive sample-count intervals, epoch-based intervals, and ground truth. Score interval coverage, top-k stability, false confidence rate, and time required to reach a stable optimization decision.
+
+**Academic value.** The key question becomes "when is a profile decision statistically resolved?" rather than only "how many samples were collected?"
+
+**Production value.** Engineers can stop collecting when a decision is stable, or avoid optimizing noise when it is not.
+
+**Failure condition.** If epoch-level uncertainty is so wide on normal production windows that it rarely resolves useful rankings, the approach needs stronger stratification or a different estimator rather than another UI confidence badge.
+
+### 3. Uncertainty-triggered selective instrumentation
+
+**Gap.** Sampling remains attractive because it is cheap, while the workloads most likely to fool it can require stronger coverage.
+
+**Mechanism.** Start with low-overhead sampling. Use the diagnostics above to identify uncertain regions: symbols with unstable rank, short routines with suspiciously low coverage, phase-sensitive groups, or event classes with large skid risk. Spend a bounded instrumentation budget only on those regions for a short validation window.
+
+The instrumented window becomes a local oracle. It can measure entry counts, bounded timing, or exact events for the selected functions. The profiler compares sampled estimates with that oracle, learns a correction or declares the region not safely sampleable, then removes the instrumentation.
+
+This design should be conservative about correction. A one-time ratio should not silently "fix" future profiles if workload structure changes. The output should preserve which values are sampled, instrumented, corrected, or unresolved.
+
+**Delta.** Hybrid profilers already combine mechanisms, and Blink demonstrates that lightweight instrumentation can be practical. The new question is whether **uncertainty itself can drive where instrumentation is activated**, under a fixed overhead budget.
+
+**Artifact.** A hybrid profiler with a budget manager, sampling diagnostics, temporary function instrumentation, and a provenance-aware report format.
+
+**Evaluation.** Reproduce flat workloads similar to Blink's target class, plus server workloads with a few dominant hot functions. Compare sampling only, full instrumentation, and uncertainty-triggered instrumentation at equal overhead budgets. Measure coverage, attribution error, top-k correctness, instrumentation footprint, and time to diagnosis.
+
+**Academic value.** This turns measurement confidence into an online control signal for the profiler.
+
+**Production value.** A fleet profiler can stay cheap most of the time and pay for precision only where sampling evidence says it is needed.
+
+**Failure condition.** If identifying uncertain regions already requires enough instrumentation to erase the overhead advantage, or if dynamic instrumentation perturbs the flat workload more than it helps, the hybrid design is not worthwhile.
+
+## A benchmark needs adversarial sampling workloads, not only ordinary applications
+
+A profiler can look correct on workloads with one dominant function and still fail badly on periodic or flat code. Evaluation should therefore include workloads designed to stress the estimator itself.
+
+A useful benchmark matrix would contain:
+
+| Workload | What it tests |
+| --- | --- |
+| fixed periodic phases | phase locking and aliasing |
+| slowly drifting phase | whether randomization remains representative |
+| thousands of short equal-weight routines | incomplete coverage and rank error |
+| one dominant hot function | simple case where sampling should win |
+| bursty request phases | time correlation and epoch design |
+| PMU event with configurable precision | skid sensitivity |
+| sampler under CPU pressure | throttling and effective-rate changes |
+| selectively instrumented ground truth | estimator error and interval coverage |
+
+The benchmark should score more than overhead and visual similarity. At minimum it should measure:
+
+- per-symbol relative error;
+- top-k precision and recall;
+- pairwise rank reversals;
+- fraction of executed functions ever observed;
+- uncertainty-interval coverage;
+- false-confidence rate, where the profile declares a stable ranking that ground truth disproves;
+- effective sample rate and loss;
+- CPU and memory overhead.
+
+The most important metric may be **decision error**. If the profiler causes an engineer or optimizer to choose the wrong function to optimize, a tiny aggregate histogram error is not reassuring.
+
+## The first prototype should be deliberately boring
+
+This problem does not initially require a new kernel subsystem.
+
+A useful first prototype can run in userspace around existing `perf_event_open()` interfaces:
+
+1. collect several short independent epochs;
+2. vary or jitter supported sampling periods while preserving the same total overhead budget;
+3. record timestamps, periods, loss, and throttle evidence already available from perf;
+4. compute phase concentration and rank stability;
+5. selectively instrument a small set of ambiguous functions in a controlled benchmark;
+6. compare both paths against known ground truth.
+
+Only after that experiment shows a missing primitive should the work ask for kernel support, such as a stronger randomized-overflow mode or better sample-schedule provenance.
+
+This order matters. McCanne and Torek already showed that the clock matters more than thirty years ago. A 2026 systems contribution should not be "randomize the timer again." It should show that **modern profilers can detect when their measurement is biased, quantify unresolved uncertainty, and escalate precision without violating a fixed overhead budget.**
+
+## What would change this conclusion?
+
+Three results would weaken the case substantially.
+
+First, if current `perf` frequency control and common event-period practices produce unbiased, stable rankings across periodic, flat, short-function, and phase-changing workloads at low overhead, there is little reason to add a richer sampling contract.
+
+Second, if Blink-style instrumentation or another low-overhead instrumentation method is consistently cheap enough and more accurate across the same workload classes, the right answer may be to instrument rather than make sampling more statistically sophisticated.
+
+Third, if epoch-level uncertainty and aliasing diagnostics do not predict real ground-truth errors, then they are only plausible-looking statistics. The benchmark must show that a warning corresponds to a higher probability of a wrong optimization decision.
+
+Until those tests are run, sample percentages should be treated as estimates with a measurement design behind them, not as exact CPU accounting. The interesting systems problem is no longer how to collect more samples. It is how to make a profiler explain **when its own samples are enough to trust**.

--- a/docs/research/profiler-sampling-bias.zh.md
+++ b/docs/research/profiler-sampling-bias.zh.md
@@ -1,0 +1,249 @@
+---
+date: 2026-08-19
+title: "性能分析器的采样什么时候会产生偏差？"
+description: "采样结果看起来很精确，但相位锁定、skid 和短函数漏采都可能造成系统性偏差。本文讨论怎样让 profiler 给出可验证的置信度和退化路径。"
+tags:
+  - 每日报告
+  - 性能分析
+  - Sampling
+  - Linux perf
+  - 可观测性
+  - 统计
+research_question: "采样型性能分析器怎样识别并量化相位锁定、覆盖不足、skid 和其他系统性误差，而不是把 sample 百分比当成精确计数？"
+source_cutoff: 2026-08-19
+status: daily-report
+---
+
+# 性能分析器的采样什么时候会产生偏差？
+
+一个 profiler 每秒对某个服务采样 1000 次。服务内部正好有一个重复的 1 ms 控制循环。报告显示函数 A 占 8.1% CPU，函数 B 占 5.7%。第二次运行时，两者的顺序反过来了。把采样频率再调高，两边的百分比又一起变了。
+
+这时候应该相信哪一次？
+
+最常见的回答是多采一点。这个办法只在主要问题是随机方差时有效。如果 sampler 总是在周期性 workload 的同一个相位打断程序，或者持续漏掉短函数，或者 PMU overflow 发生后实际记录的 IP 已经滑到了后面的指令，多跑十分钟只会收集更多同一种错误。
+
+<!-- more -->
+
+问题的本质是：sampling profile 是一个**估计器**，但很多 profiler 的 UI 把它显示得像精确计数器。一个 `8.1%` 隐藏了大量条件：sample 是怎样安排的、哪些代码有机会被看到、丢了多少 sample、采样周期有没有和程序周期同步、不同独立运行是不是得到相同排名。
+
+这并不是新发现。Steven McCanne 和 Chris Torek 在 1993 年发表的 [A Randomized Sampling Clock for CPU Utilization Estimation and Code Profiling](https://www.usenix.org/conference/usenix-winter-1993-conference/randomized-sampling-clock-cpu-utilization-estimation-and) 就专门处理周期采样和程序行为同步的问题。后来一篇 USENIX profiler 工作也讨论了 DCPI 怎样随机化 sample interval，以及不可预测的一次性 timer 为什么能减少意外同步。到了今天，Linux kernel 的 Propeller 文档在收集硬件 sample 时仍然建议使用类似 `500009` 这样的合适大质数作为 event period，而不是随手选一个整齐的数。
+
+但相位锁定只是其中一类误差。OSDI 2026 的 operational systems paper [When Sampling Lies: Trustworthy Performance Profiling for Flat Workloads with Blink](https://www.usenix.org/conference/osdi26/presentation/devsot) 研究了一类很平的 mobile workload：成千上万个生命周期很短的 routine 分摊整体执行时间，没有一个明显热点。作者发现 `perf` 一类 sampling profiler 会因为 skid、shadow effect 和 function coverage 不完整而出现系统性错误，不只是方差变大。Blink 改用轻量 instrumentation，在论文评测 workload 上报告了 99.999% accuracy 和约 1% overhead。
+
+这些结果说明，比“提高采样频率”更有价值的目标是：**profiler 应该能告诉用户，当前 workload 下自己的估计到底可不可信；如果不可信，还应该有一个有预算上限的精确化路径。**
+
+本文刻意把这个问题作为 adjacent-systems 主题，而不是 eBPF 主题。它同样适用于 `perf`、PMU profiler、runtime profiler、mobile profiler、GPU profiler 和其他周期或 event-driven sampler。eBPF 可以参与实现，但并不是核心机制成立的必要条件。
+
+## 一个 sample 百分比背后有很多假设
+
+Linux `perf_event_open()` 同时提供 `sample_period` 和 `sample_freq`。使用 period 时，每累计到指定数量的 event 就触发一次 overflow。使用 frequency mode 时，kernel 会调整 period，尽量达到目标采样频率。sample 本身还可以带上当前 period、timestamp、CPU、instruction pointer、callchain，以及丢 sample 等信息。
+
+这些接口足够构建很强的 profiler，但下面这个比例：
+
+```text
+归因到 X 的 samples / 总 samples
+```
+
+只有在采样过程足够有代表性时，才能成为 CPU 时间或事件占比的好估计。
+
+现实里有几类假设很容易失效。
+
+### 采样时钟会和 workload 同步
+
+假设程序一直重复下面的周期：
+
+```text
+A 运行 300 us -> B 运行 300 us -> C 运行 400 us -> 重复
+```
+
+如果 profiler 每 1 ms 在相同相位取一次 sample，它可能几乎只看到其中一段。继续收集十倍时间没有帮助，因为新增观察一直重复原来的偏差。
+
+这也是为什么 randomized sampling 这个三十多年前的想法今天仍然值得认真对待。1993 年的 randomized clock 工作把 synchronization 当成 sampling 设计问题。Linux Propeller 文档建议使用较大质数 period，也是在工程实践里尽量避免简单周期关系。
+
+大质数不是独立性的证明，frequency feedback 也不等于随机采样。真正重要的是：**sample timing 本身属于测量设计，不只是 overhead 参数。**
+
+### Hardware sample 会 skid
+
+PMU overflow 并不总能精确落在逻辑上造成 event 的那条指令。现代硬件和 `perf` 在部分 event 上提供更精确的采样能力，但不同事件和架构之间差异很大。
+
+如果只是找一个占 CPU 40% 的大热点，一点 skid 可能无关紧要。如果是大量短函数、很平的 profile，或者需要指令级 event attribution，skid 就可能直接改变排名。Blink 在 OSDI 2026 的结果里把它当成系统性误差来源之一，而不是简单的随机噪声。
+
+### 很短的函数可能几乎没有被观察到的机会
+
+一个函数每次只执行 20 微秒，但被调用很多次，总 CPU 成本仍然可能很高。可是在任意一个 sampler interrupt 到来的瞬间，它恰好在运行的概率可能很低。周围更长的函数反而更容易被 sample 命中，于是占比被高估。
+
+这和“样本数不够”不是一回事。如果 observation process 系统性 shadow 掉某一类函数，延长采样时间甚至可能越来越稳定地收敛到错误分布。
+
+### Profiler 会动态改变自己的采样过程
+
+Sampling 有成本。Linux 的 `perf_cpu_time_max_percent` 可以在 profiler 消耗过多 CPU 时触发 throttling。frequency mode 也会动态调整 period 来追踪目标频率。
+
+这些机制本身很合理，但它们意味着有效采样过程会随时间变化。如果最终产物只保存一张 symbol histogram，就会丢掉判断这张 histogram 是怎样采出来的证据。
+
+## 现有工作还薄弱在哪里
+
+### Randomization 常常只是一个调参技巧，而不是测量契约
+
+随机化 sample period 本身并不新。真正缺的是 profiler 把**实际发生的采样 schedule**保存成一等证据，让用户能在事后判断是否发生 aliasing。
+
+一个更可靠的 profile 至少应该能回答：
+
+- 下一次 sample interval 来自什么分布？
+- 最终实际 interval 是多少？
+- kernel 或 runtime 有没有 throttle 或重新调整？
+- sample 时间相对于某个重复 workload 周期是否集中在固定相位？
+- 换一个独立 schedule 后，hot-code 排名是否仍然一致？
+
+如果没有这些信息，用户只能不断改 `-F` 和 `-c`，然后肉眼比较两张报告，却不知道结果为什么变了。
+
+### Sample 数量很多，不等于置信度很高
+
+一千万个 sample 听起来很有说服力。但如果 workload 有强周期性，或者大量 sample 都落在同一个相位，或者一类短函数一直被漏掉，那么这些 sample 并不是一千万个独立观察。
+
+因此，只基于独立 Bernoulli sample 假设得到的经典 confidence interval 可能过于乐观。Profiler 的 uncertainty 应该反映时间相关性、独立 collection epoch 和 coverage，而不是只看 `sqrt(n)`。
+
+### Profiler UI 很少区分随机方差和结构性偏差
+
+这两个问题需要完全不同的处理：
+
+1. **随机方差**：采样过程大体正确，只是 sample 不够多；
+2. **结构性偏差**：sampler 系统性地看到了错误的执行区域。
+
+多采样对第一类有帮助。对第二类，它只会让错误答案看起来更“稳定”。
+
+一个好的 profiler 应该把两种状态分开。多个独立 randomized epoch 的排名反复变化，说明证据还不够。sample 结果长期和 selective instrumentation 或已知 ground truth 不一致，则更像结构性偏差。
+
+### Instrumentation 不应该总被当成 sampling 的对立面
+
+Sampling 的优势是 overhead 低、部署范围广。Instrumentation 的覆盖更完整，但传统上成本更高，也可能改变程序行为。
+
+Blink 表明这个 trade-off 取决于 workload 和实现。论文里的约 1% overhead 当然不能直接推广到所有程序，但它说明 instrumentation 可以作为一个**局部 oracle**，而不是只能在“全量 sampling”和“全量 instrumentation”之间二选一。
+
+这带来一个更实用的问题：profiler 能不能只在 sampling 证据明显不足的地方花 instrumentation budget？
+
+## 值得继续做的研究和工程方向
+
+### 1. 带 aliasing 诊断的 randomized sampling contract
+
+**Gap.** 现有接口能设置 period 或目标频率，但最终 profile 通常没有完整描述实际采样随机过程，因此出了 synchronization 以后很难解释。
+
+**Mechanism.** 把 sampling schedule 当成 profile 的一等元数据。每个 collection epoch 给出目标 overhead budget 和 interval distribution，例如 bounded exponential 或带 jitter 的 renewal process，而不是固定周期。每个 sample 同时记录 intended interval、realized interval、trigger source、当前 hardware period、CPU、timestamp，以及 throttle 和 loss 信息。
+
+分析层再做 aliasing 检查。它可以从 scheduler、request、runtime 或 application marker 中寻找主要 workload period，然后检查 sample timestamp 对这些周期取模后的 phase distribution。如果样本集中在很窄的 phase 范围，就说明 sampling clock 没有均匀探索整个执行周期。
+
+Sampler 也不应该无脑随机化。某些有明确语义的硬件 event 更适合按 event count 采样，有些 profiler 还需要可复现的确定性 schedule。因此 contract 应该明确记录 fixed、frequency-controlled、randomized 或 mixed mode，而不是强制只有一种模式。
+
+**Delta.** Randomized clock 已经是已有工作。新的系统贡献不是“再随机一次 timer”，而是把 schedule 及其真实执行结果写进 profile artifact，并提供明确的 aliasing diagnostic。
+
+**Artifact.** 一个兼容 `perf` 数据路径的 prototype，或者独立 collector。它输出 sampling manifest，并在报告里显示 interval distribution、phase concentration、throttling、sample loss 和不同 epoch 之间的 profile 差异。
+
+**Evaluation.** 构造周期长度已知的 microbenchmark，在相同 overhead budget 下比较 fixed period、prime period、frequency mode 和几种 randomized schedule。再加入 phase drift、CPU migration 和负载变化。测量 per-function estimation error、top-k rank error、aliasing detection precision/recall 和 overhead。
+
+**学术价值。** 可以直接测量 sampler 的随机过程与 profile bias 之间的关系。
+
+**生产价值。** Hot-function 排名变化时，工程师能判断到底是 workload 变了，还是 sampler 和 workload 同步了。
+
+**Failure condition.** 如果普通 `perf` frequency mode 或经过良好选择的固定 period 已经能在现实周期 workload 上消除有意义的 phase bias，那么更复杂的 randomized contract 不值得维护。
+
+### 2. 用独立 profile epoch 表达 uncertainty 和 rank stability
+
+**Gap.** 传统 profile 百分比没有 uncertainty；sample 数量又不能区分独立证据和强相关观察。
+
+**Mechanism.** 把总采集预算分成几个彼此独立的 epoch，每个 epoch 使用独立 seed 或 schedule。对每个 symbol 和 stack 保留 per-epoch estimate，不要一开始就把全部 samples 合并掉。最后输出 central estimate、跨 epoch uncertainty 和 rank-stability score。
+
+对于有强时间相关性的长 workload，应把 epoch 当成 resampling unit，而不是假设每一个 sample 都 IID。可以使用 block bootstrap 或其他 dependence-aware estimator 来估计变化范围。
+
+UI 还应该明确显示“尚未解决”的排序。如果 A 是 8%，B 是 7%，但两个 epoch-level interval 大量重叠，就不应该用两位小数把 A 固定排在 B 前面。相反，如果独立 schedule 下 top five 始终一致，这比一张巨大的合并 histogram 更有说服力。
+
+**Delta.** 统计学里的 uncertainty 当然不是新东西。这里真正的系统问题，是 profile collection pipeline 是否保留了足够结构，让 uncertainty 和 rank stability 成为合法、可验证的测量属性。
+
+**Artifact.** 扩展 profile format 和 analysis tool，保存 epoch identity、effective sample period、lost sample、per-epoch histogram、uncertainty interval 和 stable/unstable rank group。
+
+**Evaluation.** 用 CPU share 已知的 workload、重复 phase change 和 flat short-function workload 比较 naive sample-count interval、epoch-based interval 和 ground truth。测 interval coverage、top-k stability、false-confidence rate，以及达到稳定优化决策需要的采集时间。
+
+**学术价值。** 问题会从“收了多少 sample”变成“这个 profile decision 在统计上什么时候真正 resolved”。
+
+**生产价值。** 工程师可以在决策已经稳定时停止采集，也可以避免把随机排名当成热点去优化。
+
+**Failure condition.** 如果正常生产时间窗口下 epoch-level uncertainty 总是太宽，几乎无法给出有用排序，那么应该改进 stratification 或 estimator，而不是只在 UI 上加一个 confidence badge。
+
+### 3. 由 uncertainty 触发 selective instrumentation
+
+**Gap.** Sampling 的最大价值仍然是便宜，但最容易被 sampling 骗到的 workload 恰好需要更强覆盖。
+
+**Mechanism.** 先低成本 sampling。用前面的诊断找出证据不足的区域，例如 rank 不稳定的 symbol、疑似覆盖率过低的短函数、phase-sensitive function group，或者 skid 风险很大的 event。然后只在这些区域开启一个有严格预算的短期 instrumentation window。
+
+这个 instrumented window 作为局部 oracle，可以记录 entry count、受控 timing 或选定的 exact event。Profiler 把 sampling estimate 和 oracle 对比，判断当前区域能否安全用 sampling；如果不能，就明确标记 unresolved 或临时保留 instrumentation。
+
+Correction 必须保守。不能用一次 ratio 永久“修正”后续 profile，因为 workload 结构可能已经变化。输出里要保留哪些值来自 sampled、instrumented、corrected 或 unresolved。
+
+**Delta.** Hybrid profiler 并不新，Blink 也证明了轻量 instrumentation 在一些 workload 上很实用。这里新的问题是：**能不能让 uncertainty 自己成为 instrumentation placement 的控制信号**，并且始终遵守固定 overhead budget？
+
+**Artifact.** 一个 hybrid profiler，包含 budget manager、sampling diagnostics、临时 function instrumentation，以及带 provenance 的 report format。
+
+**Evaluation.** 复现 Blink 一类 flat workload，同时加入少数函数占主导的普通 server workload。在同样 overhead budget 下比较 sampling-only、full instrumentation 和 uncertainty-triggered instrumentation。测 coverage、attribution error、top-k correctness、instrumentation footprint 和 time-to-diagnosis。
+
+**学术价值。** Measurement confidence 从一个离线统计值变成 profiler 的在线控制信号。
+
+**生产价值。** Fleet profiler 大多数时间保持低成本，只有 sampling 证据确实不足时才为精度付费。
+
+**Failure condition.** 如果识别 uncertain region 本身就需要接近全量 instrumentation 的成本，或者动态 instrumentation 对 flat workload 的扰动大于收益，那么 hybrid design 就不成立。
+
+## Benchmark 应该专门包含会“骗过” sampler 的 workload
+
+一个 profiler 在“一个函数占 50% CPU”的 workload 上表现很好，不代表它面对周期和 flat workload 也可靠。因此 benchmark 不能只选常见 application，还要专门攻击 estimator。
+
+可以包含下面这些 case：
+
+| Workload | 主要检查的问题 |
+| --- | --- |
+| 固定周期 phase | phase locking 和 aliasing |
+| 缓慢漂移的 phase | randomization 是否仍有代表性 |
+| 上千个等权短函数 | coverage 和 rank error |
+| 一个明显热点函数 | sampling 应该表现很好的简单场景 |
+| bursty request phase | 时间相关性和 epoch 划分 |
+| 支持不同 precision 的 PMU event | skid sensitivity |
+| CPU 压力下的 sampler | throttling 和实际 sample rate 变化 |
+| 有 selective instrumentation ground truth 的 case | estimator error 和 interval coverage |
+
+评价指标也不能只有 overhead 和图看起来像不像。至少需要：
+
+- per-symbol relative error；
+- top-k precision / recall；
+- pairwise rank reversal；
+- 实际执行过的函数中，有多少从未被 sample 看见；
+- uncertainty interval coverage；
+- false-confidence rate，也就是 profiler 声称排名已经稳定，但 ground truth 证明它错了的比例；
+- effective sample rate 和 sample loss；
+- CPU / memory overhead。
+
+最有意义的指标可能是 **decision error**。如果 profiler 导致工程师或 optimizer 去优化错误的函数，那么整体 histogram 只有很小的数值误差也没有太大安慰作用。
+
+## 第一版 prototype 应该尽量普通
+
+这个问题一开始不需要发明新的 kernel subsystem。
+
+一个有价值的第一版完全可以围绕现有 `perf_event_open()` 做：
+
+1. 收几个短而独立的 epoch；
+2. 在总 overhead budget 不变的条件下，改变或 jitter 支持的 sampling period；
+3. 保存 perf 已经能给出的 timestamp、period、loss 和 throttle 证据；
+4. 计算 phase concentration 和 rank stability；
+5. 在 benchmark 里只 instrumentation 一小组 ambiguous function；
+6. 把两条路径都和已知 ground truth 对比。
+
+只有这个实验明确证明缺少底层 primitive 之后，才应该讨论 kernel 侧支持，例如更直接的 randomized overflow mode 或更完整的 sample-schedule provenance。
+
+这个顺序很重要。McCanne 和 Torek 三十多年前就已经证明 sampling clock 会影响结果。2026 年真正值得做的系统工作不应该只是“再随机一下 timer”。它应该证明：**现代 profiler 能识别自己的 measurement 什么时候有偏差，能量化还没解决的 uncertainty，并且在不突破 overhead budget 的前提下升级精度。**
+
+## 哪些结果会改变这个判断？
+
+有三类结果会明显削弱上面的方向。
+
+第一，如果当前 `perf` frequency control 加上常见 event-period 选择，在周期、flat、短函数和 phase-changing workload 上已经能以低 overhead 给出无明显偏差且稳定的排名，那么没有必要再增加 sampling contract。
+
+第二，如果 Blink 一类 instrumentation 或其他低成本 instrumentation 方法在同样 workload 上持续更准确，而且成本已经足够低，那么更直接的工程答案可能是 instrumentation，而不是让 sampling 变得越来越复杂。
+
+第三，如果 epoch-level uncertainty 和 aliasing diagnostic 与真实 ground-truth error 没有预测关系，那么这些统计值只是看起来合理。Benchmark 必须证明 warning 真正对应更高的错误优化决策概率。
+
+在这些实验完成之前，sample 百分比更应该被看成有明确 measurement design 的估计，而不是精确 CPU accounting。真正有意思的问题已经不是“怎样收更多 sample”，而是 profiler 怎样解释：**自己的这些 sample 到底什么时候已经足够可信。**


### PR DESCRIPTION
## Evidence

- The first complete Daily Report ten-report window must contain one genuine adjacent-systems report. Before this change the completed archive is 7 eBPF-centered / 2 pure Agent / 0 adjacent out of 9.
- Current Google evidence does not justify an unrelated SEO rewrite. The valid finalized GSC six-day comparison is 393 clicks / 66,510 impressions for Aug 10-15 versus 478 / 69,053 for Aug 3-8; the older slice includes the unusual Aug 5 impression spike, and complete adjacent 7-day plus 28-day comparisons remain unavailable.
- The GA4 Aug 10-16 weekly aggregate is now finalized under the repository's three-day lag: 970 sessions at ~44.95% session-weighted engagement versus 991 at ~44.90% for Aug 3-9. `(not set)` is 134 vs 116; excluding it, sessions are 836 vs 875.
- The current public-safe brief reports homepage HTTP 200, reachable robots/sitemap, canonical homepage, and 672 sitemap entries. No new technical SEO defect is established.
- Primary profiling evidence includes the 1993 randomized sampling-clock work, Linux `perf_event_open()` sampling semantics and current kernel profiling guidance, and the OSDI 2026 Blink result on systematic sampling error in flat workloads.

## Scope

- Publish exactly one new bilingual Daily Report: general profiler sampling bias and confidence.
- Update both Daily Report indexes.
- Record the adjacent-systems detour in the active series and preserve the first ten-report window at 7 eBPF / 2 Agent / 1 adjacent.
- Refresh the daily operating record, status, plan, and Google finalization state.
- Repair the already-merged Aug 18 PR #162 closeout omission before this public change; that repair is a PR comment only and is not part of this diff.
- No unrelated technical SEO implementation change.

## Report thesis

Sampling percentages are estimators, not counters. Fixed or retuned sampling can phase-lock with periodic work, PMU samples can skid, short-lived routines can be systematically under-covered, and sample count alone can create false confidence. The report develops: (1) a realized sampling-schedule contract with aliasing diagnostics, (2) replicated independent profile epochs with uncertainty and rank stability, and (3) uncertainty-triggered selective instrumentation under a fixed overhead budget.

This is classified adjacent systems because the mechanism applies to `perf`, PMU, runtime, mobile, GPU, and other profilers without requiring eBPF.

## Validation

Repository CI is authoritative for SEO-data validation, Daily Report structure, generated content, links, metadata, static build, and deployment readiness. After all expected checks are green I will review the complete final diff, commits, and generated output before squash merge.

## Production target and acceptance

- Deployment: exact squash commit through `Deploy Static App` / GitHub Pages.
- Verify both `/research/profiler-sampling-bias/` and `/zh/research/profiler-sampling-bias/` in production.
- Acceptance includes Daily Report navigation, correct title/description, canonical URL, reciprocal `en`/`zh` plus `x-default`, Article JSON-LD, internal/external links, explicit current-work gap, developed directions, and conclusion-change boundary.
- Add exactly one compact closeout comment to this merged PR with exact CI/deployment/verification evidence. No second closeout PR.

The SEO skill submodule remains pinned. Upstream is newer but the consuming contract still depends on the pinned layout, so no pointer-only update is included.