### PR TITLE
Daily: define application-resource profiling semantics

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -20,7 +20,7 @@ already configured and enabled; it is not a blocker.
 Google Drive access is verified and is not a blocker. The configured folder
 contains three adjacent weekly Search Console and GA4 export sets beginning
 `2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer weekly set was observed on
-`2026-08-19`. The newest Search Console date file has rows through `2026-08-15`,
+`2026-08-20`. The newest Search Console date file has rows through `2026-08-15`,
 which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
@@ -31,8 +31,8 @@ The 28-day comparison also remains unavailable because the export history is not
 long enough.
 
 GA4 landing-page files are weekly aggregates without a date dimension. On
-`2026-08-19`, the complete `2026-08-10` through `2026-08-16` aggregate is outside
-the configured three-day finalization lag and is usable as a finalized
+`2026-08-20`, the complete `2026-08-10` through `2026-08-16` aggregate remains
+outside the configured three-day finalization lag and is usable as a finalized
 source-native weekly comparison against `2026-08-03` through `2026-08-09`. The
 landing-page exports still do not provide complete acquisition, conversion, or
 outbound behavior coverage by themselves.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -78,11 +78,21 @@ how to distinguish allocation from pages that were actually touched, faulted,
 reclaimed, migrated, or responsible for sampled memory cost while preserving
 provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
-The `2026-08-19` report is a deliberate one-run **adjacent profiling detour** on
-sampling bias. Its central mechanism is general profiler measurement design, not
-eBPF, so it is classified as adjacent systems. It closes the first ten-report
-window at the intended 7 eBPF / 2 Agent / 1 adjacent mix without relabeling an
-eBPF-essential question.
+The `2026-08-19` report is a deliberate **adjacent profiling detour** on sampling
+bias. Its central mechanism is general profiler measurement design, not eBPF, so
+it is classified as adjacent systems.
+
+Before the `2026-08-20` topic was selected, the rolling ten-report window was
+**7 eBPF-centered / 2 pure Agent / 1 adjacent systems**. Adding another eBPF
+report would have pushed the window to 8 eBPF reports because the oldest report
+leaving the window was an Agent report. The mix therefore required another
+non-eBPF report even though the active series itself is eBPF-first.
+
+The `2026-08-20` report stays inside observability and profiling but asks a
+collector-neutral question: how a profiler can discover, version, and validate
+the semantics of application-defined resources. eBPF and uprobes are useful
+observers, but they are not essential to the proposed resource-semantics
+contract, so the report is classified as adjacent systems.
 
 ### Published progress
 
@@ -100,29 +110,38 @@ eBPF-essential question.
    selective instrumentation. Because the mechanism applies to profilers in
    general and does not require eBPF, this report is adjacent systems rather than
    eBPF-centered.
+3. `2026-08-20`: `/research/application-defined-resource-profiling/` asks how a
+   profiler can obtain a trustworthy identity, lifetime, unit, capacity, and
+   event model for application-defined resources. It builds on OSDI 2026
+   gigiprofiler and current Linux `user_events`/uprobe interfaces, then develops
+   a versioned resource-semantics manifest, runtime stale-model validation with
+   explicit confidence loss, and a ground-truth semantic benchmark. Because the
+   contract is intentionally independent of the collector, this report is
+   adjacent systems rather than eBPF-centered.
 
-After these reports, the first complete ten-report window is **7 eBPF-centered /
-2 pure Agent / 1 adjacent systems out of 10**. The next normal run may return to
-an eBPF-centered question inside this active series. Continue enforcing the
-rolling 10-report window as the oldest reports age out rather than treating the
-7 / 2 / 1 split as permanent.
+After the `2026-08-20` publication, the rolling window becomes **7 eBPF-centered /
+1 pure Agent / 2 adjacent systems out of 10**. The next run must remain non-eBPF:
+the oldest report that would leave the window is still the remaining pure-Agent
+report, so an eBPF report would again produce 8 eBPF reports. After one more
+non-eBPF publication ages that Agent report out, a subsequent eBPF report can
+return while keeping the window at or below 7 eBPF-centered reports.
 
 ### Preferred next questions
 
-Sampling theory is now covered by the adjacent report above. The preferred next
-questions inside the active eBPF series are:
+For the next run, stay near the active observability/profiling series while
+respecting the temporary non-eBPF mix constraint. Preferred adjacent questions
+are:
 
 1. always-on semantic compression that preserves diagnostic evidence instead of
-   raw event volume;
-2. application-defined resource profiling that combines static discovery,
-   runtime eBPF evidence, and online validation;
-3. causal profiling for GPU host-side bottlenecks and megakernel execution;
+   raw event volume, framed as a collector-neutral profiling problem;
+2. host/device causal profiling for GPU workloads when the mechanism is about
+   cross-layer evidence rather than eBPF itself;
+3. uncertainty-aware profile comparison across software versions or deployments;
 4. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
 
-The next run should start with these active-series questions and use current
-primary evidence to choose among them. A weak or duplicative candidate should be
-rejected rather than padded.
+Once the rolling window permits an eBPF-centered report again, return to the
+active eBPF questions rather than extending the adjacent detour by default.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
@@ -204,8 +223,11 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-These occupy the pure-Agent budget in the current rolling window. Do not schedule
-another pure Agent report until the rolling mix permits it.
+After the `2026-08-20` publication, only
+`/research/parallel-agent-effect-serializability/` remains inside the rolling
+ten-report window. A future pure-Agent report is numerically permitted by the
+1–2 cap, but it should still be selected only when it is stronger than adjacent
+systems candidates and does not displace the active eBPF roadmap unnecessarily.
 
 Future Agent reports should preferentially connect back to eBPF or systems
 infrastructure, for example OS-level effect tracing, eBPF policy enforcement,

--- a/.github/seo-data/daily/2026-08-20.md
+++ b/.github/seo-data/daily/2026-08-20.md
@@ -1,0 +1,207 @@
+# Daily SEO and research operation — 2026-08-20
+
+## Decision summary
+
+- Publish exactly one new bilingual Daily Report: **How Should a Profiler Discover Application-Defined Resources? / 性能分析器应该如何发现应用自定义资源？**
+- Classify it as **adjacent systems**, not eBPF-centered. Its main mechanism is a collector-neutral resource-semantics contract; eBPF and uprobes are optional evidence sources rather than required mechanisms.
+- Make no unrelated technical SEO change. Current evidence does not establish a crawl, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect that justifies speculative site work.
+- Refresh the rolling-series roadmap and operating metadata because the ten-report mix constrains topic selection more tightly than the previous roadmap text implied.
+
+## Source coverage
+
+| Source | Coverage on this run | Status |
+| --- | --- | --- |
+| Google Search Console weekly exports | Sets through week ending `2026-08-16`; finalized date rows through `2026-08-15` | available but history-limited |
+| GA4 organic landing-page weekly exports | Through `2026-08-16`; newest aggregate finalized | available |
+| Google Drive configured weekly-export folder | Rechecked `2026-08-20`; no newer weekly set present | available |
+| Cloudflare | Disabled in repository configuration | unavailable, not zero |
+| Repository public-safe data brief | Generated `2026-08-20 08:02 UTC` | current |
+| Live public site | Homepage fetched today; repository collector also checked homepage, robots and sitemap | available |
+| Public GitHub portfolio | Current public-safe repository snapshot | available |
+| Public primary research / kernel documentation | OSDI 2026 application-resource paper; Linux 6.18 `user_events` and uprobe documentation | available |
+
+No raw analytics, Drive identifiers, account identifiers, credentials, or private URLs are stored in this record.
+
+## Data movement and uncertainty
+
+### Search Console
+
+The valid equal-duration comparison remains `2026-08-10` through `2026-08-15`
+versus `2026-08-03` through `2026-08-08` because the `2026-08-09` date row is
+absent across adjacent exports.
+
+| Metric | 2026-08-10..15 | 2026-08-03..08 | Movement |
+| --- | ---: | ---: | ---: |
+| Clicks | 393 | 478 | -17.8% |
+| Impressions | 66,510 | 69,053 | -3.7% |
+| Weighted CTR | 0.591% | 0.692% | -0.101 pp |
+| Impression-weighted position | 9.91 | 9.42 | 0.49 worse |
+
+The older slice contains the unusual `2026-08-05` spike at 24,516 impressions.
+The available weekly exports still do not provide date-by-page or date-by-query
+evidence that would justify attributing that spike to one page or query family.
+
+A complete latest-seven-days versus previous-seven-days GSC comparison remains
+unavailable rather than approximated. The required 28-day comparison is also
+unavailable because the configured export history is not long enough.
+
+### GA4
+
+The finalized `2026-08-10` through `2026-08-16` organic landing-page aggregate
+contains 970 sessions at about 44.95% session-weighted engagement, versus 991
+sessions at about 44.90% for `2026-08-03` through `2026-08-09`. Sessions are about
+2.1% lower and engagement is effectively flat. `(not set)` is 134 versus 116
+sessions; excluding it, sessions are 836 versus 875.
+
+These are source-native acquisition and measurement signals. They do not support
+a causal claim that a title, navigation, Daily Report, or site-structure change
+caused the movement.
+
+### Public operating brief
+
+The current repository-generated public-safe brief reports:
+
+- homepage HTTP 200 in 189 ms;
+- `robots.txt` and sitemap reachable;
+- 674 sitemap entries;
+- canonical homepage `https://eunomia.dev/`;
+- 97 active non-fork public repositories, 9,775 stars, 1,280 forks, and 284 open issue/PR records;
+- 60 observed DEV articles, 43 public reactions, and 4 comments.
+
+The public web crawler returned a current homepage but an older cached Daily
+Report index snapshot. That cache lag is not treated as evidence of a production
+indexing or deployment defect without a fresh direct observation of the affected
+route.
+
+## Technical SEO/GEO audit
+
+The repository already generates sitemap, robots, canonical URLs, reciprocal
+language alternates, Open Graph metadata, Article structured data, legacy redirect
+stubs, and static HTTP-audit artifacts. Current repository and public-safe
+collection evidence does not establish a new defect in those surfaces.
+
+The mandatory report adds only the directly coupled public artifacts:
+
+- one English report;
+- one Chinese report;
+- English and Chinese Daily Report index entries.
+
+No unrelated title, copy, navigation, redirect, canonical, structured-data, or
+frontend change is included.
+
+## Rolling Daily Report mix before topic selection
+
+The ten reports already published before today's new page classify as:
+
+- eBPF-centered: **7 / 10**;
+- pure Agent-centered: **2 / 10**;
+- adjacent systems: **1 / 10**.
+
+The oldest report leaving the window today is a pure-Agent report. Therefore an
+eBPF-centered publication would make the new window **8 eBPF / 1 Agent / 1
+adjacent**, violating the configured 5–7 eBPF range. The topic for this run must
+be non-eBPF unless the classification is manipulated, which is explicitly
+forbidden.
+
+After today's adjacent report, the rolling window is **7 eBPF / 1 pure Agent / 2
+adjacent**. The next run must also remain non-eBPF because the remaining Agent
+report is then the oldest item that will leave the window. A subsequent run may
+return to eBPF once an old eBPF report begins aging out.
+
+## Research selection
+
+### Selected question
+
+**How can a profiler discover the identity, lifetime, capacity, units, and usage
+semantics of application-defined resources, validate that model at runtime, and
+detect when an inferred or declared model has become stale?**
+
+This stays inside the active observability/profiling area without pretending that
+eBPF is essential to a collector-neutral problem.
+
+### Primary evidence
+
+The current OSDI 2026 paper *Diagnosing Performance Issues in
+Application-Defined Resources* is the strongest recent anchor. The final paper
+studies 45 real application-resource issues, uses an LLM plus static-analysis
+pipeline to identify resource-use events, instruments `WAIT`, `ACQUIRE`, `USE`,
+and `RELEASE`, evaluates 15 reproduced issues across five applications, and
+reports two additional MariaDB issues confirmed by developers. Its detailed
+coverage study also exposes the remaining semantic problem: LLM-only event
+identification has high false positives, validation reduces them, and an
+exhaustive MySQL buffer-pool study still finds missed events.
+
+Linux 6.18 `user_events` provides typed user-space trace events, enable-state
+feedback, and multi-format event registration. Current uprobe tracing can attach
+to existing user-space code and fetch arguments or return values. These are useful
+collection mechanisms, but neither interface defines application-resource
+identity, lifetime, capacity unit, ownership, or stale-model detection.
+
+### Gap
+
+Existing work can discover useful resource-use sites and transport application
+trace payloads, but there is no small shared contract that states:
+
+- what identifies one logical resource instance;
+- when an identity or pointer generation expires;
+- what an acquired unit means;
+- whether capacity is fixed, dynamic, or unknown;
+- what events change ownership or pressure;
+- which binary/module version the mapping applies to;
+- when runtime evidence should invalidate or downgrade the mapping.
+
+This is distinct from the existing asynchronous causal-profiler report. That
+report assumes useful logical identities can be obtained and asks how to connect
+work across execution contexts. Today's report asks how those resource identities
+and lifecycle semantics become trustworthy in the first place.
+
+### Developed directions
+
+1. **Portable resource-semantics manifest.** Normalize declared and inferred
+   resource descriptions into a versioned artifact with instance keys,
+   generation rules, units, capacity semantics, event mappings, build identity,
+   evidence source, and confidence.
+2. **Runtime stale-model validation.** Check semantic invariants and explicitly
+   downgrade a resource class to degraded/unknown when observations contradict
+   the contract instead of silently emitting normal attribution.
+3. **Ground-truth application-resource benchmark.** Compare manual annotations,
+   static user events, uprobes, automatic inference, and hybrid designs on known
+   resource identities/lifetimes under controlled software-version mutations.
+
+### Falsifier
+
+The proposed semantic-contract layer is unnecessary if automatic discovery stays
+accurate across substantial software evolution, existing application events
+already expose sufficient lifecycle semantics, or identity/lifetime errors do not
+materially change diagnosis. The discriminating experiment is longitudinal:
+freeze profiler knowledge at version N and measure attribution/diagnosis across
+later versions with no adaptation, rediscovery, explicit descriptors, and
+descriptors plus runtime validation.
+
+## Files in the daily change
+
+Public content:
+
+- `docs/research/application-defined-resource-profiling.md`
+- `docs/research/application-defined-resource-profiling.zh.md`
+- `docs/research/index.md`
+- `docs/research/index.zh.md`
+
+Operating state:
+
+- `.github/seo-data/daily/2026-08-20.md`
+- `.github/seo-data/status.md`
+- `.github/seo-data/plan.md`
+- `.github/seo-data/block.md`
+- `.github/seo-data/site.md`
+- `.github/seo-data/content-series.md`
+
+## Delivery state
+
+Branch: `daily/2026-08-20-application-resource-profiling`.
+
+The required non-draft pull request, authoritative CI, complete final diff and
+generated-output self-review, squash merge, exact-commit production deployment,
+bilingual public verification, and one merged-PR closeout comment are completed
+later in this same daily operation. Until those steps finish, the run is not
+considered complete.

