### PR TITLE
Daily: attribute GPU kernel launch latency

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -18,24 +18,24 @@ already configured and enabled; it is not a blocker.
 ## Current data-history constraint
 
 Google Drive access is verified and is not a blocker. The configured folder
-contains three adjacent weekly Search Console and GA4 export sets beginning
-`2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer weekly set was observed on
-`2026-08-19`. The newest Search Console date file has rows through `2026-08-15`,
-which are finalized under the configured three-day lag.
+contains adjacent weekly export sets beginning `2026-07-27`, `2026-08-03`, and
+`2026-08-10`; no newer weekly set beginning `2026-08-17` was observed on
+`2026-08-20`. The newest verified Search Console date rows remain through
+`2026-08-15`, which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
 unavailable because the `2026-08-09` date row is absent across the adjacent
 weekly exports. The available data supports an equal-duration six-day comparison
 for `2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
-The 28-day comparison also remains unavailable because the export history is not
-long enough.
+The 28-day comparison also remains unavailable because the verified export
+history is not long enough.
 
-GA4 landing-page files are weekly aggregates without a date dimension. On
-`2026-08-19`, the complete `2026-08-10` through `2026-08-16` aggregate is outside
-the configured three-day finalization lag and is usable as a finalized
-source-native weekly comparison against `2026-08-03` through `2026-08-09`. The
-landing-page exports still do not provide complete acquisition, conversion, or
-outbound behavior coverage by themselves.
+GA4 landing-page files are weekly aggregates without a date dimension. The
+complete `2026-08-10` through `2026-08-16` aggregate remains outside the
+configured three-day finalization lag and is usable as a finalized source-native
+weekly comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4
+set was observed on `2026-08-20`. The landing-page exports still do not provide
+complete acquisition, conversion, or outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use
 the available Google exports, live-site evidence, public GitHub evidence, and

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -78,11 +78,17 @@ how to distinguish allocation from pages that were actually touched, faulted,
 reclaimed, migrated, or responsible for sampled memory cost while preserving
 provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
-The `2026-08-19` report is a deliberate one-run **adjacent profiling detour** on
-sampling bias. Its central mechanism is general profiler measurement design, not
-eBPF, so it is classified as adjacent systems. It closes the first ten-report
-window at the intended 7 eBPF / 2 Agent / 1 adjacent mix without relabeling an
-eBPF-essential question.
+The `2026-08-19` report is a deliberate **adjacent profiling detour** on sampling
+bias. Its central mechanism is general profiler measurement design, not eBPF, so
+it is classified as adjacent systems. It closes the first ten-report window at
+7 eBPF / 2 Agent / 1 adjacent without relabeling an eBPF-essential question.
+
+The `2026-08-20` report is a second adjacent profiling detour required by the
+rolling-window arithmetic. It asks whether a late CUDA kernel start came from
+host scheduling, runtime/command-buffer work, a dependency, or device
+availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
+host tracing can be an optional evidence source but is not essential, so this
+report is also adjacent systems rather than eBPF-centered.
 
 ### Published progress
 
@@ -100,29 +106,39 @@ eBPF-essential question.
    selective instrumentation. Because the mechanism applies to profilers in
    general and does not require eBPF, this report is adjacent systems rather than
    eBPF-centered.
+3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
+   command-buffer queue/submission, dependency readiness, device availability,
+   and kernel execution. It develops an explicit launch-state ledger, a
+   cross-domain launch identity that survives host handoffs and graph replay, and
+   a ground-truth launch-delay attribution benchmark. The central question is GPU
+   profiling, so it is adjacent systems.
 
-After these reports, the first complete ten-report window is **7 eBPF-centered /
-2 pure Agent / 1 adjacent systems out of 10**. The next normal run may return to
-an eBPF-centered question inside this active series. Continue enforcing the
-rolling 10-report window as the oldest reports age out rather than treating the
-7 / 2 / 1 split as permanent.
+After the August 20 report, the rolling ten-report window is **7 eBPF-centered /
+1 pure Agent / 2 adjacent systems**. The oldest report still inside that window
+is the remaining pure-Agent parallel-effect report. Therefore the next
+publication must again be non-eBPF: immediately adding an eBPF-centered report
+would create 8 eBPF reports in the rolling ten and violate the 5–7 requirement.
+Once the oldest eBPF reports start aging out, an eBPF-centered report can return
+without exceeding the cap.
 
 ### Preferred next questions
 
-Sampling theory is now covered by the adjacent report above. The preferred next
-questions inside the active eBPF series are:
+The active eBPF-series questions remain valuable but are deferred while the
+rolling window is at its eBPF ceiling:
 
 1. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
 2. application-defined resource profiling that combines static discovery,
    runtime eBPF evidence, and online validation;
-3. causal profiling for GPU host-side bottlenecks and megakernel execution;
+3. causal profiling for GPU host-side bottlenecks and megakernel execution where
+   eBPF is genuinely essential to the mechanism;
 4. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
 
-The next run should start with these active-series questions and use current
-primary evidence to choose among them. A weak or duplicative candidate should be
-rejected rather than padded.
+For the next run, choose a genuine adjacent-systems question or an unusually
+strong pure-Agent systems question after fresh evidence and novelty review. Do
+not relabel one of the eBPF-essential candidates just to continue the active
+series one day earlier.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
@@ -193,6 +209,11 @@ eBPF-like programmable monitors near GPU or DPU execution.
 Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
 runtime is central to the mechanism being evaluated.
 
+The August 20 launch-latency report is a focused adjacent-systems contribution to
+this roadmap. It does not promote this queued series to active; the active series
+remains eBPF Observability and Profiling once the rolling mix permits another
+eBPF-centered report.
+
 ## Queued series — Agent Systems (limited)
 
 Pure Agent systems work is intentionally a minority topic. Use this series only
@@ -204,8 +225,10 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-These occupy the pure-Agent budget in the current rolling window. Do not schedule
-another pure Agent report until the rolling mix permits it.
+After the August 20 report, only the parallel-effect report remains inside the
+rolling ten-report window. Pure-Agent publication is allowed by the cap, but is
+not required; prefer a technically stronger adjacent-systems question when one
+passes the evidence and novelty gates.
 
 Future Agent reports should preferentially connect back to eBPF or systems
 infrastructure, for example OS-level effect tracing, eBPF policy enforcement,
@@ -216,14 +239,14 @@ sandbox escape visibility, syscall/tool causality, or runtime resource control.
 Each daily run should:
 
 1. calculate the current rolling topic mix;
-2. start inside the active series;
+2. start inside the active series when the mix permits it;
 3. research multiple candidate questions if necessary;
 4. reject candidates that do not pass the evidence and novelty gates;
 5. choose one question that both passes quality review and keeps the rolling mix
    compliant;
 6. publish exactly one new Daily Report;
 7. record the chosen series, topic classification, rejected candidates when
-   useful, and why the report materially advances the series.
+   useful, and why the report materially advances the roadmap.
 
-A series switch should be recorded in the daily operating record and in this
-file so the repository, not chat history, remains authoritative.
+A temporary out-of-series detour should be recorded in the daily operating record
+and in this file so the repository, not chat history, remains authoritative.