--- a/.github/seo-data/daily/2026-08-20.md
+++ b/.github/seo-data/daily/2026-08-20.md
@@ -1,125 +1,93 @@
-# Daily SEO and research operation — 2026-08-20
+# SEO operations — 2026-08-20
 
-## Decision summary
+## Scope
 
-- Publish exactly one new bilingual Daily Report: **How Should a Profiler Discover Application-Defined Resources? / 性能分析器应该如何发现应用自定义资源？**
-- Classify it as **adjacent systems**, not eBPF-centered. Its main mechanism is a collector-neutral resource-semantics contract; eBPF and uprobes are optional evidence sources rather than required mechanisms.
-- Make no unrelated technical SEO change. Current evidence does not establish a crawl, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect that justifies speculative site work.
-- Refresh the rolling-series roadmap and operating metadata because the ten-report mix constrains topic selection more tightly than the previous roadmap text implied.
+This run follows the repository-authoritative `DAILY_TASK.md`: use all enabled
+analytics and public evidence, audit technical SEO/GEO, calculate the rolling
+Daily Report mix before topic selection, publish exactly one new bilingual Daily
+Report, and deliver the public change through one fresh branch and one non-draft
+pull request.
 
-## Source coverage
+The selected report is **How Should a Profiler Discover Application-Defined
+Resources? / 性能分析器应该如何发现应用自定义资源？**. It is classified as
+**adjacent systems**, not eBPF-centered, because its central mechanism is a
+collector-neutral resource-semantics contract. eBPF and uprobes are useful
+observers but are not required by the proposed mechanism.
 
-| Source | Coverage on this run | Status |
+No unrelated technical SEO implementation change is included. Current evidence
+does not establish a crawl, canonical, hreflang, structured-data, redirect,
+rendering, accessibility, performance, or deployment defect that justifies a
+speculative site change.
+
+## Data window
+
+This run used every source enabled by `.github/seo-data/site.md`.
+
+| Source | Coverage used | State |
 | --- | --- | --- |
-| Google Search Console weekly exports | Sets through week ending `2026-08-16`; finalized date rows through `2026-08-15` | available but history-limited |
-| GA4 organic landing-page weekly exports | Through `2026-08-16`; newest aggregate finalized | available |
-| Google Drive configured weekly-export folder | Rechecked `2026-08-20`; no newer weekly set present | available |
-| Cloudflare | Disabled in repository configuration | unavailable, not zero |
-| Repository public-safe data brief | Generated `2026-08-20 08:02 UTC` | current |
-| Live public site | Homepage fetched today; repository collector also checked homepage, robots and sitemap | available |
-| Public GitHub portfolio | Current public-safe repository snapshot | available |
-| Public primary research / kernel documentation | OSDI 2026 application-resource paper; Linux 6.18 `user_events` and uprobe documentation | available |
+| Google Search Console | weekly Drive export sets through the week ending `2026-08-16`; finalized date rows through `2026-08-15` | available; history-limited |
+| Google Analytics 4 | weekly organic landing-page aggregates through `2026-08-16` | available; newest aggregate finalized |
+| Google Drive configured weekly-export folder | rechecked `2026-08-20`; no newer weekly set present | available |
+| Public-safe repository collection | `.github/data-analysis/latest.md`, generated `2026-08-20 08:02 UTC` | available |
+| Public GitHub | current repository and project state | available |
+| Live / generated technical site evidence | homepage, robots, sitemap, canonical and prior production evidence | available |
+| Public web / primary research | application-resource research and current Linux tracing documentation checked through `2026-08-20` | available |
+| Cloudflare | disabled in `site.md` | not collected by design |
 
-No raw analytics, Drive identifiers, account identifiers, credentials, or private URLs are stored in this record.
+No raw analytics, Drive identifiers, account identifiers, credentials, or private
+URLs are stored in this record. Missing source coverage is not converted into
+zero.
 
-## Data movement and uncertainty
+A complete latest-seven-days versus previous-seven-days Search Console comparison
+remains unavailable because the `2026-08-09` date row is absent across adjacent
+weekly files. The required 28-day comparison is also unavailable because the
+verified export history is too short. The valid equal-duration comparison remains
+`2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`.
+
+## Evidence collected
 
 ### Search Console
 
-The valid equal-duration comparison remains `2026-08-10` through `2026-08-15`
-versus `2026-08-03` through `2026-08-08` because the `2026-08-09` date row is
-absent across adjacent exports.
+For `2026-08-10` through `2026-08-15`, Search Console reports **393 clicks** and
+**66,510 impressions**, weighted CTR about **0.591%**, and
+impression-weighted average position about **9.91**.
 
-| Metric | 2026-08-10..15 | 2026-08-03..08 | Movement |
-| --- | ---: | ---: | ---: |
-| Clicks | 393 | 478 | -17.8% |
-| Impressions | 66,510 | 69,053 | -3.7% |
-| Weighted CTR | 0.591% | 0.692% | -0.101 pp |
-| Impression-weighted position | 9.91 | 9.42 | 0.49 worse |
+The comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks** and
+**69,053 impressions**, **0.692%** CTR, and average position about **9.42**.
+Clicks are about **17.8% lower**, impressions about **3.7% lower**, CTR about
+**0.101 percentage points lower**, and average position about **0.49 positions
+worse** in the newer slice.
 
 The older slice contains the unusual `2026-08-05` spike at 24,516 impressions.
 The available weekly exports still do not provide date-by-page or date-by-query
 evidence that would justify attributing that spike to one page or query family.
 
-A complete latest-seven-days versus previous-seven-days GSC comparison remains
-unavailable rather than approximated. The required 28-day comparison is also
-unavailable because the configured export history is not long enough.
-
-### GA4
+### Google Analytics 4
 
 The finalized `2026-08-10` through `2026-08-16` organic landing-page aggregate
-contains 970 sessions at about 44.95% session-weighted engagement, versus 991
-sessions at about 44.90% for `2026-08-03` through `2026-08-09`. Sessions are about
-2.1% lower and engagement is effectively flat. `(not set)` is 134 versus 116
-sessions; excluding it, sessions are 836 versus 875.
+contains **970 sessions** at about **44.95%** session-weighted engagement, versus
+**991 sessions** at about **44.90%** for `2026-08-03` through `2026-08-09`.
+Sessions are about **2.1% lower** and engagement is effectively flat. `(not set)`
+is **134 versus 116 sessions**; excluding it, sessions are **836 versus 875**.
 
 These are source-native acquisition and measurement signals. They do not support
 a causal claim that a title, navigation, Daily Report, or site-structure change
 caused the movement.
 
-### Public operating brief
+### Public operating evidence
 
-The current repository-generated public-safe brief reports:
-
-- homepage HTTP 200 in 189 ms;
-- `robots.txt` and sitemap reachable;
-- 674 sitemap entries;
-- canonical homepage `https://eunomia.dev/`;
-- 97 active non-fork public repositories, 9,775 stars, 1,280 forks, and 284 open issue/PR records;
-- 60 observed DEV articles, 43 public reactions, and 4 comments.
+The current repository-generated public-safe brief reports homepage HTTP 200 in
+189 ms, reachable `robots.txt` and sitemap, 674 sitemap entries, canonical
+homepage `https://eunomia.dev/`, 97 active non-fork public repositories, 9,775
+stars, 1,280 forks, 284 open issue/PR records, and a DEV surface of 60 articles,
+43 public reactions, and 4 comments.
 
 The public web crawler returned a current homepage but an older cached Daily
 Report index snapshot. That cache lag is not treated as evidence of a production
 indexing or deployment defect without a fresh direct observation of the affected
 route.
 
-## Technical SEO/GEO audit
-
-The repository already generates sitemap, robots, canonical URLs, reciprocal
-language alternates, Open Graph metadata, Article structured data, legacy redirect
-stubs, and static HTTP-audit artifacts. Current repository and public-safe
-collection evidence does not establish a new defect in those surfaces.
-
-The mandatory report adds only the directly coupled public artifacts:
-
-- one English report;
-- one Chinese report;
-- English and Chinese Daily Report index entries.
-
-No unrelated title, copy, navigation, redirect, canonical, structured-data, or
-frontend change is included.
-
-## Rolling Daily Report mix before topic selection
-
-The ten reports already published before today's new page classify as:
-
-- eBPF-centered: **7 / 10**;
-- pure Agent-centered: **2 / 10**;
-- adjacent systems: **1 / 10**.
-
-The oldest report leaving the window today is a pure-Agent report. Therefore an
-eBPF-centered publication would make the new window **8 eBPF / 1 Agent / 1
-adjacent**, violating the configured 5–7 eBPF range. The topic for this run must
-be non-eBPF unless the classification is manipulated, which is explicitly
-forbidden.
-
-After today's adjacent report, the rolling window is **7 eBPF / 1 pure Agent / 2
-adjacent**. The next run must also remain non-eBPF because the remaining Agent
-report is then the oldest item that will leave the window. A subsequent run may
-return to eBPF once an old eBPF report begins aging out.
-
-## Research selection
-
-### Selected question
-
-**How can a profiler discover the identity, lifetime, capacity, units, and usage
-semantics of application-defined resources, validate that model at runtime, and
-detect when an inferred or declared model has become stale?**
-
-This stays inside the active observability/profiling area without pretending that
-eBPF is essential to a collector-neutral problem.
-
-### Primary evidence
+### Research evidence
 
 The current OSDI 2026 paper *Diagnosing Performance Issues in
 Application-Defined Resources* is the strongest recent anchor. The final paper
@@ -137,57 +105,52 @@ to existing user-space code and fetch arguments or return values. These are usef
 collection mechanisms, but neither interface defines application-resource
 identity, lifetime, capacity unit, ownership, or stale-model detection.
 
-### Gap
+## Work performed
 
-Existing work can discover useful resource-use sites and transport application
-trace payloads, but there is no small shared contract that states:
+The ten reports already published before today's page classify as **7 eBPF / 2
+pure Agent / 1 adjacent systems**. The oldest report leaving the rolling window
+today is a pure-Agent report. An eBPF-centered publication would therefore make
+the new window **8 eBPF / 1 Agent / 1 adjacent**, violating the configured 5–7
+eBPF range. Today's report must be non-eBPF unless classification is manipulated,
+which the repository explicitly forbids.
 
-- what identifies one logical resource instance;
-- when an identity or pointer generation expires;
-- what an acquired unit means;
-- whether capacity is fixed, dynamic, or unknown;
-- what events change ownership or pressure;
-- which binary/module version the mapping applies to;
-- when runtime evidence should invalidate or downgrade the mapping.
+The selected question is: **How can a profiler discover the identity, lifetime,
+capacity, units, and usage semantics of application-defined resources, validate
+that model at runtime, and detect when an inferred or declared model has become
+stale?**
 
-This is distinct from the existing asynchronous causal-profiler report. That
-report assumes useful logical identities can be obtained and asks how to connect
-work across execution contexts. Today's report asks how those resource identities
-and lifecycle semantics become trustworthy in the first place.
+The report identifies a gap distinct from the existing asynchronous causal
+profiler. The earlier report assumes useful logical identities can be obtained
+and asks how to connect work across execution contexts. Today's report asks how
+resource identities and lifecycle semantics become trustworthy in the first
+place.
 
-### Developed directions
+It develops three directions:
 
-1. **Portable resource-semantics manifest.** Normalize declared and inferred
+1. **Portable resource-semantics manifest:** normalize declared and inferred
    resource descriptions into a versioned artifact with instance keys,
    generation rules, units, capacity semantics, event mappings, build identity,
    evidence source, and confidence.
-2. **Runtime stale-model validation.** Check semantic invariants and explicitly
-   downgrade a resource class to degraded/unknown when observations contradict
-   the contract instead of silently emitting normal attribution.
-3. **Ground-truth application-resource benchmark.** Compare manual annotations,
+2. **Runtime stale-model validation:** check semantic invariants and explicitly
+   downgrade a resource class to degraded or unknown when observations
+   contradict the contract instead of silently emitting normal attribution.
+3. **Ground-truth application-resource benchmark:** compare manual annotations,
    static user events, uprobes, automatic inference, and hybrid designs on known
-   resource identities/lifetimes under controlled software-version mutations.
+   resource identities and lifetimes under controlled software-version changes.
 
-### Falsifier
+The falsifier is longitudinal. Freeze profiler knowledge at version N and measure
+attribution and diagnosis across later versions with no adaptation, rediscovery,
+explicit descriptors, and descriptors plus runtime validation. If stale models
+rarely cause wrong decisions, the semantic-contract layer is unnecessary.
 
-The proposed semantic-contract layer is unnecessary if automatic discovery stays
-accurate across substantial software evolution, existing application events
-already expose sufficient lifecycle semantics, or identity/lifetime errors do not
-materially change diagnosis. The discriminating experiment is longitudinal:
-freeze profiler knowledge at version N and measure attribution/diagnosis across
-later versions with no adaptation, rediscovery, explicit descriptors, and
-descriptors plus runtime validation.
-
-## Files in the daily change
-
-Public content:
+Public content changed:
 
 - `docs/research/application-defined-resource-profiling.md`
 - `docs/research/application-defined-resource-profiling.zh.md`
 - `docs/research/index.md`
 - `docs/research/index.zh.md`
 
-Operating state:
+Operating state changed:
 
 - `.github/seo-data/daily/2026-08-20.md`
 - `.github/seo-data/status.md`
@@ -196,12 +159,54 @@ Operating state:
 - `.github/seo-data/site.md`
 - `.github/seo-data/content-series.md`
 
-## Delivery state
+The SEO skill submodule remains pinned at
+`516e9e2dcf012506a677a749049d64c5914643e9`. A pointer-only update is not mixed
+into this daily change because the consuming repository still names interfaces
+from the pinned layout.
+
+## Validation and self-review
+
+The first `Validate SEO Operations` run correctly rejected the initial daily
+record because it did not use the pinned validator's required headings. The
+record was corrected on the same branch to the required title and schema before
+merge. This failure is treated as validation evidence, not bypassed.
+
+The final pre-merge gate is the repository's authoritative CI plus a complete
+review of the final PR diff and generated static output. Review scope includes
+report evidence fidelity, bilingual equivalence, public-data safety, rolling-mix
+classification, metadata, canonical and language alternates, internal links,
+required research headings, and the conclusion/falsifier boundary.
+
+## Delivery
 
 Branch: `daily/2026-08-20-application-resource-profiling`.
 