--- a/.github/seo-data/daily/2026-08-20.md
+++ b/.github/seo-data/daily/2026-08-20.md
@@ -1,0 +1,230 @@
+# SEO operations — 2026-08-20
+
+## Scope
+
+This run follows the repository-authoritative `DAILY_TASK.md`: analyze every
+enabled evidence source, audit technical SEO/GEO behavior, calculate the rolling
+Daily Report mix before topic selection, publish exactly one new bilingual Daily
+Report, and deliver the public change through one fresh `daily/` branch and one
+non-draft pull request.
+
+The completed archive contains ten reports before today's publication: **7
+eBPF-centered / 2 pure Agent / 1 adjacent systems**. Because the oldest report
+that leaves the rolling ten after today's publication is a pure-Agent report,
+an eBPF-centered report today would produce 8 eBPF reports in the rolling ten and
+violate the repository's 5–7 rule. The selected question is therefore genuinely
+adjacent systems: **how a GPU profiler can distinguish host launch delay,
+command-buffer queue/submission, dependency wait, device availability, and
+kernel execution without turning one timeline gap into an invented cause**.
+
+No unrelated technical SEO implementation change is included because today's
+evidence does not establish a new defect.
+
+## Data window
+
+This run used every source enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
+| --- | --- | --- |
+| Google Search Console | weekly Drive export history through the week ending `2026-08-16`; finalized rows through `2026-08-15` | available but incomplete for the required adjacent 7-day comparison because `2026-08-09` is absent |
+| Google Analytics 4 | weekly organic landing-page aggregates through `2026-08-16` | available; newest aggregate finalized under the three-day lag |
+| Public-safe repository collection | `.github/data-analysis/latest.md`, generated `2026-08-20 08:02 UTC` | available |
+| Public GitHub | current repository and public project state | available |
+| Live / generated technical site evidence | homepage, robots, sitemap, canonical, and exact production static artifacts | available |
+| Public web / primary research | current NVIDIA CUPTI, Nsight Systems, and CUDA documentation checked through `2026-08-20` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
+
+The configured Google Drive folder was resolved by its configured name and
+searched again. No newer weekly set beginning `2026-08-17` was observed. Missing
+or delayed source coverage is unavailable rather than zero.
+
+A complete latest-seven-days versus previous-seven-days GSC comparison remains
+unavailable because the `2026-08-09` date row is absent across adjacent exports.
+The required 28-day comparison is also unavailable because verified history is
+too short. The valid equal-duration six-day comparison remains `2026-08-10`
+through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
+
+## Evidence collected
+
+### Search Console
+
+For `2026-08-10` through `2026-08-15`, Search Console reports **393 clicks** and
+**66,510 impressions**, weighted CTR about **0.591%**, and
+impression-weighted average position about **9.91**.
+
+The comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks** and
+**69,053 impressions**, **0.692%** CTR, and average position about **9.42**.
+Clicks are therefore about **17.8% lower**, impressions about **3.7% lower**, CTR
+about **0.101 percentage points lower**, and average position about **0.49
+positions worse** in the newer slice.
+
+The older slice contains the unusual `2026-08-05` spike of **24,516
+impressions**, while available exports do not provide date-by-page or
+date-by-query joins. The movement remains observed but unattributed and does not
+justify a search-facing rewrite.
+
+### Google Analytics 4
+
+The finalized `2026-08-10` through `2026-08-16` organic landing-page aggregate
+contains **970 sessions** at about **44.95%** session-weighted engagement. The
+preceding `2026-08-03` through `2026-08-09` aggregate contains **991 sessions**
+at about **44.90%** engagement.
+
+Sessions are about **2.1% lower** while engagement is effectively flat. `(not
+set)` is **134 versus 116 sessions**; excluding that row, sessions are **836
+versus 875**. These remain acquisition and measurement-quality signals rather
+than evidence for a speculative content, title, navigation, or analytics change.
+
+### Public-safe technical and repository evidence
+
+The current public-safe operating brief reports:
+
+- homepage HTTP 200 in **189 ms**;
+- `robots.txt` and sitemap HTTP 200;
+- **674** sitemap entries;
+- canonical homepage `https://eunomia.dev/`;
+- **97** active non-fork repositories in the public GitHub portfolio snapshot;
+- **9,775** stars, **1,280** forks, and **284** open issue/PR records;
+- **60** DEV articles, **43** public reactions, and **4** comments.
+
+The technical audit does not establish a new crawl, canonical, `hreflang`,
+structured-data, redirect, broken-link, rendering, accessibility, performance,
+or deployment defect. Today's public site scope is therefore the mandatory Daily
+Report and its directly coupled bilingual indexes and operating state.
+
+### Previous-run closeout completed before today's delivery
+
+PR `#163` was already prepared on August 19 but had not been merged or closed out.
+This run completed that lifecycle before today's publication.
+
+Verified facts are:
+
+- squash commit: `38d50fd8584293490cf845f2c4ff710c368dbe88`;
+- final PR head `cbfea59e774ba15b839e75abe7efac0945554380` passed `Deploy Static App` run `32274536861` and `Validate SEO Operations` run `32274536879`;
+- production branch `new` contains static export commit `a0ab9aed6af348eb8d85634339f407eca2122616` with exact message `deploy static app for 38d50fd8584293490cf845f2c4ff710c368dbe88`;
+- generated English and Chinese profiler-sampling routes contain the expected title/description, canonical URLs, reciprocal `en`/`zh` plus `x-default`, Article JSON-LD, and Daily Report navigation;
+- exactly one compact closeout comment was added to merged PR `#163`.
+
+No second closeout pull request was created.
+
+## Rolling topic mix and report selection
+
+Before today's report, the rolling window is **7 eBPF / 2 pure Agent / 1
+adjacent**. Publishing an eBPF-centered report would remove the oldest pure-Agent
+report and create an invalid **8 eBPF / 1 Agent / 1 adjacent** window.
+
+The active eBPF Observability and Profiling questions on semantic compression,
+application-defined resources, and eBPF-essential GPU causality were therefore
+deferred rather than relabeled. A GPU profiling question from the adjacent
+heterogeneous-systems roadmap passed the novelty and usefulness gates: whether a
+late CUDA kernel start can be attributed to the host, runtime/command buffer,
+dependency system, or device boundary using evidence that current tooling
+actually exposes.
+
+The report is classified **adjacent systems**. eBPF can provide Linux host-side
+scheduling evidence, but CUPTI, CUDA, and GPU scheduling/dependency semantics are
+the central mechanism. After publication, the rolling ten becomes **7 eBPF / 1
+Agent / 2 adjacent**. The next publication must again remain non-eBPF until the
+rolling window can accept another eBPF-centered report without exceeding seven.
+
+## Research evidence and novelty gate
+
+Primary evidence checked for the report includes:
+
+- NVIDIA CUPTI Activity API and `CUpti_ActivityAPI`: <https://docs.nvidia.com/cupti/api/group__CUPTI__ACTIVITY__API.html> and <https://docs.nvidia.com/cupti/api/structCUpti__ActivityAPI.html>
+- NVIDIA CUPTI usage documentation for external correlation: <https://docs.nvidia.com/cupti/main/main.html>
+- NVIDIA `CUpti_ActivityKernel9`, including optional `queued` and `submitted` latency timestamps: <https://docs.nvidia.com/cupti/13.0.0/api/structCUpti__ActivityKernel9.html>
+- NVIDIA Nsight Systems Post-Collection Analysis Guide for CUDA API/queue/kernel timing: <https://docs.nvidia.com/nsight-systems/AnalysisGuide/index.html>
+- NVIDIA CUDA Programming Guide, Programmatic Dependent Launch: <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html>
+
+Current tooling already exposes substantial timing and correlation information,
+so the report does not claim that queue timing or correlation IDs are new. The
+remaining gap is **causal interpretation**: a timestamp proves a state boundary,
+but does not automatically prove that a dependency was ready or that the GPU
+scheduler alone caused the remaining delay.
+
+The report develops three testable directions:
+
+1. a launch-state ledger whose fields are observed, inferred under a named rule,
+   or explicitly unknown;
+2. a versioned launch identity that survives CPU-thread handoff, CUDA Graph
+   construction/replay, batching, and one-to-many kernel fan-out;
+3. a ground-truth launch-delay benchmark that independently injects host,
+   command-buffer, dependency, and GPU-availability delays and scores the
+   profiler's causal diagnosis rather than only timestamp error.
+
+The thesis is falsifiable. If current CUPTI latency timestamps plus Nsight traces
+already classify controlled delay causes with equal precision and lower cost,
+the extra ledger is unnecessary. If dependency readiness cannot be usefully
+observed or bounded, a profiler should expose a wider unresolved interval rather
+than finer device-delay labels. If richer correlation perturbs latency-sensitive
+workloads, the mechanism should be selectively enabled rather than always on.
+
+## Work performed
+
+Exactly one new bilingual Daily Report is included in this delivery:
+
+- English: `/research/gpu-kernel-launch-latency/`
+- Chinese: `/zh/research/gpu-kernel-launch-latency/`
+
+The report is implemented in:
+
+- `docs/research/gpu-kernel-launch-latency.md`
+- `docs/research/gpu-kernel-launch-latency.zh.md`
+
+Both Daily Report indexes are updated. `content-series.md` records the adjacent
+GPU-profiling detour and the corrected rolling-window arithmetic. `plan.md`,
+`site.md`, `status.md`, and `block.md` are refreshed with current data coverage,
+prior-run closeout state, and the next-run editorial constraint.
+
+No unrelated technical SEO implementation change is made.
+
+### SEO skill freshness
+
+The consuming repository remains pinned to SEO skill commit
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` remains
+`f42128a3f05c73cf10c786a2711c488bb3a14839`. The consuming repository still
+names interfaces from the pinned layout, so a pointer-only submodule bump remains
+incompatible and is not mixed into this daily delivery.
+
+## Validation and self-review contract
+
+- No raw analytics rows, private queries, Drive IDs, analytics property IDs,
+  credentials, personal data, or private URLs are added to Git.
+- Missing Search Console history remains unavailable rather than zero-filled.
+- The report is classified adjacent systems because eBPF is optional rather than
+  necessary to its mechanism.
+- Primary technical claims link to current NVIDIA documentation.
+- The report distinguishes observed command-buffer state from dependency/device
+  causality and preserves unknown states instead of inventing readiness.
+- English and Chinese variants share evidence and conclusions while using
+  language-specific prose.
+- The intended branch scope is exactly one bilingual report, two indexes, this
+  daily record, and directly coupled SEO operating state.
+
+Repository CI is authoritative for the SEO-data validator, Daily Report content
+checks, generated metadata, static export, links, and deployment readiness. The
+final PR head must pass every required and expected check. After CI is green,
+the complete final diff and generated output must receive a clean self-review
+before squash merge. The exact squash commit must then deploy through `Deploy
+Static App`, both public language routes must be verified, and exactly one
+compact closeout comment must be added to the merged PR.
+
+## Delivery
+
+- Branch: `daily/2026-08-20-gpu-launch-latency`
+- Pull request: to be opened as one non-draft daily PR
+- Production target: GitHub Pages through `Deploy Static App`
+- Merge policy: squash merge only after all expected CI succeeds and final self-review is clean
+- Closeout policy: one compact comment on the merged daily PR; no second closeout PR
+
+## Decisions and follow-ups
+
+1. Complete today's GPU launch-latency report through final CI, full diff/generated-output review, squash merge, exact production deployment, bilingual verification, and one closeout comment.
+2. Keep the next publication non-eBPF while the rolling window remains at the seven-report ceiling; do not relabel an eBPF-essential active-series question.
+3. Keep full GSC 7-day and 28-day comparisons unavailable until the missing history exists.
+4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+5. Continue monitoring Search Console click/CTR movement before changing search-facing titles, copy, or navigation.
+6. Investigate GA4 `(not set)` and legacy `/en/` traffic only with richer source-native evidence.
+7. Migrate the consuming SEO contract before moving the pinned SEO-skill submodule.
+8. Add Cloudflare evidence only when repository configuration enables a supported read-only source.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,20 +71,24 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix. The `2026-08-19` general profiler-sampling
-   report is genuinely adjacent systems rather than eBPF-centered, so the first
-   complete ten-report window is **7 eBPF-centered / 2 pure Agent / 1 adjacent**.
-   Recalculate the rolling window on every later run as old reports age out; do
-   not treat this one split as a permanent target.
-2. Return normal topic selection to the active **eBPF Observability and Profiling**
-   series. Sampling theory is now covered as an adjacent measurement-design
-   question. Prefer the remaining active questions on always-on semantic
-   compression, application-defined resource profiling, and GPU host/device
-   causal profiling, subject to fresh primary evidence and novelty checks.
+1. Preserve the rolling ten-report mix mechanically as reports age out. After the
+   `2026-08-20` GPU launch-latency report, the most recent ten reports are **7
+   eBPF-centered / 1 pure Agent / 2 adjacent systems**. The oldest remaining
+   report in that window is the pure-Agent parallel-effect report, so the next
+   publication must again be non-eBPF; adding an eBPF-centered report immediately
+   would produce 8 eBPF reports in the rolling ten and violate the 5–7 rule.
+2. Keep **eBPF Observability and Profiling** as the active series, but defer its
+   eBPF-essential questions until the rolling window permits them again. The
+   August 20 report is a GPU-profiling adjacent-systems detour about launch-delay
+   attribution, distinct from the August 19 sampling-bias detour. For the next
+   run, prefer a genuine adjacent systems question or a strong pure-Agent systems
+   question rather than relabeling an eBPF mechanism. Once the oldest eBPF report
+   starts aging out, return to always-on semantic compression,
+   application-defined resource profiling, or GPU host/device causal profiling
+   with eBPF as an essential mechanism only when the mix remains compliant.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-19`, the `2026-08-10` through `2026-08-16` GA4 weekly aggregate is
-   now outside the configured three-day finalization lag and can be compared as a
-   finalized source-native week against `2026-08-03` through `2026-08-09`.
+   On `2026-08-20`, no newer weekly set than `2026-08-10` through `2026-08-16`
+   was observed. That GA4 aggregate remains finalized under the three-day lag.
    Search Console still lacks the `2026-08-09` date row, so keep the required
    complete 7-day and 28-day comparisons unavailable until source history really
    supports them.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,7 +32,7 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`; the newest GA4 weekly aggregate through `2026-08-16` is finalized under the three-day lag on `2026-08-19`
+- Verified export window: `2026-07-27` through `2026-08-16`; the newest Search Console date export has finalized rows through `2026-08-15`; the newest GA4 weekly aggregate through `2026-08-16` is finalized under the three-day lag
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
 The Drive folder is discovered by its configured name. Do not store its folder ID,
@@ -53,7 +53,7 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
 `2026-08-16`; no newer weekly set was observed in the configured Drive folder on
-`2026-08-19`. Search Console rows through `2026-08-15` are usable. The
+`2026-08-20`. Search Console rows through `2026-08-15` are usable. The
 `2026-08-09` Search Console date row is still absent across the adjacent files,
 so a complete latest-7-days versus previous-7-days comparison remains
 unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
@@ -61,12 +61,11 @@ unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
 also unavailable because the export history is not long enough.
 
 GA4 weekly landing-page exports have no date dimension for trimming a partial or
-unfinalized day within a file. On `2026-08-19`, every day in the newest
-`2026-08-10` through `2026-08-16` aggregate is outside the configured three-day
-finalization lag, so the whole aggregate is now usable as a finalized
-source-native weekly comparison against `2026-08-03` through `2026-08-09`.
-Public repository and live-site data supplement these exports but do not replace
-their source-native meanings.
+unfinalized day within a file. Every day in the newest `2026-08-10` through
+`2026-08-16` aggregate is outside the configured three-day finalization lag, so
+the whole aggregate is usable as a finalized source-native weekly comparison
+against `2026-08-03` through `2026-08-09`. Public repository and live-site data
+supplement these exports but do not replace their source-native meanings.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,56 +7,58 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-18`
-- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`, with the newest weekly aggregate finalized under the three-day lag on `2026-08-19`
-- Latest daily record: `2026-08-19`
-- Last completed public-change pull request: `#162`
-- Last verified production publication from a daily run: static export commit `a26e10fb68a0d0896dcf77d5a79f74c898517bfc` for squash commit `36df29128cbe388eaa37dc573e2ad9902c9c1904`
-- Current daily branch: `daily/2026-08-19-profiler-sampling-bias`
+- Last completed daily run: `2026-08-19`
+- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`
+- Latest daily record: `2026-08-20`
+- Last completed public-change pull request: `#163`
+- Last verified production publication from a daily run: static export commit `a0ab9aed6af348eb8d85634339f407eca2122616` for squash commit `38d50fd8584293490cf845f2c4ff710c368dbe88`
+- Current daily branch: `daily/2026-08-20-gpu-launch-latency`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#162` is fully closed out. It squash-merged as
-`36df29128cbe388eaa37dc573e2ad9902c9c1904`; final PR-head `Validate SEO
-Operations` run `32158581620` and `Deploy Static App` run `32158581694`
-succeeded. The production static branch contains commit
-`a26e10fb68a0d0896dcf77d5a79f74c898517bfc` with the exact message `deploy
-static app for 36df29128cbe388eaa37dc573e2ad9902c9c1904`, and its generated English
-and Chinese memory-attribution pages contain the expected canonical URLs,
-reciprocal language alternates plus `x-default`, Article JSON-LD, and report
-metadata. The merged PR now has the required compact closeout comment.
+PR `#163` is fully closed out. It squash-merged as
+`38d50fd8584293490cf845f2c4ff710c368dbe88`; final PR-head `Deploy Static App`
+run `32274536861` and `Validate SEO Operations` run `32274536879` succeeded. The
+production `new` branch contains static export commit
+`a0ab9aed6af348eb8d85634339f407eca2122616` with exact message `deploy static
+app for 38d50fd8584293490cf845f2c4ff710c368dbe88`. Its generated English and
+Chinese profiler-sampling pages contain the correct titles, canonical URLs,
+reciprocal language alternates plus `x-default`, Article JSON-LD, Daily Report
+navigation, and report content. The merged PR has one compact closeout comment.
 
 ## Current Daily Report mix
 