-The required non-draft pull request, authoritative CI, complete final diff and
-generated-output self-review, squash merge, exact-commit production deployment,
-bilingual public verification, and one merged-PR closeout comment are completed
-later in this same daily operation. Until those steps finish, the run is not
-considered complete.
+Main pull request: `#166`, non-draft. The run is not complete while any required
+or expected check is missing, queued, skipped, cancelled, timed out, or failed.
+After green CI and a clean final self-review, the pull request is squash-merged.
+The exact squash commit must then complete the production `Deploy Static App`
+workflow, and the generated English and Chinese report routes must be verified
+before closeout.
+
+The final merge SHA, CI runs, production export, public verification, and
+closeout result are recorded in the single compact merged-PR comment rather than
+a second closeout pull request.
+
+## Decisions and follow-ups
+
+After today's adjacent report, the rolling window becomes **7 eBPF / 1 pure Agent
+/ 2 adjacent systems**. The next run must also remain non-eBPF because the oldest
+report that will leave the window is still the remaining pure-Agent report.
+After that report ages out, a later run can return to an eBPF-centered question
+while keeping the rolling window at or below seven eBPF reports.
+
+Preferred next adjacent questions near the active observability/profiling series
+are collector-neutral semantic compression, host/device causal evidence for GPU
+workloads, and uncertainty-aware cross-version profile comparison.
+
+Keep the complete GSC 7-day and 28-day comparisons unavailable until source
+history supports them; never treat the missing `2026-08-09` row as zero. Obtain
+date-by-page or date-by-query evidence before attributing the `2026-08-05`
+impression spike. Continue monitoring Search Console click/CTR movement before
+changing search-facing titles, copy, or navigation. Add Cloudflare evidence only
+when a supported read-only route is enabled in repository configuration.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -71,23 +71,22 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix. The `2026-08-19` general profiler-sampling
-   report is genuinely adjacent systems rather than eBPF-centered, so the first
-   complete ten-report window is **7 eBPF-centered / 2 pure Agent / 1 adjacent**.
-   Recalculate the rolling window on every later run as old reports age out; do
-   not treat this one split as a permanent target.
-2. Return normal topic selection to the active **eBPF Observability and Profiling**
-   series. Sampling theory is now covered as an adjacent measurement-design
-   question. Prefer the remaining active questions on always-on semantic
-   compression, application-defined resource profiling, and GPU host/device
-   causal profiling, subject to fresh primary evidence and novelty checks.
+1. Preserve the rolling ten-report mix. Before the `2026-08-20` topic selection,
+   the window was **7 eBPF-centered / 2 pure Agent / 1 adjacent**. The new
+   application-defined-resource profiling report is genuinely adjacent because
+   its semantic contract is collector-neutral; after publication the window is
+   **7 eBPF / 1 pure Agent / 2 adjacent**. The next run must remain non-eBPF
+   because another eBPF report would push the rolling window to 8 eBPF reports.
+2. Keep topic selection near the active **eBPF Observability and Profiling**
+   series while the mix temporarily requires a non-eBPF report. Prefer adjacent
+   questions on always-on semantic compression, GPU host/device causal evidence,
+   or uncertainty-aware cross-version profile comparison. Return to an
+   eBPF-centered question as soon as the rolling window permits it.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-19`, the `2026-08-10` through `2026-08-16` GA4 weekly aggregate is
-   now outside the configured three-day finalization lag and can be compared as a
-   finalized source-native week against `2026-08-03` through `2026-08-09`.
-   Search Console still lacks the `2026-08-09` date row, so keep the required
-   complete 7-day and 28-day comparisons unavailable until source history really
-   supports them.
+   No newer set was present on `2026-08-20`. The `2026-08-10` through
+   `2026-08-16` GA4 weekly aggregate is finalized; Search Console still lacks the
+   `2026-08-09` date row, so keep the required complete 7-day and 28-day
+   comparisons unavailable until source history supports them.
 4. Obtain or generate date-by-page or date-by-query Search Console evidence before
    attributing the `2026-08-05` impression spike to a specific page or query family.
 5. Monitor the current Search Console click/CTR decline and homepage/branded

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -53,7 +53,7 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
 `2026-08-16`; no newer weekly set was observed in the configured Drive folder on
-`2026-08-19`. Search Console rows through `2026-08-15` are usable. The
+`2026-08-20`. Search Console rows through `2026-08-15` are usable. The
 `2026-08-09` Search Console date row is still absent across the adjacent files,
 so a complete latest-7-days versus previous-7-days comparison remains
 unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
@@ -61,9 +61,9 @@ unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
 also unavailable because the export history is not long enough.
 
 GA4 weekly landing-page exports have no date dimension for trimming a partial or
-unfinalized day within a file. On `2026-08-19`, every day in the newest
+unfinalized day within a file. On `2026-08-20`, every day in the newest
 `2026-08-10` through `2026-08-16` aggregate is outside the configured three-day
-finalization lag, so the whole aggregate is now usable as a finalized
+finalization lag, so the whole aggregate remains usable as a finalized
 source-native weekly comparison against `2026-08-03` through `2026-08-09`.
 Public repository and live-site data supplement these exports but do not replace
 their source-native meanings.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,81 +7,76 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-18`
-- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`, with the newest weekly aggregate finalized under the three-day lag on `2026-08-19`
-- Latest daily record: `2026-08-19`
-- Last completed public-change pull request: `#162`
-- Last verified production publication from a daily run: static export commit `a26e10fb68a0d0896dcf77d5a79f74c898517bfc` for squash commit `36df29128cbe388eaa37dc573e2ad9902c9c1904`
-- Current daily branch: `daily/2026-08-19-profiler-sampling-bias`
+- Last completed daily run: `2026-08-19`
+- Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`, with the newest weekly aggregate finalized under the three-day lag
+- Latest daily record: `2026-08-20`
+- Last completed public-change pull request: `#163`
+- Last verified production publication from a daily run: static export commit `a0ab9aed6af348eb8d85634339f407eca2122616` for squash commit `38d50fd8584293490cf845f2c4ff710c368dbe88`
+- Current daily branch: `daily/2026-08-20-application-resource-profiling`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#162` is fully closed out. It squash-merged as
-`36df29128cbe388eaa37dc573e2ad9902c9c1904`; final PR-head `Validate SEO
-Operations` run `32158581620` and `Deploy Static App` run `32158581694`
-succeeded. The production static branch contains commit
-`a26e10fb68a0d0896dcf77d5a79f74c898517bfc` with the exact message `deploy
-static app for 36df29128cbe388eaa37dc573e2ad9902c9c1904`, and its generated English
-and Chinese memory-attribution pages contain the expected canonical URLs,
-reciprocal language alternates plus `x-default`, Article JSON-LD, and report
-metadata. The merged PR now has the required compact closeout comment.
+PR `#163` is fully closed out. It squash-merged as
+`38d50fd8584293490cf845f2c4ff710c368dbe88`; final PR-head `Deploy Static App`
+run `32274536861` and `Validate SEO Operations` run `32274536879` succeeded. The
+production branch contains static-export commit
+`a0ab9aed6af348eb8d85634339f407eca2122616` with the exact deployment message for
+the squash commit, and the generated English and Chinese profiler-sampling pages
+were verified for report content, canonical URLs, reciprocal language alternates
+plus `x-default`, Article JSON-LD, and Daily Report navigation. The required
+closeout comment is present on the merged PR.
 
 ## Current Daily Report mix
 
-Before the current change, the completed archive contains nine reports:
+Before the `2026-08-20` publication, the rolling ten-report window is:
 
-- eBPF-centered: **7 of 9**
-- pure Agent-centered: **2 of 9**
-- adjacent systems: **0 of 9**
+- eBPF-centered: **7 of 10**
+- pure Agent-centered: **2 of 10**
+- adjacent systems: **1 of 10**
 
-Today's profiler-sampling report is a genuine adjacent-systems report. Its
-central mechanisms are sampling-schedule design, phase-locking diagnostics,
-uncertainty estimation, rank stability, and selective instrumentation; they
-apply to `perf`, PMU, runtime, mobile, and other profilers without requiring
-eBPF. After publication the first complete ten-report window becomes **7 eBPF /
-2 pure Agent / 1 adjacent out of 10**, satisfying the repository's rolling mix
-without relabeling an eBPF-essential topic.
+The new application-defined-resource profiling report is a genuine adjacent
+systems report. Its central mechanism is a collector-neutral resource-semantics
+contract, stale-model validation, and a cross-instrumentation benchmark. eBPF and
+uprobes can provide evidence but are not essential to the mechanism. After
+publication the window becomes **7 eBPF / 1 pure Agent / 2 adjacent out of 10**.
 
-Normal topic selection can return to the active **eBPF Observability and
-Profiling** series on the next run, subject to the rolling ten-report window as
-the oldest reports later age out.
+The next run must remain non-eBPF because the oldest report that would leave the
+window is still the remaining pure-Agent report. Another eBPF report would push
+the window to 8 eBPF reports and violate the configured 5–7 range.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-19 07:58 UTC`
-- Homepage: HTTP 200 in **137 ms** in the current operating brief
+- Repository-generated public-safe operating brief: refreshed `2026-08-20 08:02 UTC`
+- Homepage: HTTP 200 in **189 ms** in the current operating brief
 - `robots.txt`: reachable; sitemap: reachable
-- Sitemap entries observed: **672**
+- Sitemap entries observed: **674**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,771 stars, 1,279 forks, and 283 open issue/PR records
+- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,775 stars, 1,280 forks, and 284 open issue/PR records
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; the newest complete aggregate is finalized on `2026-08-19`
+- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; newest aggregate finalized
 - Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
 - Cloudflare: disabled by repository configuration
 
-For the valid equal-duration Search Console comparison, `2026-08-10` through
-`2026-08-15` reports **393 clicks / 66,510 impressions**, weighted CTR about
-**0.591%**, and impression-weighted average position about **9.91**. The
+The valid equal-duration Search Console comparison is unchanged. `2026-08-10`
+through `2026-08-15` reports **393 clicks / 66,510 impressions**, weighted CTR
+about **0.591%**, and impression-weighted average position about **9.91**. The
 comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks / 69,053
 impressions**, **0.692%** CTR, and position about **9.42**. Clicks are about
 **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage
 points lower**, and average position about **0.49 positions worse**. The older
-slice includes the unusual `2026-08-05` impression spike, so the movement remains
-monitored rather than attributed to one page, query, or Daily Report.
+slice includes the unusual `2026-08-05` impression spike, so movement remains
+monitored rather than attributed to one page, query, or report.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison remains
-unavailable because the `2026-08-09` date row is absent across the adjacent
-weekly files. The required 28-day comparison is also unavailable rather than
-inferred.
+unavailable because the `2026-08-09` date row is absent. The required 28-day
+comparison is also unavailable rather than inferred.
 
 The finalized GA4 organic landing-page export for `2026-08-10` through
 `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted
 engagement, versus **991 sessions** at about **44.90%** for `2026-08-03` through
-`2026-08-09`. Sessions are about **2.1% lower** while engagement is effectively
-flat. `(not set)` is **134 versus 116 sessions**; excluding it, sessions are
-**836 versus 875**. These are source-native acquisition and measurement signals,
-not evidence for a speculative title, copy, navigation, or site-structure
-change.
+`2026-08-09`. `(not set)` is **134 versus 116 sessions**; excluding it, sessions
+are **836 versus 875**. No newer weekly export set was present in the configured
+Drive folder on `2026-08-20`.
 
 ## Current technical baseline
 
@@ -89,34 +84,33 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and HTTP audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The `2026-08-19` public-safe operating brief and current repository evidence do
-not establish a new crawl, canonical, hreflang, structured-data, redirect,
-broken-link, rendering, accessibility, performance, or deployment defect. The
-appropriate public site change today is therefore the mandatory bilingual Daily
-Report and directly coupled report-index/series updates, not an unrelated
-technical SEO patch.
+The `2026-08-20` public-safe brief and repository evidence do not establish a new
+crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering,
+accessibility, performance, or deployment defect. The public web crawler can lag
+the current generated Daily Report index, so cached search snapshots are not
+used as evidence of a production defect without a fresh direct observation. The
+appropriate public change is the mandatory bilingual Daily Report and coupled
+report-index/series updates, not an unrelated technical SEO patch.
 
-Today's research asks when profiler sampling becomes structurally biased rather
-than merely noisy. Primary evidence spans the 1993 randomized sampling-clock
-work, Linux `perf_event_open()` sampling semantics and current profile-collection
-guidance, and the OSDI 2026 Blink result on flat workloads. The report develops
-a realized sampling-schedule contract with aliasing diagnostics, replicated
-profile epochs with uncertainty and rank stability, and uncertainty-triggered
-selective instrumentation under a fixed overhead budget.
+Today's report asks how profilers can discover the identity, lifetime, units,
+capacity, and usage semantics of application-defined resources and detect when
+that model becomes stale. Primary evidence includes the OSDI 2026 gigiprofiler
+paper and current Linux 6.18 `user_events` and uprobe documentation. The report
+develops a portable resource-semantics manifest, runtime confidence degradation,
+and a ground-truth benchmark spanning multiple instrumentation strategies.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream remains at
-`f42128a3f05c73cf10c786a2711c488bb3a14839`, while the consuming repository still
-names interfaces from the pinned layout. A pointer-only update is therefore not
-mixed into this daily delivery.
+`516e9e2dcf012506a677a749049d64c5914643e9`; a pointer-only update is not mixed
+into this daily delivery because the consuming contract still names pinned-layout
+interfaces.
 
 ## Current focus
 
-1. Complete the `2026-08-19` profiler-sampling Daily Report through final CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. On the next normal run, return to the active eBPF Observability and Profiling series and evaluate the remaining questions on semantic compression, application-defined resource profiling, and GPU causal profiling.
-3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
+1. Complete the `2026-08-20` application-resource Daily Report through CI, full diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Keep the next report non-eBPF to preserve the rolling ten-report maximum; prefer an adjacent observability/profiling question close to the active series.
+3. Keep the complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
-5. Monitor the Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
+5. Monitor Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
 6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.