-Before the current change, the completed archive contains nine reports:
+Before today's publication, the completed archive contains ten reports:
 
-- eBPF-centered: **7 of 9**
-- pure Agent-centered: **2 of 9**
-- adjacent systems: **0 of 9**
+- eBPF-centered: **7 of 10**
+- pure Agent-centered: **2 of 10**
+- adjacent systems: **1 of 10**
 
-Today's profiler-sampling report is a genuine adjacent-systems report. Its
-central mechanisms are sampling-schedule design, phase-locking diagnostics,
-uncertainty estimation, rank stability, and selective instrumentation; they
-apply to `perf`, PMU, runtime, mobile, and other profilers without requiring
-eBPF. After publication the first complete ten-report window becomes **7 eBPF /
-2 pure Agent / 1 adjacent out of 10**, satisfying the repository's rolling mix
-without relabeling an eBPF-essential topic.
+Today's GPU launch-latency report is a genuine adjacent-systems report. Its
+central mechanisms are CUDA/CUPTI launch-state attribution, cross-domain launch
+lineage, dependency uncertainty, and a ground-truth launch-delay benchmark.
+eBPF can contribute host scheduling evidence on Linux but is not required for
+the mechanism, so the report is not classified eBPF-centered.
 
-Normal topic selection can return to the active **eBPF Observability and
-Profiling** series on the next run, subject to the rolling ten-report window as
-the oldest reports later age out.
+After publication, the rolling ten-report window becomes **7 eBPF / 1 pure Agent
+/ 2 adjacent**. The next run must remain non-eBPF because adding an eBPF report
+while the oldest remaining report is the pure-Agent parallel-effect report would
+raise the eBPF count to 8 of 10. Keep the active eBPF Observability and Profiling
+series but defer its eBPF-essential questions until the rolling window permits
+another eBPF-centered publication.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-19 07:58 UTC`
-- Homepage: HTTP 200 in **137 ms** in the current operating brief
-- `robots.txt`: reachable; sitemap: reachable
-- Sitemap entries observed: **672**
+- Repository-generated public-safe operating brief: refreshed `2026-08-20 08:02 UTC`
+- Homepage: HTTP 200 in **189 ms** in the current operating brief
+- `robots.txt`: HTTP 200; sitemap: HTTP 200
+- Sitemap entries observed: **674**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,771 stars, 1,279 forks, and 283 open issue/PR records
+- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,775 stars, 1,280 forks, and 284 open issue/PR records
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; the newest complete aggregate is finalized on `2026-08-19`
+- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; the newest complete aggregate is finalized under the three-day lag
 - Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
+- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-20`
 - Cloudflare: disabled by repository configuration
 
 For the valid equal-duration Search Console comparison, `2026-08-10` through