--- a/docs/research/application-defined-resource-profiling.md
+++ b/docs/research/application-defined-resource-profiling.md
@@ -1,0 +1,217 @@
+---
+date: 2026-08-20
+title: "How Should a Profiler Discover Application-Defined Resources?"
+description: "Application-defined resources hide behind normal CPU and memory metrics. This report asks how profilers can discover their semantics and detect stale models safely."
+tags:
+  - Daily Report
+  - Profiling
+  - Observability
+  - Performance
+  - Linux
+research_question: "How can a profiler discover the identity, lifetime, capacity, and usage semantics of application-defined resources, validate that model at runtime, and detect when an inferred or declared model has become stale?"
+source_cutoff: 2026-08-20
+status: daily-report
+---
+
+# How Should a Profiler Discover Application-Defined Resources?
+
+Suppose a database suddenly loses throughput while CPU utilization, resident memory, and lock contention still look ordinary. One request has filled an internal buffer pool with temporary data. Later requests now trigger expensive eviction and I/O, but the operating system only sees memory that the database allocated long ago. The important resource is not a page allocator or kernel lock. It is a buffer pool whose meaning exists inside the application.
+
+This is the visibility gap behind **application-defined resource profiling**. Recent work shows that a profiler can recover much of this hidden structure from source code and runtime behavior. The harder next problem is keeping that recovered model correct as software changes. A profiler needs to know not only that a variable or function looks resource-related, but what identifies one resource instance, when that identity can be reused, what units are acquired or released, which operations indicate pressure, and whether the model still matches the binary that is running.
+
+<!-- more -->
+
+The useful design target is therefore a **versioned resource semantics contract**. Applications may declare part of it explicitly. Offline analysis may infer missing pieces. Runtime observation should then validate the contract and downgrade confidence when the observed behavior no longer matches it. This is a general profiling problem. Linux `user_events`, static trace markers, uprobes, compiler instrumentation, and eBPF can all provide evidence, but none of them alone defines what an application resource means.
+
+This report follows the [asynchronous causal profiling report](https://eunomia.dev/research/async-ebpf-causal-profiler/) from a different direction. That report asks how to connect work after a logical operation moves across threads and queues. Here the question comes one step earlier: **how does a profiler obtain a trustworthy identity and lifecycle for an application resource in the first place?**
+
+## Why system metrics can be correct and still miss the bottleneck
+
+The OSDI 2026 paper *Diagnosing Performance Issues in Application-Defined Resources* gives a concrete example. MySQL can fill its InnoDB buffer pool with temporary table pages. Later requests then pay for eviction and reload. The operating system does not report memory pressure because the buffer pool is already allocated inside MySQL. CPU, memory, lock, and I/O profilers can expose symptoms, but the causal resource abstraction is defined by the application.
+
+The paper studies 45 real performance issues and identifies 38 distinct application-defined resources across databases and search systems. These include memory-like pools, shared state such as logs and indexes, and internal queues. Its analytical model maps 39 of the 45 cases to recurring resource pathologies. The important point is not the exact taxonomy. It is that application logic creates performance-relevant capacity and ownership rules that do not necessarily correspond to a kernel object.
+
+[gigiprofiler](https://homes.cs.washington.edu/~baris/public/gigiprofiler.pdf) attacks this gap with a hybrid pipeline. An LLM proposes candidate resources and resource-use sites from names, comments, documentation, and surrounding code. Static analysis validates candidates against control and data flow. The runtime then instruments four kinds of interactions, `WAIT`, `ACQUIRE`, `USE`, and `RELEASE`, and correlates them with requests.
+
+That combination matters because neither semantic inference nor program analysis is sufficient by itself. In the paper's MySQL study, LLM-only candidate identification has false-positive rates between 45% and 60% across the tested models. Static validation reduces false positives, and runtime validation reduces them further. Even after the full discovery pipeline, an exhaustive buffer-pool study finds that the tested models miss about 23% of resource-use events on average. The system still diagnoses all 15 reproduced issues in its evaluation and finds two additional MariaDB bugs confirmed by developers, which shows that an incomplete resource map can still be useful when downstream analysis is robust to missing events.
+
+This is a strong result, but it also exposes the next systems question. A discovered event site is not yet a durable semantic contract.
+
+## A resource event is not yet a resource model
+
+Consider a profiler that has correctly identified these calls:
+
+```text
+get_page(pool, key)
+release_page(pool, page)
+evict(pool)
+```
+
+Several facts remain ambiguous.
+
+First, **identity**. Is `pool` a singleton, a per-tenant pool, a sharded pool, or a wrapper whose backing object can change? Is `page` itself the resource, or one unit borrowed from `pool`?
+
+Second, **lifetime**. If an address is freed and reused, the same pointer can name two different logical resources over a long-running profile. A profiler that treats raw addresses as permanent identities can create false joins.
+
+Third, **units and capacity**. `ACQUIRE(pool, 1)` only means something if one unit has a stable interpretation. A buffer page, token slot, connection, queue credit, and cache byte are different accounting units. Some resources have a hard capacity; others grow until a policy threshold triggers cleanup.
+
+Fourth, **state transitions**. A call named `get` may acquire capacity, look up existing state, or merely return a borrowed reference. A `release` may make capacity immediately reusable or only enqueue deferred reclamation. Function names are evidence, not semantics.
+
+Finally, **version**. An application upgrade can inline a wrapper, change an allocator, split one pool into shards, rename an event, or alter the meaning of a counter without changing the high-level feature. The profiler needs a way to detect when yesterday's resource model is no longer valid for today's binary.
+
+These details determine whether an apparent bottleneck is real. If the profiler joins two generations of an object, counts borrowed references as ownership, or assumes the wrong capacity unit, a convincing resource flamegraph can be semantically wrong.
+
+## Linux already offers several ways to expose evidence
+
+A resource contract does not require one instrumentation mechanism.
+
+Linux [`user_events`](https://docs.kernel.org/6.18/trace/user_events.html) lets a process register typed trace events that existing tracing tools such as ftrace and perf can consume. The application can also observe whether a tool has enabled an event and avoid emitting data when nobody is listening. Current Linux documentation includes a multi-format registration mode so different payload formats for the same logical event name can coexist. That solves an important transport and schema-evolution problem.
+
+But a trace-event schema still does not say that `pool_id` is unique only until a pool is destroyed, or that `units` means pages rather than bytes. Those are semantic properties above the event format.
+
+Linux [uprobes](https://docs.kernel.org/6.18/trace/uprobetracer.html) provide the opposite trade-off. A profiler can attach to existing user-space code without modifying the application, fetch arguments or return values, and count probe hits. This is useful for retrofitting observability. The attachment point is still a code location in a particular executable or library, and the tracer needs to understand which value at that location represents the logical resource.
+
+Static user-space trace markers and compiler-inserted probes provide more stable semantic intent because application developers can name events deliberately. gigiprofiler shows another path: infer events automatically and inject instrumentation with an LLVM pass. These approaches are complementary. The missing layer is a representation that lets a profiler compare and combine their semantic claims.
+
+## The profiler should carry a versioned resource semantics contract
+
+A compact contract can make the assumptions explicit without requiring every application to adopt a large tracing framework. Conceptually, one resource class might expose:
+
+```text
+ResourceClass {
+    name: "buffer_pool"
+    schema_version: 3
+    build_identity: <binary or module identity>
+    instance_key: <expression or declared field>
+    generation_rule: <creation/destruction boundary>
+    unit: "page"
+    capacity: <fixed, dynamic, or unknown>
+    events: {
+        acquire: ...
+        use: ...
+        wait: ...
+        release: ...
+    }
+    scope: <process, tenant, shard, request, ...>
+    evidence: <declared, statically-validated, inferred>
+}
+```
+
+This is not intended as a universal ontology for all software resources. It is a minimum contract for answering profiling questions safely: which instance did an event affect, how long is that identity valid, what quantity changed, and how confident are we that the mapping still applies?
+
+The profiler can build the contract from three sources.
+
+1. **Declared semantics.** An application or library can publish a small descriptor next to `user_events`, USDT-style probes, or another stable instrumentation API.
+2. **Inferred semantics.** Source or binary analysis can propose resource classes and event mappings when no descriptor exists.
+3. **Observed invariants.** Runtime evidence can test whether the declared or inferred model behaves consistently, for example whether object generations overlap, capacity accounting becomes impossible, or expected release paths disappear.
+
+The third source is what keeps the system from treating an old contract as truth forever.
+
+## Where current work is still weak
+
+### Resource discovery is evaluated mostly as event-site accuracy, not semantic identity accuracy
+
+The gigiprofiler evaluation carefully measures false positives and missed resource-use events. That is necessary, but a profiler can find the right function and still assign the wrong logical identity or lifetime to the value observed there.
+
+The missing evidence is an evaluation that separates **event-site correctness** from **resource-instance correctness**. A benchmark should deliberately reuse addresses, shard pools, hand off borrowed references, and change ownership rules between versions. It should measure false joins and split identities in addition to event precision and recall.
+
+This matters in production because a false join can transfer cost from one tenant, request, or generation to another. A resource model that is 95% accurate at finding probe sites can still produce misleading attribution if the remaining semantic mistakes occur at high-fanout resources.
+
+### Explicit trace schemas describe payloads better than lifecycle semantics
+
+`user_events` can register typed fields and even support multiple formats for one event name. Static markers can provide stable named probe points. Neither interface defines a common language for resource generation, capacity units, ownership, borrowing, or delayed reclamation.
+
+The missing capability is not another event transport. It is a small semantic layer that can state those properties and bind them to a particular binary or module version.
+
+A decisive test is cross-tool reuse. If perf, an eBPF-based profiler, and an application-specific debugger cannot consume the same descriptor and agree on resource identities for a workload, the contract has not separated semantics from one profiler implementation.
+
+### Automatic inference lacks a strong stale-model detector
+
+The OSDI 2026 results show why hybrid validation is useful: model-only discovery has high false positives, and later static and dynamic checks remove many of them. The paper also reports missed events when comments are absent or validation rules do not match an access pattern.
+
+Software evolution creates the same problem over time. A resource mapping inferred from version N may silently become incomplete in version N+1. A profiler needs a negative signal that says, "this contract no longer explains the observed execution," rather than continuing with a clean-looking but stale profile.
+
+Useful signals could include impossible capacity balances, unmatched object generations, event distributions moving to previously unseen call sites, or a build identity mismatch. The important property is explicit confidence degradation, not perfect automatic repair.
+
+### There is no shared benchmark for resource semantics across instrumentation strategies
+
+Today it is difficult to compare manual annotations, static markers, compiler instrumentation, automatic inference, uprobes, and hybrid designs on the same ground truth. Each technique pays a different engineering and runtime cost.
+
+A useful benchmark needs resource definitions whose true identity, lifetime, capacity, and ownership are known. It should include source and binary changes that preserve behavior but perturb instrumentation, as well as semantic changes that must invalidate an old descriptor.
+
+Without this benchmark, a low runtime-overhead number says little about the maintenance cost or false-confidence risk of the resource model itself.
+
+## Promising directions with academic and production value
+
+### 1. A portable resource semantics manifest
+
+**Gap.** Existing event formats can carry values, while automatic profilers can infer resource-use sites, but neither produces a small reusable description of resource identity and lifecycle.
+
+**Mechanism.** Define a versioned manifest that names resource classes, instance keys, generation boundaries, units, capacity semantics, ownership scope, and event mappings. Bind the manifest to build IDs or module identities. Let declared descriptors and offline inference produce the same representation, with every field carrying an evidence source and confidence state.
+
+**Delta.** The difference from gigiprofiler is not another resource detector. The detector becomes one producer of a durable artifact that can be reused by multiple profilers and checked across upgrades. The difference from `user_events` is that the manifest describes resource meaning rather than only event payload layout.
+
+**Artifact.** A schema, compiler/runtime adapters for a few representative applications, and readers for perf-style or pprof-style analysis tools.
+
+**Evaluation.** Use databases, web servers, runtimes, and model-serving caches with manual ground truth. Compare manual instrumentation, `user_events` or static markers, gigiprofiler-style inference, and the manifest pipeline. Measure descriptor authoring effort, event precision/recall, resource-instance precision/recall, false joins, attribution error, runtime overhead, and reuse across software versions.
+
+**Academic value.** The general question is whether semantic observability can be expressed as a portable contract independent of one tracing mechanism.
+
+**Production value.** Operators could keep a stable profiling interface for internal pools, queues, caches, and credits while changing the low-level collector.
+
+**Failure condition.** If per-application descriptors require nearly as much maintenance as hand-written diagnostic code, or inferred models remain equally accurate across upgrades without explicit semantics, the manifest adds little value.
+
+### 2. Runtime contract validation with explicit confidence loss
+
+**Gap.** A descriptor can be wrong even when it parses and its probe points still exist.
+
+**Mechanism.** Add lightweight validators that watch semantic invariants rather than only event delivery. Examples include generation uniqueness, acquire/release balance ranges, capacity bounds when known, legal transition ordering, and expected coverage of high-level operations. When evidence contradicts the contract, mark affected resource classes as degraded or unknown instead of silently producing normal attribution.
+
+The validator can use whichever observer is cheapest for the application: declared events, compiler hooks, uprobes, eBPF, or a combination. Expensive checks can activate only after a cheap invariant fails.
+
+**Delta.** Post-profiling validation in gigiprofiler removes candidate false positives from observed workloads. This direction treats validation as a persistent production property and makes stale semantics visible to downstream consumers.
+
+**Artifact.** A validation runtime, a confidence model attached to profile records, and fault-injection tests that mutate resource implementations without updating the descriptor.
+
+**Evaluation.** Measure how quickly the validator detects stale contracts, false alarm rate, percentage of corrupted attribution prevented, overhead, and recovery after a descriptor update. Include versions that only rename functions, versions that reorganize code without changing semantics, and versions that truly change ownership or lifecycle semantics.
+
+**Academic value.** This asks how an observability system can know when its own semantic model has stopped being trustworthy.
+
+**Production value.** A stale profiler integration becomes an explicit health problem instead of a hidden source of bad performance conclusions.
+
+**Failure condition.** If invariant checks either miss most semantic drift or alarm on ordinary workload changes, they are not useful as a trust signal.
+
+### 3. A ground-truth benchmark for application-resource profiling
+
+**Gap.** Current profiler evaluations usually know the root cause of selected bugs, but not every resource identity and transition throughout execution.
+
+**Mechanism.** Build a benchmark harness where resource truth is generated alongside the workload. Include fixed pools, elastic caches, bounded queues, reusable object slots, borrowed references, deferred reclamation, sharded ownership, and cross-request interference. Then create controlled transformations such as inlining, wrapper insertion, allocator changes, object-address reuse, and schema-version changes.
+
+**Delta.** The benchmark would test the semantic layer that ordinary CPU-profile and bug-reproduction suites omit. It would also distinguish a detector that finds useful hot sites from one that reconstructs correct resource lifecycles.
+
+**Artifact.** Open workloads, truth traces, mutation/version pairs, and a scoring harness for event and resource semantics.
+
+**Evaluation.** Compare system-only profiling, manual annotations, static user events, dynamic uprobes, automatic inference, and hybrid approaches under the same overhead budget. Report event-site accuracy, identity/lifetime accuracy, root-cause ranking, attribution error, false confidence, maintenance effort, and runtime cost.
+
+**Academic value.** It provides a reproducible measurement problem for semantic observability rather than another collection of profiler anecdotes.
+
+**Production value.** Tool builders can tell whether a new collector or inference model preserves resource meaning before deploying it on production binaries.
+
+**Failure condition.** If performance diagnoses remain correct even when identity and lifecycle reconstruction is deliberately degraded, then the extra semantic machinery is solving a problem that does not materially affect the target decisions.
+
+## What would change this conclusion?
+
+This argument assumes that application-defined resources matter often enough, and evolve often enough, that stale semantic mappings are a practical source of profiling error. The OSDI 2026 evidence establishes that hidden application resources can cause serious real performance problems and that automated discovery can diagnose them. It does not establish that every production profiler needs a persistent resource contract.
+
+A simpler design should win if automatic inference remains accurate across substantial software evolution, if applications already expose stable resource events with sufficient lifecycle semantics, or if operators only need one-off diagnosis against a fixed source revision. In those cases, a versioned manifest and online validator would add maintenance cost without changing the decision.
+
+The strongest experiment is therefore longitudinal. Take several evolving applications, freeze profiler knowledge at version N, and measure how quickly attribution and diagnosis degrade across later commits. Compare no adaptation, rediscovery from scratch, explicit descriptors, and descriptor-plus-validation. If stale models rarely create wrong decisions, the contract is unnecessary. If they do, the profiler should treat semantic model health as part of observability itself.
+
+## References
+
+- Yigong Hu et al., [*Diagnosing Performance Issues in Application-Defined Resources*](https://homes.cs.washington.edu/~baris/public/gigiprofiler.pdf), OSDI 2026.
+- Linux kernel documentation, [`user_events`: User-based Event Tracing](https://docs.kernel.org/6.18/trace/user_events.html).
+- Linux kernel documentation, [Uprobe-based Event Tracing](https://docs.kernel.org/6.18/trace/uprobetracer.html).
+- SystemTap documentation, [Static user-space probe points](https://sourceware.org/systemtap/langrefse4.html#x33-330004.5.7).
+- Eunomia Daily Report, [What Must an eBPF Profiler Track Beyond Threads?](https://eunomia.dev/research/async-ebpf-causal-profiler/).
+- Eunomia Daily Report, [When Does Profiler Sampling Become Biased?](https://eunomia.dev/research/profiler-sampling-bias/).

--- a/docs/research/application-defined-resource-profiling.zh.md
+++ b/docs/research/application-defined-resource-profiling.zh.md
@@ -1,0 +1,221 @@
+---
+date: 2026-08-20
+title: "性能分析器应该如何发现应用自定义资源？"
+description: "应用内部的 buffer pool、cache 和 queue 可能不会表现为系统资源压力。本文分析 profiler 如何发现这些资源的语义，并在软件升级后识别过期的资源模型。"
+tags:
+  - Daily Report
+  - Profiling
+  - Observability
+  - Performance
+  - Linux
+research_question: "Profiler 如何发现 application-defined resource 的身份、生命周期、容量与使用语义，在运行时验证这些语义，并在推断或声明的资源模型过期时明确发现它？"
+source_cutoff: 2026-08-20
+status: daily-report
+---
+
+# 性能分析器应该如何发现应用自定义资源？
+
+假设一个数据库的吞吐突然下降，但 CPU 利用率、常驻内存和锁竞争都没有明显异常。真正的问题可能是某个请求把内部 buffer pool 填满了临时数据，后续请求不得不反复淘汰页面并重新读取磁盘。操作系统看到的仍然只是数据库很早以前就分配好的那块内存，因此普通系统指标可以完全正常。
+
+这里真正影响性能的资源不是内核里的 page allocator 或某把锁，而是应用自己定义的 buffer pool。它的容量、所有权、淘汰策略和生命周期都存在于应用逻辑里。
+
+这就是 **application-defined resource profiling** 面临的可见性缺口。近期研究已经证明，Profiler 可以从源码语义、静态分析和运行时行为里恢复大量隐藏的资源结构。下一步更难的问题不是再多找到几个函数，而是保证恢复出来的资源模型在软件持续变化以后仍然正确。Profiler 需要知道一个资源实例怎样标识、这个标识什么时候会被复用、获取和释放的单位是什么、哪些操作代表压力，以及当前模型是否仍然匹配正在运行的 binary。
+
+<!-- more -->
+
+因此，更值得做的系统机制是一个**带版本的资源语义契约**。应用可以显式声明其中一部分，离线分析可以补全缺失部分，运行时观测再负责验证。如果真实行为和契约开始不一致，Profiler 应该降低置信度，而不是继续输出一张看起来很完整的错误 profile。
+
+Linux `user_events`、静态 trace marker、uprobe、编译器插桩和 eBPF 都可以提供证据，但它们本身都没有定义“这个应用资源到底是什么”。所以这篇报告讨论的是通用 profiling 问题，而不是把某一种采集机制包装成答案。
+
+这和之前的[异步 eBPF causal profiler](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)问题相邻，但边界不同。那篇报告问的是：逻辑工作离开原线程以后，怎样把不同 execution context 重新接起来。这里的问题更早一步：**Profiler 最开始怎样获得一个可信的应用资源身份和生命周期？**
+
+## 为什么系统指标可以完全正确，却仍然看不到瓶颈
+
+OSDI 2026 论文 *Diagnosing Performance Issues in Application-Defined Resources* 给出了一个很具体的 MySQL 例子。临时表页面可以占满 InnoDB buffer pool，后续请求随后承担昂贵的页面淘汰和重新读取成本。由于 buffer pool 本来就是 MySQL 预先分配并自行管理的内存，操作系统未必会看到 memory pressure。CPU、memory、lock 和 I/O profiler 可以看到症状，却不知道真正需要分析的资源抽象是什么。
+
+论文分析了 45 个真实性能问题，在数据库和搜索系统中识别出 38 种不同的应用自定义资源，包括类似内存池的资源、日志和索引等共享状态，以及内部任务队列。论文提出的分析模型能够覆盖其中 39 个案例。这里更重要的不是具体分类，而是一个事实：**应用逻辑会创造自己的容量和所有权规则，而这些规则不一定对应任何内核对象。**
+
+[gigiprofiler](https://homes.cs.washington.edu/~baris/public/gigiprofiler.pdf) 使用一条混合流水线来恢复这些语义。LLM 根据名字、注释、文档和周围代码提出候选资源和使用位置；静态分析再根据 control flow 与 data flow 验证这些候选；运行时随后插桩四类交互：`WAIT`、`ACQUIRE`、`USE` 和 `RELEASE`，并把它们与请求关联起来。
+
+这几层验证很重要，因为纯语义推断和纯程序分析都不够可靠。在论文的 MySQL 实验里，只使用 LLM 时，不同模型产生的 false positive rate 在 45% 到 60% 之间。静态验证会继续减少 false positive，运行时验证还能进一步过滤候选。另一方面，对 MySQL buffer pool 的穷举分析显示，不同模型平均仍会漏掉约 23% 的 resource-use event。
+
+尽管资源图并不完整，gigiprofiler 仍然成功诊断了实验中复现的 15 个问题，并另外发现了两个后来得到开发者确认的 MariaDB 问题。这说明一件很有意思的事：**资源发现不需要完美才能有诊断价值，但“能诊断”不等于“资源语义已经稳定”。**
+
+## 找到一个 event site，还没有得到一个资源模型
+
+假设 Profiler 已经正确找到下面几个调用点：
+
+```text
+get_page(pool, key)
+release_page(pool, page)
+evict(pool)
+```
+
+仍然有几类关键语义没有确定。
+
+第一是**身份**。`pool` 是整个进程唯一的对象、每个 tenant 一个、每个 shard 一个，还是一个可能切换 backing object 的 wrapper？`page` 本身是独立资源，还是从 `pool` 借出的一份容量？
+
+第二是**生命周期**。一个地址释放后可能再次被 allocator 使用。长时间运行的 Profiler 如果把 pointer 当作永久唯一 ID，就可能把两个完全不同的资源实例拼到一起。
+
+第三是**单位和容量**。`ACQUIRE(pool, 1)` 只有在“1”有稳定含义时才有价值。一个 buffer page、一个 connection、一个 queue credit、一个 token slot 和一个 byte 代表的容量完全不同。有些资源存在硬上限，有些资源会持续增长，直到某个策略阈值触发回收。
+
+第四是**状态变化**。名字叫 `get` 的函数可能是在真正占用容量，也可能只是查询已有对象，或者返回一个 borrowed reference。`release` 也未必意味着容量马上可以再次使用，它可能只是把对象放进延迟回收队列。函数名只能提供线索，不能直接等同于语义。
+
+最后是**版本**。软件升级以后，一个 wrapper 可能被 inline，一个 pool 可能被拆成多个 shard，allocator 可能更换，counter 的意义也可能改变。高层功能看起来没有变化，但昨天生成的 resource model 已经不一定适用于今天的 binary。
+
+这些错误会直接污染 attribution。只要 Profiler 错误地连接了两个 object generation，或者把借用引用当作资源所有权，一张视觉上很合理的 resource flamegraph 也可能在语义上完全错误。
+
+## Linux 已经提供了多种证据入口
+
+资源语义契约不需要绑定一种插桩技术。
+
+Linux 的 [`user_events`](https://docs.kernel.org/6.18/trace/user_events.html) 允许用户进程注册带类型的 trace event，再交给 ftrace、perf 等现有工具消费。应用还可以知道当前 event 有没有被启用，没有消费者时就不必发送数据。当前 Linux 文档还定义了 multi-format registration，同一个逻辑 event name 可以同时存在多个 payload format。这已经解决了一个很重要的传输和 schema 演进问题。
+
+但是一个 event schema 仍然不会告诉 Profiler：`pool_id` 只在资源销毁前唯一，或者 `units` 表示 page 而不是 byte。这里缺失的是比 payload 格式更高一层的资源语义。
+
+Linux [uprobe](https://docs.kernel.org/6.18/trace/uprobetracer.html) 提供了另一种取舍。Profiler 无需修改应用，就可以在现有用户态代码位置插入 probe，读取参数或返回值，也可以统计命中次数。这很适合给已有 binary 补 observability。问题是 attach point 仍然只是某个 executable 或 library 中的代码位置，Tracer 还需要知道哪个值才代表真正的逻辑资源。
+
+静态用户态 marker 和编译器插桩则能表达更稳定的开发者意图。gigiprofiler 走的是另一条路：自动推断 event，再通过 LLVM pass 插入探针。这些方式并不冲突。真正缺的是一个中间表示，让不同 Profiler 可以比较、复用并验证它们对资源语义的判断。
+
+## Profiler 应该携带一个带版本的资源语义契约
+
+这个契约不需要成为庞大的通用 ontology。它只要把 profiling 真正依赖的假设写清楚：一个 event 影响哪个资源实例，这个身份在多长时间内有效，变化了多少资源量，以及当前映射有多可信。
+
+概念上，一个资源类别可以表示成：
+
+```text
+ResourceClass {
+    name: "buffer_pool"
+    schema_version: 3
+    build_identity: <binary or module identity>
+    instance_key: <expression or declared field>
+    generation_rule: <creation/destruction boundary>
+    unit: "page"
+    capacity: <fixed, dynamic, or unknown>
+    events: {
+        acquire: ...
+        use: ...
+        wait: ...
+        release: ...
+    }
+    scope: <process, tenant, shard, request, ...>
+    evidence: <declared, statically-validated, inferred>
+}
+```
+
+契约可以来自三种证据。
+
+1. **显式声明。** 应用或 library 在 `user_events`、USDT 风格 marker 或其他稳定 instrumentation API 旁边给出一个很小的 descriptor。
+2. **自动推断。** 当没有 descriptor 时，源码或 binary 分析生成候选资源类别和 event mapping。
+3. **运行时不变量。** Profiler 检查真实执行是否继续符合这些语义，例如 generation 是否发生重叠、容量账本是否变得不可能成立、原本应该存在的 release 路径是否消失。
+
+第三类证据决定了这个系统能不能长期工作。没有运行时验证，自动生成的契约很容易变成另一种过期配置文件。
+
+## 现有研究还缺什么
+
+### 资源发现主要测 event site 对不对，却很少单独测资源身份对不对
+
+gigiprofiler 对 false positive 和漏掉的 resource-use event 做了很细的评估，这是必要的。但 Profiler 即使找到了正确函数，也可能把函数参数解释成错误的逻辑 identity，或者不知道这个 identity 在什么时候失效。
+
+缺少的实验是把 **event-site correctness** 和 **resource-instance correctness** 分开测。Benchmark 应该故意复用地址、把 pool 做成 shard、传递 borrowed reference，并在不同版本之间修改 ownership rule。除了 event precision/recall，还要测 false join 和 identity split。
+
+生产环境里，这类错误尤其危险，因为一次 false join 可能把一个 tenant、request 或 generation 的成本归到另一个对象上。即使绝大多数 probe site 都找对了，高 fan-out 资源上的少量语义错误也可能让最终判断失真。
+
+### 显式 trace schema 能描述 payload，却没有统一描述生命周期
+
+`user_events` 可以定义字段类型，也能让同名 event 的多个格式共存；静态 marker 也可以提供稳定的命名位置。但这些接口都没有一个公共语言来表示 generation、容量单位、所有权、借用和延迟回收。
+
+缺少的不是新的 event transport，而是一层很小的 semantic descriptor，并且这个 descriptor 必须绑定到具体 build 或 module version。
+
+一个直接的验证标准是跨工具复用：如果 perf、一个 eBPF Profiler 和应用专用 debugger 读取同一个 descriptor 后仍无法对资源 identity 达成一致，那么语义还没有真正从某个 Profiler 实现中独立出来。
+
+### 自动推断缺少足够强的“模型已经过期”信号
+
+OSDI 2026 的结果已经说明为什么需要多层验证。纯 LLM discovery 的 false positive 很高，静态和运行时分析可以继续过滤；论文也观察到注释缺失或 validation rule 不匹配时会漏掉真正的 event。
+
+软件演进会把同一个问题放大。版本 N 推断出的 mapping 在版本 N+1 可能只是部分失效。如果 Profiler 没有明确的负面信号，它就会继续生成很干净的 profile，却不知道自己的资源模型已经过期。
+
+可以检查的信号包括不可能成立的容量平衡、重叠的 object generation、event 大量迁移到从未见过的 call site，或者 binary build identity 变化。这里最重要的性质不是自动修复一切，而是**明确降低置信度**。
+
+### 不同插桩策略之间缺少统一的资源语义 benchmark
+
+手写 annotation、静态 marker、编译器插桩、自动推断、uprobe 和混合方案付出的工程成本与运行时成本不同，目前很难在一套 ground truth 上公平比较。
+
+需要一个 benchmark 明确知道每个资源的 identity、lifetime、capacity 和 ownership，并提供两类软件变化：一种只改变实现形状，不改变资源语义；另一种真正改变语义，必须让旧 descriptor 失效。
+
+没有这套 benchmark，仅仅报告低 runtime overhead 并不能回答维护成本和 false confidence 风险。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 可移植的资源语义 manifest
+
+**缺口。** Event format 可以携带值，自动 Profiler 也能找到 resource-use site，但两者都没有产生一个小而可复用的资源身份和生命周期描述。
+
+**机制。** 定义一个带版本的 manifest，描述 resource class、instance key、generation boundary、计量单位、capacity semantics、ownership scope 和 event mapping，并绑定 binary build ID 或 module identity。显式 descriptor 和自动推断都输出同一种结构，每个字段同时标记证据来源和置信状态。
+
+**与现有工作的差别。** 相比 gigiprofiler，重点不是再实现一个 detector，而是把 detector 的结果变成其他工具可以复用、并能跨升级检查的 durable artifact。相比 `user_events`，manifest 说明的是资源含义，而不是 event payload 的字节布局。
+
+**产物。** 一个开放 schema，为若干代表性应用实现 compiler/runtime adapter，再给 perf 或 pprof 风格工具实现 reader。
+
+**评测。** 选择数据库、Web server、runtime 和 model-serving cache，并人工建立 ground truth。比较手工插桩、`user_events` 或静态 marker、gigiprofiler 风格推断，以及 manifest pipeline。指标包括 descriptor 编写成本、event precision/recall、resource-instance precision/recall、false join、attribution error、runtime overhead 和跨版本复用率。
+
+**学术价值。** 核心问题是 semantic observability 能否成为独立于某一种 tracing mechanism 的可移植契约。
+
+**生产价值。** 运维团队可以稳定地分析内部 pool、queue、cache 和 credit，同时自由替换底层 collector。
+
+**失败条件。** 如果每个应用维护 descriptor 的成本接近手写诊断逻辑，或者纯自动推断在版本升级后仍然同样准确，那么 manifest 没有带来足够收益。
+
+### 2. 运行时验证契约，并允许置信度显式下降
+
+**缺口。** Descriptor 即使语法合法、probe point 仍然存在，也可能已经表达错误的语义。
+
+**机制。** 运行轻量 validator，检查 semantic invariant 而不只检查 event 有没有送到。可以验证 generation 是否唯一、acquire/release 的平衡范围、已知 capacity 的边界、合法状态顺序，以及高层操作是否覆盖预期 event。当证据和契约冲突时，把对应 resource class 标记成 degraded 或 unknown，而不是继续输出普通 attribution。
+
+具体 observer 可以按应用选择：显式 event、compiler hook、uprobe、eBPF 或组合都可以。昂贵检查只在低成本 invariant 失败后再开启。
+
+**与现有工作的差别。** gigiprofiler 的 post-profiling validation 会根据运行时 workload 过滤候选 false positive。这里把 validation 变成持续的生产属性，并且把“语义可能过期”传递给下游消费者。
+
+**产物。** 一个 validation runtime、写进 profile record 的 confidence model，以及一套在不更新 descriptor 的情况下修改资源实现的 fault-injection tests。
+
+**评测。** 测量 stale contract 的发现延迟、false alarm、阻止了多少错误 attribution、运行时开销以及 descriptor 更新后的恢复速度。测试既包括只改函数名或代码结构、语义不变的版本，也包括真正改变 ownership 或 lifecycle 的版本。
+
+**学术价值。** 这是一个可观测性系统怎样判断“自己的语义模型已经不可信”的问题。
+
+**生产价值。** 过期的 Profiler 集成会变成显式健康问题，而不是悄悄制造错误性能结论。
+
+**失败条件。** 如果 invariant 检查既抓不到大部分语义漂移，又经常把正常 workload 变化误报成错误，那么它不能作为可信度信号。
+
+### 3. 面向 application-resource profiling 的 ground-truth benchmark
+
+**缺口。** 现有 Profiler 评测通常知道选定 bug 的 root cause，却不知道整个执行过程中每个资源实例和状态变化的完整真值。
+
+**机制。** 构建一个 workload harness，在运行 workload 的同时生成资源 ground truth。覆盖固定 pool、弹性 cache、有界 queue、可复用 object slot、borrowed reference、延迟回收、sharded ownership 和跨请求干扰。再加入受控的软件变换，例如 inline、增加 wrapper、更换 allocator、复用 object address 和改变 schema version。
+
+**与现有工作的差别。** 这套 benchmark 测的是普通 CPU profile 和 bug reproduction suite 没有覆盖的 semantic layer。它还能区分“找到几个有用 hot site”和“正确重建资源生命周期”这两个能力。
+
+**产物。** 开放 workload、truth trace、成对的软件 mutation/version，以及针对 event 与 resource semantics 的评分工具。
+
+**评测。** 在相同 overhead budget 下比较纯系统 profiling、手写 annotation、静态 user event、动态 uprobe、自动推断和混合方案。报告 event-site accuracy、identity/lifetime accuracy、root-cause ranking、attribution error、false confidence、维护成本和运行时开销。
+
+**学术价值。** 它把 semantic observability 变成一个可复现的 measurement problem，而不是继续积累不同 Profiler 的案例。
+
+**生产价值。** 工具开发者可以在把新 collector 或 inference model 放进生产环境前，先验证它是否保持了资源语义。
+
+**失败条件。** 如果即使主动破坏 identity 和 lifecycle reconstruction，最终性能诊断仍然几乎不受影响，那么额外的语义机制并没有改变目标决策。
+
+## 哪些结果会改变这个判断？
+
+这里的判断建立在两个假设上：应用自定义资源足够经常地影响真实性能，而且软件演进足够快，使过期的语义 mapping 成为实际问题。OSDI 2026 的证据已经说明隐藏资源可以导致严重性能问题，也说明自动发现能够诊断这些问题，但它没有证明每个生产 Profiler 都需要长期维护一个 resource contract。
+
+如果自动推断可以跨大幅软件升级仍然保持稳定准确，或者应用已经通过现有 trace event 暴露了足够完整的生命周期语义，又或者运维只需要针对固定源码版本做一次性诊断，那么更简单的方案应该胜出。此时再加 manifest 和在线 validator 只会增加维护成本。
+
+最有区分力的实验应该是 longitudinal study：选择几个持续演进的大型应用，把 Profiler 知识冻结在版本 N，然后测后续 commit 中 attribution 与 diagnosis 的准确度怎样下降。比较完全不适配、每次重新 discovery、显式 descriptor，以及 descriptor 加运行时验证四种策略。如果 stale model 很少导致错误决策，这层契约没有必要；如果错误会快速积累，那么 Profiler 就应该把“语义模型本身是否健康”也纳入 observability。
+
+## 参考资料
+
+- Yigong Hu 等，[*Diagnosing Performance Issues in Application-Defined Resources*](https://homes.cs.washington.edu/~baris/public/gigiprofiler.pdf)，OSDI 2026。
+- Linux kernel documentation，[`user_events`: User-based Event Tracing](https://docs.kernel.org/6.18/trace/user_events.html)。
+- Linux kernel documentation，[Uprobe-based Event Tracing](https://docs.kernel.org/6.18/trace/uprobetracer.html)。
+- SystemTap documentation，[Static user-space probe points](https://sourceware.org/systemtap/langrefse4.html#x33-330004.5.7)。
+- Eunomia 每日报告，[异步系统里，eBPF Profiler 还要追踪什么？](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)。
+- Eunomia 每日报告，[性能分析器的采样什么时候会产生偏差？](https://eunomia.dev/zh/research/profiler-sampling-bias/)。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [How Should a Profiler Discover Application-Defined Resources?](https://eunomia.dev/research/application-defined-resource-profiling/)
+
+Application-defined resources such as buffer pools, caches, and internal queues can dominate performance while remaining invisible to system resource metrics. This report develops a versioned resource-semantics manifest, runtime validation with explicit confidence loss, and a ground-truth benchmark for comparing declared, inferred, and dynamically observed resource models.
+
 ### [When Does Profiler Sampling Become Biased?](https://eunomia.dev/research/profiler-sampling-bias/)
 
 Sampling percentages can be systematically wrong when a sampler phase-locks with periodic work, skids past the event that caused a sample, or repeatedly misses short-lived code. This report develops an explicit sampling-schedule contract with aliasing diagnostics, replicated profile epochs with rank uncertainty, and uncertainty-triggered selective instrumentation under a fixed overhead budget.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [性能分析器应该如何发现应用自定义资源？](https://eunomia.dev/zh/research/application-defined-resource-profiling/)
+
+应用内部的 buffer pool、cache 和 queue 可能主导性能，却不会直接表现成系统资源压力。本文提出带版本的资源语义 manifest、能够显式降低置信度的运行时验证机制，以及统一比较显式声明、自动推断和动态观测资源模型的 ground-truth benchmark。
+
 ### [性能分析器的采样什么时候会产生偏差？](https://eunomia.dev/zh/research/profiler-sampling-bias/)
 
 当 sampler 与周期 workload 相位锁定、hardware sample 出现 skid，或者短函数持续被漏采时，profile 百分比可能系统性出错。本文提出带 aliasing 诊断的 sampling-schedule contract、用独立 profile epoch 表达 rank uncertainty，以及在固定 overhead budget 下由 uncertainty 触发 selective instrumentation。


### PR DESCRIPTION
## Summary

- publish one new bilingual Daily Report on application-defined resource profiling
- keep the report collector-neutral and classify it as adjacent systems so the rolling 10-report mix remains compliant
- update EN/ZH Daily Report indexes and operating state
- refresh Google-data freshness and current public-safe site/GitHub signals
- make no unrelated technical SEO change because current evidence does not establish a site defect

## Research

The report builds on the OSDI 2026 application-defined-resource profiler and current Linux `user_events`/uprobe interfaces. It develops a versioned resource-semantics manifest, runtime stale-model validation with explicit confidence loss, and a ground-truth benchmark across instrumentation strategies.

## Data limits

GSC remains finalized through 2026-08-15 with the 2026-08-09 row absent, so complete 7-day and 28-day comparisons remain unavailable. GA4 weekly data through 2026-08-16 is finalized. Cloudflare remains disabled and is not interpreted as zero.

## Validation

Authoritative repository CI and final generated-output review are required before squash merge. Exact squash-commit production deployment plus bilingual public verification will be completed before closeout.