@@ -89,20 +91,21 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and HTTP audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The `2026-08-19` public-safe operating brief and current repository evidence do
+The `2026-08-20` public-safe operating brief and current repository evidence do
 not establish a new crawl, canonical, hreflang, structured-data, redirect,
 broken-link, rendering, accessibility, performance, or deployment defect. The
 appropriate public site change today is therefore the mandatory bilingual Daily
 Report and directly coupled report-index/series updates, not an unrelated
 technical SEO patch.
 
-Today's research asks when profiler sampling becomes structurally biased rather
-than merely noisy. Primary evidence spans the 1993 randomized sampling-clock
-work, Linux `perf_event_open()` sampling semantics and current profile-collection
-guidance, and the OSDI 2026 Blink result on flat workloads. The report develops
-a realized sampling-schedule contract with aliasing diagnostics, replicated
-profile epochs with uncertainty and rank stability, and uncertainty-triggered
-selective instrumentation under a fixed overhead budget.
+Today's research asks whether a CUDA kernel was slow or merely started late.
+Current CUPTI exposes API timing and correlation plus optional kernel `queued`
+and `submitted` latency timestamps; Nsight Systems exposes API/queue/kernel
+phases but documents that its queue interval is an approximation. The report
+therefore treats timestamps as evidence about states rather than automatic proof
+of one cause. It develops an explicit launch-state ledger with unknown states,
+a launch identity that survives host handoffs and CUDA Graph replay, and a
+controlled benchmark with independently injected delay causes.
 
 The SEO skill submodule remains pinned at
 `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream remains at
@@ -112,11 +115,11 @@ mixed into this daily delivery.
 
 ## Current focus
 
-1. Complete the `2026-08-19` profiler-sampling Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. On the next normal run, return to the active eBPF Observability and Profiling series and evaluate the remaining questions on semantic compression, application-defined resource profiling, and GPU causal profiling.
+1. Complete the `2026-08-20` GPU launch-latency Daily Report through CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Keep the next publication non-eBPF while the rolling window remains at the seven-report eBPF ceiling; select a genuine adjacent-systems or unusually strong pure-Agent systems question rather than relabeling an eBPF mechanism.
 3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
-5. Monitor the Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
+5. Monitor Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
 6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.

--- a/docs/research/gpu-kernel-launch-latency.md
+++ b/docs/research/gpu-kernel-launch-latency.md
@@ -1,0 +1,194 @@
+---
+date: 2026-08-20
+title: "Was the GPU Kernel Slow, or Did It Just Start Late?"
+description: "GPU launch latency can hide host scheduling, runtime work, queueing, dependencies, and device delay. This report proposes causal timing and ground-truth tests."
+tags:
+  - Daily Report
+  - GPU Profiling
+  - CUDA
+  - Observability
+research_question: "How can a profiler distinguish host launch delay, command-buffer queueing, dependency wait, and actual GPU kernel execution without inventing causality from one timeline gap?"
+source_cutoff: 2026-08-20
+status: daily-report
+---
+
+# Was the GPU Kernel Slow, or Did It Just Start Late?
+
+A CUDA kernel launch can look simple on a timeline: a CPU thread calls a launch API, some time passes, the kernel starts on the GPU, and later it finishes. But if the call begins at 10.000 ms and the kernel does not start until 12.000 ms, the missing two milliseconds are not one thing.
+
+The CPU thread may have been descheduled before it reached the launch. The runtime or driver may have spent time inside the API. The launch may have been written to a command buffer but not yet submitted. It may be ordered behind earlier stream work or a graph dependency. The GPU may already be busy. The command may be eligible but still wait for device resources. Those cases imply different fixes, yet a profiler can easily collapse them into one number called **launch latency** or **queue time**.
+
+Current NVIDIA tooling already exposes much more than a single number. CUPTI API activity records include start and end timestamps, process and thread identity, and a correlation ID that matches the associated kernel activity. Current kernel activity records can also expose `queued` and `submitted` timestamps; these latency timestamps are optional rather than collected by default. Nsight Systems separates API time, queue time, and kernel time, and its documentation is unusually explicit about an important limitation: the reported queue time is measured from the end of the CUDA API call to kernel start even though the actual enqueue happens somewhere inside that API call. A kernel can even start before the launch API returns, in which case that simplified queue interval disappears.
+
+That means the basic instrumentation is already strong. The unresolved problem is narrower: **can a profiler turn these timestamps and identities into a defensible explanation of why a particular kernel started late?**
+
+This is not primarily an eBPF problem. Linux scheduling traces, including eBPF-based ones, can contribute host-side evidence, but the central mechanism is a GPU profiling and causal-attribution problem that also exists on systems using other host tracing mechanisms.
+
+## What current GPU traces already tell us
+
+CUPTI provides a useful chain from host API to device work. A runtime or driver API invocation has start/end timestamps and a `correlationId`; the corresponding kernel record carries the same correlation identity. For CUDA Graph launches, kernel activity records also expose graph and graph-node identities. CUPTI external correlation can map a higher-level runtime or application ID into CUDA correlation IDs, although the external-correlation stack is maintained per CPU thread and has to be managed by the client.
+
+The kernel-side record can expose four especially useful moments:
+
+1. `queued`: the command was written into a CUDA command buffer;
+2. `submitted`: the command buffer containing the launch was submitted to the GPU;
+3. `start`: kernel execution began;
+4. `end`: kernel execution ended.
+
+Those timestamps already support better questions than "how long did the kernel take?" For example, a long interval before `queued` points toward host/runtime work, while a long `queued -> submitted` interval is different from a long `submitted -> start` interval.
+
+But these are still **events**, not a complete state machine. `submitted` does not necessarily mean "this kernel is dependency-ready and only the GPU scheduler is delaying it." CUDA stream ordering, events, graphs, synchronization, resource availability, and newer mechanisms such as Programmatic Dependent Launch all affect when execution may legally begin. The CUDA Programming Guide also notes that Programmatic Dependent Launch only creates an opportunity for overlap; concurrent execution is opportunistic rather than guaranteed.
+
+Nsight Systems therefore makes a sensible practical compromise. Its CUDA kernel reports divide time into API, queue, and kernel phases, while warning that queue time is an approximation and is not inherently bad. A busy GPU can have substantial queue time precisely because useful work is already occupying it.
+
+The missing layer is an explanation that keeps these distinctions intact instead of converting every pre-start gap into a single cause.
+
+## The diagnostic failure: intervals are not causes
+
+Suppose a model-serving process launches the same 80-microsecond kernel thousands of times. After a deployment, end-to-end latency rises by 1.5 ms. A trace shows that the kernel execution duration is still about 80 microseconds, but its start moves later.
+
+There are at least four materially different diagnoses:
+
+- **Host readiness delay.** The application or framework did not reach the CUDA API promptly because the launching CPU thread was descheduled, blocked, or doing other work.
+- **Runtime or command-buffer delay.** The CUDA API itself, or the path from API entry to command-buffer queue/submission, became expensive.
+- **Dependency delay.** The kernel was correctly ordered behind stream, event, graph, or programmatic dependencies. Calling this scheduler delay would be wrong.
+- **Device availability delay.** The launch was submitted and eligible, but earlier GPU work or resource pressure prevented immediate execution.
+
+A fifth case is even more awkward: the trace does not contain enough information to distinguish dependency delay from device availability. A trustworthy profiler should say **unknown at this boundary** rather than picking the most plausible-looking colored segment on the timeline.
+
+This distinction matters operationally. Pinning a CPU thread cannot fix an intentional stream dependency. Rewriting a CUDA Graph cannot fix a host thread that wakes 2 ms late. Kernel optimization does not help when kernel duration is already stable. Increasing GPU occupancy can actually increase queue time while improving throughput.
+
+The profiler therefore needs to answer a different question: **what state transition is evidenced, what transition is only inferred, and which possible causes remain observationally equivalent?**
+
+## Where current work is still weak
+
+### 1. There is no common launch-state contract for interpreting timestamps
+
+CUPTI exposes the pieces needed for a richer timeline, but applications and profilers still have to decide what each interval means. `queued -> submitted` has a concrete command-buffer interpretation. `submitted -> start` is more ambiguous because stream dependencies, graph dependencies, device work, and resource availability can overlap conceptually.
+
+The missing capability is not another timestamp. It is a machine-readable contract that says which state transition a timestamp proves, which preconditions are known, and which are unknown. The practical test is an injected-delay benchmark where each delay source is independently controlled. If a profiler labels the right interval but the wrong cause, the contract is insufficient.
+
+### 2. Correlation does not automatically preserve high-level causality across host execution
+
+CUPTI correlation IDs connect CUDA APIs to device activities very well. External correlation can connect those records to another API domain, but the client owns the mapping and the external-correlation stack is CPU-thread scoped. Modern runtimes may prepare work on one thread, hand it off, batch it into a graph, and launch from another.
+
+The missing capability is a stable **launch identity across host handoffs and graph transformations**, not just a local API-to-kernel join. A profiler should be able to tell whether the thread that called CUDA late was itself late, or whether the application intentionally handed the work to it late. The test is a workload that moves launch preparation and submission across thread pools while preserving known logical request IDs.
+
+### 3. Existing queue summaries do not establish dependency readiness
+
+Nsight Systems correctly documents that its reported queue time is an API-end-to-kernel-start approximation and that queueing itself is not necessarily a problem. CUPTI's optional `queued` and `submitted` timestamps sharpen the command-buffer boundary, but neither timestamp alone proves the exact instant at which every dependency became satisfied.
+
+The missing evidence is an explicit readiness boundary—or, when one cannot be observed, an uncertainty marker. The test is to compare traces against workloads with known stream/event/graph dependencies and independent GPU saturation. A useful profiler must avoid blaming the GPU scheduler for time that was legally required by dependencies.
+
+## Promising directions with academic and production value
+
+### Direction 1: A launch-state ledger with explicit unknown states
+
+**Gap.** Current tools expose timestamps but do not provide one portable interpretation of the causal states between application intent and kernel execution.
+
+**Mechanism.** Record one append-only ledger per logical launch with the strongest available evidence:
+
+```text
+request_ready? -> api_enter -> queued? -> submitted? -> dependency_ready? -> kernel_start -> kernel_end
+```
+
+The question marks are part of the schema. A field can be observed, inferred under a named rule, or unknown. Each transition carries the source that established it: runtime hook, CUPTI API activity, CUPTI latency timestamp, graph dependency, OS scheduler trace, or application correlation.
+
+The ledger should not invent a `dependency_ready` timestamp when the runtime cannot expose one. Instead, it can bound the delay: for example, `submitted <= ready <= start`. A diagnosis can then say "1.2 ms is between submission and execution, but dependency readiness is unknown" rather than "1.2 ms GPU scheduler delay."
+
+**Delta.** This is not a replacement for CUPTI or Nsight Systems. It is an interpretation layer above their activity records that preserves missing evidence as a first-class result.
+
+**Artifact.** A small open trace schema plus a reference CUPTI collector that enables latency timestamps selectively and emits launch ledgers. On Linux, host scheduling evidence could come from perf, ftrace, eBPF, or Nsight OS-runtime/context-switch tracing; the schema should not depend on one collector.
+
+**Evaluation.** Measure phase-bound accuracy and cause-classification precision on controlled launch delays. Compare against ordinary API/queue/kernel summaries and a full-trace baseline. Report collection overhead and the fraction of launches that remain honestly unresolved.
+
+**Academic value.** The general question is how to represent causal uncertainty when multiple schedulers and dependency systems share one asynchronous timeline.
+
+**Production value.** Operators get a diagnosis that points to the host, runtime, dependency graph, or device boundary without asking them to inspect several tools manually.
+
+**Failure condition.** If existing CUPTI latency timestamps plus current Nsight reports already identify injected causes with equivalent accuracy and lower overhead, the extra ledger is not justified.
+
+### Direction 2: A cross-domain launch identity that survives handoff and graph batching
+
+**Gap.** CUDA correlation is precise near the CUDA API boundary, but high-level work may move across CPU threads or be transformed into CUDA Graph nodes before the final launch.
+
+**Mechanism.** Give each logical GPU launch a versioned `launch_epoch` created when the application or framework first declares the work. Propagate that identity through host handoffs, then bind it to CUPTI external correlation, CUDA correlation IDs, and graph/node IDs when those become available. Record one-to-many relationships rather than assuming one request maps to one kernel.
+
+The important property is **lineage, not naming**. If a graph replay launches the same graph node many times, the profiler needs both stable node identity and per-launch epoch. If one request fans out across multiple streams, the lineage should preserve that fan-out instead of flattening it into a thread-local stack.
+
+**Delta.** Existing external correlation provides the hook; the proposed work defines propagation semantics across thread pools, graph construction/replay, and batched launches.
+
+**Artifact.** Adapters for one framework plus a standalone correlation library and trace validator. A practical first target could be a CUDA application with a host thread pool and graph replay, because ground truth can be generated without modifying the GPU driver.
+
+**Evaluation.** Inject host handoffs, graph replay, and batching; measure lost joins, incorrect joins, storage cost, and diagnosis accuracy. Compare thread-local correlation, CUDA-only correlation, and the launch-epoch design.
+
+**Academic value.** This tests whether a small lineage contract can make heterogeneous host/device traces compositional across asynchronous runtime boundaries.
+
+**Production value.** Framework teams can connect an end-user request to the exact delayed launches even when submission occurs on infrastructure threads.
+
+**Failure condition.** If CUDA/graph correlation already preserves the required lineage for realistic frameworks without additional propagation, the launch epoch is redundant.
+
+### Direction 3: A ground-truth benchmark for launch-delay attribution
+
+**Gap.** Profilers can show detailed timelines without proving that their diagnosis of a pre-kernel gap is correct.
+
+**Mechanism.** Build a benchmark that injects one delay source at a time and records the known cause independently of the profiler:
+
+- host descheduling before API entry;
+- deliberate CPU work inside the launch path;
+- command-buffer batching or submission delay;
+- explicit stream/event dependencies;
+- CUDA Graph dependencies and replay;
+- GPU saturation from an independent stream or process;
+- kernels with different resource footprints;
+- Programmatic Dependent Launch cases where overlap is permitted but not guaranteed.
+
+Then combine causes to test ambiguity. The benchmark should include both latency-sensitive small kernels and throughput-oriented workloads where queueing is healthy.
+
+**Delta.** Existing profiler benchmarks often ask whether timestamps are cheap or accurate. This benchmark asks whether the **explanation chosen from those timestamps** is correct.
+
+**Artifact.** Reproducible CUDA workloads, injected ground-truth labels, CUPTI/Nsight export adapters, and a scorer for interval error, cause accuracy, unresolved-case calibration, and overhead.
+
+**Evaluation.** The strongest baseline is the richest current CUPTI/Nsight trace configuration. A useful new design must reduce false causal diagnoses, not merely add more events. An ablation can remove host scheduling, queued/submitted timestamps, dependency metadata, or launch lineage to quantify which evidence actually matters.
+
+**Academic value.** The benchmark makes heterogeneous scheduling attribution falsifiable rather than a timeline-visualization judgment.
+
+**Production value.** Profiler vendors and framework teams can test whether a new "launch latency" diagnosis will send users toward the right subsystem.
+
+**Failure condition.** If simple API/queue/kernel decomposition already classifies all injected cases reliably, there is no need for a richer causal model.
+
+## What this changes for profiler design
+
+The useful output is not a finer rainbow timeline. It is a smaller set of statements with stronger semantics:
+
+- the application became ready late;
+- the CUDA API path was expensive;
+- the launch spent measurable time before submission;
+- execution was ordered behind a known dependency;
+- the launch was submitted but readiness is unknown;
+- the kernel itself executed slowly.
+
+A profiler should prefer one of those statements—or an explicit unresolved interval—over a generic "GPU launch latency" warning.
+
+This complements two recent Daily Reports rather than repeating them. [The sampling-bias report](https://eunomia.dev/research/profiler-sampling-bias/) asks whether the measurements themselves are statistically trustworthy. [The asynchronous eBPF causal-profiler report](https://eunomia.dev/research/async-ebpf-causal-profiler/) asks how logical work crosses CPU-side asynchronous handoffs. This report asks a different question at the GPU boundary: once the host/device events are visible, what evidence is needed to explain **why execution started when it did**? The [page-level memory-attribution report](https://eunomia.dev/research/page-level-ebpf-memory-attribution/) uses the same broader principle: observed activity and causal ownership should not be treated as interchangeable.
+
+## What would change this conclusion?
+
+Three results would narrow or overturn the case for a richer launch-attribution layer.
+
+First, if current CUPTI latency timestamps, graph identities, and Nsight Systems host scheduling traces already classify the injected benchmark causes with high precision at acceptable overhead, then the missing piece is documentation or UI rather than a new trace contract.
+
+Second, if dependency readiness cannot be observed or bounded usefully for modern CUDA workloads, a profiler should stop short of fine-grained device-delay labels. The correct product may simply expose command-buffer timing plus an explicit unresolved dependency/device interval.
+
+Third, if collecting `queued` and `submitted` timestamps or cross-domain lineage perturbs latency-sensitive workloads enough to change their scheduling behavior, the design should become hierarchical: collect cheap API/kernel correlation continuously and enable richer evidence only for selected launches or short diagnostic epochs.
+
+The current evidence supports a cautious conclusion: GPU profilers already have many of the timestamps required to analyze launch delay, but **timestamps are not yet the same thing as a causal diagnosis**. The next useful step is to make that distinction testable.
+
+## References
+
+- NVIDIA, CUPTI Activity API, API activity records and kernel activity fields: <https://docs.nvidia.com/cupti/api/group__CUPTI__ACTIVITY__API.html>
+- NVIDIA, `CUpti_ActivityAPI`: <https://docs.nvidia.com/cupti/api/structCUpti__ActivityAPI.html>
+- NVIDIA, CUPTI usage guide, external correlation: <https://docs.nvidia.com/cupti/main/main.html>
+- NVIDIA, CUPTI `CUpti_ActivityKernel9`, including optional `queued` and `submitted` latency timestamps: <https://docs.nvidia.com/cupti/13.0.0/api/structCUpti__ActivityKernel9.html>
+- NVIDIA, Nsight Systems Post-Collection Analysis Guide, CUDA kernel launch/queue reports: <https://docs.nvidia.com/nsight-systems/AnalysisGuide/index.html>
+- NVIDIA, CUDA Programming Guide, Programmatic Dependent Launch and Synchronization: <https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html>

--- a/docs/research/gpu-kernel-launch-latency.zh.md
+++ b/docs/research/gpu-kernel-launch-latency.zh.md
@@ -1,0 +1,196 @@
+---
+date: 2026-08-20
+title: "GPU 内核是真的慢，还是只是启动晚了？"
+description: "GPU 启动延迟可能来自主机调度、运行时、命令队列、依赖关系或设备资源等待。本文拆开这些阶段，并提出可验证的因果时间线和基准。"
+tags:
+  - Daily Report
+  - GPU Profiling
+  - CUDA
+  - Observability
+research_question: "性能分析器怎样区分主机侧延迟、命令缓冲区排队、依赖等待和 GPU 内核本身的执行时间，而不从一段时间线空隙里臆测因果关系？"
+source_cutoff: 2026-08-20
+status: daily-report
+---
+
+# GPU 内核是真的慢，还是只是启动晚了？
+
+一条 CUDA 内核的时间线看起来很简单：CPU 线程调用 launch API，过一段时间，GPU 上的内核开始执行，随后结束。但如果 API 在 10.000 ms 开始，而内核到 12.000 ms 才启动，中间缺失的两毫秒并不是同一种延迟。
+
+CPU 线程可能在调用 CUDA 之前就被调度出去了；运行时或驱动可能在 API 内部花了时间；launch 命令可能已经写进 command buffer，却还没有提交给 GPU；它也可能因为 stream、event 或 CUDA Graph 的依赖而必须等待。即使依赖已经满足，GPU 上还可能有其他工作或资源压力，导致新 kernel 无法马上执行。
+
+这些情况的修复方向完全不同，但性能分析器很容易把它们压成一个叫做 **launch latency** 或 **queue time** 的数字。
+
+NVIDIA 现有工具其实已经提供了相当丰富的原始证据。CUPTI 的 API activity 记录包含 API 的开始和结束时间、进程和线程身份，以及能和对应 kernel activity 对上的 correlation ID。当前的 kernel activity 还可以提供 `queued` 和 `submitted` 时间戳，只是这类 latency timestamp 默认并不采集。Nsight Systems 把 CUDA kernel 的一次 launch 分成 API time、queue time 和 kernel time，同时明确说明一个容易被忽略的限制：它报告的 queue time 从 CUDA API 返回时刻算到 kernel 开始时刻，但真正的 enqueue 发生在 API 调用内部，因此这个区间只是近似值。kernel 甚至可能在 API 返回之前就已经启动，此时这个简化的 queue time 不会出现。
+
+所以现在缺的不是“再加一个时间戳”。更窄、也更有价值的问题是：**性能分析器能不能把这些时间戳和身份信息组合成一个站得住脚的解释，说明某次 kernel 为什么启动得晚？**
+
+这不是一个必须依赖 eBPF 才能成立的问题。在 Linux 上，eBPF、perf、ftrace 都可以补充主机侧调度证据，但本文讨论的核心是 GPU profiling 和因果归因；换成其他操作系统或 host tracer，这个问题仍然存在。因此本文按相邻系统方向分类，而不是 eBPF-centered 报告。
+
+## 现有 GPU trace 已经能告诉我们什么
+
+CUPTI 已经提供了一条很有用的 host-to-device 关联链。一次 runtime 或 driver API 调用有 start/end timestamp 和 `correlationId`，对应的 kernel 记录会携带相同的关联身份。对于 CUDA Graph，kernel activity 还可以带 graph 和 graph node 的身份。CUPTI 的 external correlation 还能把上层 runtime 或应用自己的 ID 映射到 CUDA correlation ID，不过这种 external-correlation stack 是按 CPU thread 维护的，映射关系也需要 client 自己管理。
+
+对一次 kernel launch 来说，当前 CUPTI kernel record 最有价值的四个时间点是：
+
+1. `queued`：launch 命令被写入 CUDA command buffer；
+2. `submitted`：包含该 launch 的 command buffer 被提交给 GPU；
+3. `start`：kernel 真正开始执行；
+4. `end`：kernel 执行结束。
+
+有了这些信息，问题已经可以比“kernel 跑了多久”细很多。比如，API 进入到 `queued` 很长，和 `queued -> submitted` 很长显然不是一类现象；`submitted -> start` 很长又是另一回事。
+
+但这些依旧只是**事件边界**，不是完整的状态机。`submitted` 并不等于“所有依赖都已经满足，现在只是在等 GPU scheduler”。CUDA stream 顺序、event、graph dependency、同步、资源占用都会影响一次 kernel 什么时候才允许开始执行。新的 Programmatic Dependent Launch 还进一步说明了这个问题：CUDA 可以允许 dependent kernel 提前和前序 kernel 重叠，但官方文档明确说明，这种并发只是机会而不是保证，依赖这种并发行为本身是不安全的。
+
+Nsight Systems 因此采取了一个合理的工程折中：把 launch 粗分成 API、queue 和 kernel 三段，并明确提醒 queue time 本身并不代表坏事。GPU 正在高效执行其他工作时，新 kernel 有 queue time 反而很正常。
+
+真正缺少的是一层解释机制：它要保留这些差异，而不是把所有 kernel 启动前的空隙都归到同一个原因上。
+
+## 诊断上的根本问题：时间区间不是原因
+
+假设一个模型服务会反复 launch 同一个约 80 微秒的 CUDA kernel。某次部署之后，请求延迟增加了 1.5 ms。trace 里 kernel 自己仍然只执行约 80 微秒，但是 start time 整体往后移了。
+
+至少有四种完全不同的解释：
+
+- **主机就绪延迟。** 应用或框架没有及时走到 CUDA API，因为 launch 所在 CPU thread 被抢占、阻塞，或者正在处理其他任务。
+- **运行时或 command-buffer 延迟。** CUDA API 本身变慢，或者从 API 进入到 command queue / submit 的路径变慢。
+- **依赖等待。** kernel 按语义就应该排在 stream、event、graph 或 programmatic dependency 后面。这种时间不能叫 GPU scheduler delay。
+- **设备可用性等待。** launch 已经提交，而且可以执行，但更早的 GPU 工作或资源占用让它没法马上开始。
+
+还有第五种情况更重要：trace 根本没有足够证据区分“依赖还没满足”和“GPU 已经可以执行但暂时没有资源”。可信的性能分析器应该明确说 **这个边界上无法判断**，而不是根据时间线里颜色最像的一段猜一个原因。
+
+这个区别会直接改变工程决策。绑核不能修复一个合理的 stream dependency；重写 CUDA Graph 也不能修复一个晚醒 2 ms 的 CPU thread。kernel duration 已经稳定时，继续优化 kernel 本体没有意义。更高的 GPU 利用率甚至可能增加 queue time，同时改善整体 throughput。
+
+所以 profiler 真正需要回答的是：**哪些状态转换有直接证据，哪些只是有条件推断，还有哪些原因在当前观测下无法区分？**
+
+## 现有研究还缺什么
+
+### 1. 缺少统一的 launch 状态语义
+
+CUPTI 已经提供了构建更细时间线的大部分原料，但不同工具仍然需要自己解释每一段 interval 的意义。`queued -> submitted` 有比较明确的 command-buffer 语义；而 `submitted -> start` 更复杂，因为 dependency、已有 GPU workload、资源可用性等因素都可能参与其中。
+
+真正缺少的不是新 timestamp，而是一份机器可读的状态契约：某个 timestamp 证明了什么状态，哪些前置条件已经知道，哪些仍然未知。最直接的验证方法是做一个可以独立注入各种 delay source 的 benchmark。如果 profiler 找对了 interval，却经常把 cause 标错，说明状态契约还不够。
+
+### 2. CUDA correlation 不等于上层工作在 host 侧的完整因果链
+
+CUPTI correlation ID 很擅长把 CUDA API 和 GPU activity 连起来。External correlation 还能继续接到其他 API domain，但映射由 client 管理，而且上下文本身是 CPU-thread scoped。现代 runtime 可能在一个线程准备工作，交给另一个线程池，随后 batch 成 graph，最后又由另一个基础设施线程完成 launch。
+
+这里缺少的是能够穿过 host handoff 和 graph transformation 的稳定 **launch identity**，而不仅是某个 API 周围的一次 join。Profiler 应该能区分：“真正的业务工作早就 ready 了，但是提交线程醒晚了”，和“应用本身就晚到这个提交线程”。验证可以通过线程池搬运、graph replay 和已知 request ID 的 workload 来完成。
+
+### 3. Queue summary 不能证明 dependency 已经 ready
+
+Nsight Systems 很清楚地说明，它的 queue time 是从 API end 到 kernel start 的近似区间，而且 queueing 本身未必是问题。CUPTI 的 `queued` / `submitted` timestamp 能把 command-buffer 边界切得更细，但这些字段仍然不能单独证明“所有 dependency 在某一刻已经全部满足”。
+
+缺少的是明确的 readiness boundary；如果这个边界本身不可见，就至少应该有 uncertainty marker。验证时可以分别构造已知的 stream/event/graph dependency，以及独立的 GPU saturation。如果一个 profiler 会把合法的 dependency wait 归因成 scheduler delay，这个诊断就不可信。
+
+## 兼具学术价值与生产价值的方向
+
+### 方向一：带显式未知状态的 launch-state ledger
+
+**缺口。** 现有工具提供了许多时间戳，却缺少从应用意图到 GPU 执行之间统一、可验证的状态解释。
+
+**机制。** 为每个逻辑 launch 建立一个 append-only ledger，只记录当前最强证据：
+
+```text
+request_ready? -> api_enter -> queued? -> submitted? -> dependency_ready? -> kernel_start -> kernel_end
+```
+
+这里的问号不是实现不完整，而是 schema 的一部分。每个字段需要标明它是直接观测、在某个具名规则下推断，还是未知；每个 transition 还记录证据来源，例如 runtime hook、CUPTI API activity、CUPTI latency timestamp、graph dependency、OS scheduler trace 或 application correlation。
+
+如果 runtime 无法给出真正的 `dependency_ready`，ledger 不应造一个时间点，而应保留区间约束，例如 `submitted <= ready <= start`。这样诊断结果可以说“提交到执行之间有 1.2 ms，但 dependency readiness 不可见”，而不是武断地说“GPU scheduler delay 是 1.2 ms”。
+
+**和现有工作的区别。** 这不是替代 CUPTI 或 Nsight Systems，而是在已有 activity record 上增加一层保留不确定性的语义解释。
+
+**可实现产物。** 一个开放的 trace schema，加一个 CUPTI reference collector；只在需要时开启 latency timestamp。在 Linux 上，host scheduling 可以来自 perf、ftrace、eBPF 或 Nsight 的 OS runtime/context-switch trace，schema 本身不绑定某一种 collector。
+
+**评估。** 在可控注入不同 launch delay 的 workload 上测量阶段边界误差和 cause classification precision，对比普通 API/queue/kernel summary 以及 full-trace baseline。同时报告采集开销，以及有多少 launch 最终被诚实标记为 unresolved。
+
+**学术价值。** 一般化问题是：多个 scheduler 和 dependency system 共享一条异步时间线时，怎样表达可证明的因果关系和不可消除的不确定性。
+
+**生产价值。** 用户不再需要手工同时看 CPU scheduler、CUDA API 和 GPU timeline，工具可以直接指出问题更可能位于 host、runtime、dependency graph 还是 device boundary。
+
+**失败条件。** 如果现有 CUPTI latency timestamp 加 Nsight report 已经能以同样准确率、较低开销识别所有注入原因，那么额外 ledger 没有必要。
+
+### 方向二：能穿过线程切换和 Graph batching 的跨域 launch identity
+
+**缺口。** CUDA correlation 在 CUDA API 附近很精确，但上层工作可能跨 CPU thread，或者在最终 launch 前被转换成 CUDA Graph node。
+
+**机制。** 在应用或 framework 第一次声明某段 GPU work 时创建一个 versioned `launch_epoch`。它随 host handoff 传播；等到 CUDA boundary 出现后，再绑定 CUPTI external correlation、CUDA correlation ID，以及 graph/node ID。映射必须允许一对多，而不是假设一个 request 只对应一个 kernel。
+
+关键属性不是 ID 的名字，而是**lineage**。同一个 graph node 被 replay 多次时，需要同时保留稳定 node identity 和每次 replay 的 launch epoch；一个 request fan-out 到多个 stream 时，也要保留这种分叉，而不是压平到一个 thread-local stack。
+
+**和现有工作的区别。** External correlation 已经提供了连接点；这里新增的是 thread-pool handoff、graph construction/replay 和 batched launch 之间的传播语义。
+
+**可实现产物。** 一个小型 correlation library、一个 framework adapter 和一个 trace validator。第一版可以针对“host thread pool + CUDA Graph replay”的应用，完全不需要修改 GPU driver 就能生成 ground truth。
+
+**评估。** 注入 thread handoff、graph replay 和 batching，测 lost join、wrong join、存储开销和最终诊断准确率。对比纯 thread-local correlation、仅 CUDA correlation，以及 launch-epoch 方案。
+
+**学术价值。** 可以验证一份很小的 lineage contract 是否足够让 host/device heterogeneous trace 在异步 runtime 边界上具有可组合性。
+
+**生产价值。** Framework 团队可以把一个用户请求准确关联到真正启动晚的 GPU work，即使最后的 CUDA call 是由基础设施线程发出的。
+
+**失败条件。** 如果真实 framework 中现有 CUDA/graph correlation 已经天然保留了所需 lineage，那么 launch epoch 只是重复信息。
+
+### 方向三：以真实原因作为 ground truth 的 launch-delay benchmark
+
+**缺口。** Profiler 可以画出非常精细的 timeline，却通常没有证明“它对 pre-kernel gap 的解释是对的”。
+
+**机制。** 构造一套一次只注入一种 delay source 的 workload，并在 profiler 之外记录真实原因：
+
+- CUDA API 之前的 host descheduling；
+- launch path 中人为增加的 CPU work；
+- command-buffer batching 或 submission delay；
+- 显式 stream/event dependency；
+- CUDA Graph dependency 和 replay；
+- 独立 stream 或进程制造的 GPU saturation；
+- 不同 resource footprint 的 kernel；
+- Programmatic Dependent Launch 中“允许重叠但不保证重叠”的场景。
+
+之后再把多个原因组合起来，测试真正的歧义情况。Benchmark 还应同时包含 latency-sensitive 的短 kernel 和以 throughput 为目标、正常 queueing 很多的 workload。
+
+**和现有工作的区别。** 很多 profiler benchmark 会测 timestamp 是否准确、采集是否便宜；这里测的是：**工具从这些 timestamp 推出的解释是否准确。**
+
+**可实现产物。** 一组可重复执行的 CUDA workload、独立 ground-truth label、CUPTI/Nsight export adapter，以及对 interval error、cause accuracy、unresolved calibration 和 overhead 的 scorer。
+
+**评估。** 最强 baseline 就是开启当前 CUPTI/Nsight 能提供的最丰富 trace。新的设计必须减少错误因果诊断，而不能仅仅增加事件数量。Ablation 可以分别去掉 host scheduling、queued/submitted timestamp、dependency metadata 和 launch lineage，直接量化每类证据的价值。
+
+**学术价值。** 它把 heterogeneous scheduling attribution 从“看时间线的经验判断”变成可证伪的测量问题。
+
+**生产价值。** Profiler 和 framework 团队可以在发布新的“launch latency”诊断前，先确认它真的会把用户引导到正确子系统。
+
+**失败条件。** 如果简单的 API/queue/kernel 三段划分已经能稳定分类所有注入场景，更复杂的因果模型就不值得维护。
+
+## 这会怎样改变 profiler 的输出
+
+有用的输出不应该只是更细的彩色时间线，而应该是一组语义更强的判断：
+
+- 应用本身晚 ready；
+- CUDA API path 花费异常；
+- launch 在提交前有可观测等待；
+- execution 被某个已知 dependency 合法阻塞；
+- launch 已经 submitted，但 readiness 无法确定；
+- kernel 自己执行确实变慢。
+
+Profiler 应该优先给出这些判断，或者明确的 unresolved interval，而不是笼统提示“GPU launch latency 很高”。
+
+这和最近几篇 Daily Report 是互补关系，而不是重复。[采样偏差报告](https://eunomia.dev/zh/research/profiler-sampling-bias/)问的是测量结果在统计上是否可信；[异步 eBPF 因果 profiler 报告](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)问的是逻辑工作怎样跨 CPU 侧异步 handoff。本文问的是另一个 GPU boundary 问题：当 host/device event 都已经看得见时，还需要什么证据才能解释**为什么执行在这个时刻才开始**？[页面级内存归因报告](https://eunomia.dev/zh/research/page-level-ebpf-memory-attribution/)也体现了同一个更宽泛的原则：观测到 activity，并不等于已经知道它的 causal ownership。
+
+## 哪些结果会改变这个判断？
+
+有三类结果会明显缩小甚至推翻本文对新归因层的需求。
+
+第一，如果当前 CUPTI latency timestamp、graph identity 和 Nsight Systems 的 host scheduling trace 已经能在上述注入 benchmark 中以很高 precision 区分原因，而且 overhead 可接受，那么缺的可能只是文档或 UI，而不是新的 trace contract。
+
+第二，如果现代 CUDA workload 的 dependency readiness 根本无法被可靠观测或有效约束，那么 profiler 就不应该继续细分所谓 device delay。更正确的产品可能只是展示 command-buffer timing，再明确标记一段无法区分 dependency/device 的区间。
+
+第三，如果开启 `queued` / `submitted` timestamp 或跨域 lineage 会明显扰动 latency-sensitive workload，甚至改变它原来的 scheduling behavior，那么设计应该分层：常态只保留廉价的 API/kernel correlation，在少量选中 launch 或短诊断 epoch 中再打开丰富证据。
+
+目前的证据支持一个相对克制的结论：GPU profiler 已经拥有分析 launch delay 所需的很多时间戳，但**拥有时间戳，还不等于拥有可信的因果诊断**。下一步最值得做的，是把这两者之间的差距做成可以被 benchmark 直接验证的问题。
+
+## 参考资料
+
+- NVIDIA，CUPTI Activity API，API activity 与 kernel activity 字段：<https://docs.nvidia.com/cupti/api/group__CUPTI__ACTIVITY__API.html>
+- NVIDIA，`CUpti_ActivityAPI`：<https://docs.nvidia.com/cupti/api/structCUpti__ActivityAPI.html>
+- NVIDIA，CUPTI usage guide，external correlation：<https://docs.nvidia.com/cupti/main/main.html>
+- NVIDIA，CUPTI `CUpti_ActivityKernel9`，包括可选的 `queued` / `submitted` latency timestamp：<https://docs.nvidia.com/cupti/13.0.0/api/structCUpti__ActivityKernel9.html>
+- NVIDIA，Nsight Systems Post-Collection Analysis Guide，CUDA kernel launch/queue report：<https://docs.nvidia.com/nsight-systems/AnalysisGuide/index.html>
+- NVIDIA，CUDA Programming Guide，Programmatic Dependent Launch and Synchronization：<https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html>

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Was the GPU Kernel Slow, or Did It Just Start Late?](https://eunomia.dev/research/gpu-kernel-launch-latency/)
+
+A late CUDA kernel start can come from host scheduling, runtime work, command-buffer queueing, dependencies, or device availability even when kernel execution itself is unchanged. This report develops an explicit launch-state ledger, cross-domain launch lineage, and a ground-truth benchmark for deciding which delay cause the trace actually proves.
+
 ### [When Does Profiler Sampling Become Biased?](https://eunomia.dev/research/profiler-sampling-bias/)
 
 Sampling percentages can be systematically wrong when a sampler phase-locks with periodic work, skids past the event that caused a sample, or repeatedly misses short-lived code. This report develops an explicit sampling-schedule contract with aliasing diagnostics, replicated profile epochs with rank uncertainty, and uncertainty-triggered selective instrumentation under a fixed overhead budget.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [GPU 内核是真的慢，还是只是启动晚了？](https://eunomia.dev/zh/research/gpu-kernel-launch-latency/)
+
+CUDA kernel 启动晚可能来自 host scheduling、runtime、command-buffer queueing、dependency 或 device availability，即使 kernel 本身的执行时间完全没变。本文提出带显式未知状态的 launch-state ledger、跨 host/device 的 launch lineage，以及以已知 delay source 为 ground truth 的归因 benchmark。
+
 ### [性能分析器的采样什么时候会产生偏差？](https://eunomia.dev/zh/research/profiler-sampling-bias/)
 
 当 sampler 与周期 workload 相位锁定、hardware sample 出现 skid，或者短函数持续被漏采时，profile 百分比可能系统性出错。本文提出带 aliasing 诊断的 sampling-schedule contract、用独立 profile epoch 表达 rank uncertainty，以及在固定 overhead budget 下由 uncertainty 触发 selective instrumentation。


### PR DESCRIPTION
## Evidence

- The rolling ten-report window before this change is 7 eBPF-centered / 2 pure Agent / 1 adjacent. Because the oldest report aging out is pure Agent, another eBPF-centered report would create an invalid 8/10 eBPF window. This report is therefore genuinely adjacent systems rather than an eBPF topic relabeled for cadence.
- No newer weekly Google export set beginning Aug 17 was observed. The valid GSC six-day comparison remains 393 clicks / 66,510 impressions for Aug 10-15 versus 478 / 69,053 for Aug 3-8; complete 7-day and 28-day comparisons remain unavailable because the Aug 9 row/history is missing. GA4 Aug 10-16 remains finalized at 970 sessions and ~44.95% engagement versus 991 and ~44.90% for Aug 3-9.
- The Aug 20 public-safe brief reports homepage HTTP 200 in 189 ms, robots and sitemap HTTP 200, 674 sitemap entries, and canonical `https://eunomia.dev/`. No new technical SEO defect is established.
- Current NVIDIA CUPTI exposes API timing/correlation and optional kernel `queued`/`submitted` latency timestamps; Nsight Systems documents API/queue/kernel timing and explicitly notes that queue time is an approximation. The open problem is causal interpretation rather than adding one more timestamp.

## Scope

- Publish exactly one new bilingual Daily Report: GPU launch-delay attribution.
- Update both Daily Report indexes.
- Record the adjacent-systems detour and corrected rolling-window arithmetic in the content-series roadmap.
- Refresh the Aug 20 daily record and directly coupled SEO operating state.
- No unrelated technical SEO implementation change.

## Report thesis

A late CUDA kernel start is not one cause. Host readiness, runtime/command-buffer work, dependencies, device availability, and kernel execution must be separated using evidence that the trace actually proves. The report develops: (1) a launch-state ledger with explicit unknown states, (2) cross-domain launch lineage across host handoff and CUDA Graph replay, and (3) a ground-truth benchmark that scores causal diagnosis rather than only timestamp accuracy.

This is classified adjacent systems because CUPTI/CUDA/GPU scheduling semantics are central; eBPF is only an optional Linux host-evidence source.

## Validation

Repository CI is authoritative for SEO-data validation, Daily Report structure, generated content, links, metadata, static build, and deployment readiness. After all expected checks are green, I will review the complete final diff, commits, generated output, and check results before squash merge.

## Production target and acceptance

- Deployment: exact squash commit through `Deploy Static App` / GitHub Pages.
- Verify both `/research/gpu-kernel-launch-latency/` and `/zh/research/gpu-kernel-launch-latency/` in production.
- Acceptance includes Daily Report navigation, correct title/description, canonical URL, reciprocal `en`/`zh` plus `x-default`, Article JSON-LD, internal/external links, explicit current-work gap, developed directions, and conclusion-change boundary.
- Add exactly one compact closeout comment to the merged PR with exact CI/deployment/verification evidence. No second closeout PR.

The SEO skill submodule remains pinned. Upstream is newer, but the consuming contract still depends on the pinned layout, so no pointer-only update is included.