### PR TITLE
Daily: define eBPF semantics for application resources

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,7 +1,8 @@
 # Human-only blockers
 
-Only unresolved external conditions belong here. The daily ChatGPT scheduler is
-already configured and enabled; it is not a blocker.
+Only unresolved external conditions belong here. The daily operations schedule is
+configured, enabled, and recurring; it is not a blocker and is not paused when a
+run encounters another blocker.
 
 ## Cloudflare analytics is not configured
 
@@ -20,7 +21,7 @@ already configured and enabled; it is not a blocker.
 Google Drive access is verified and is not a blocker. The configured folder
 contains adjacent weekly export sets beginning `2026-07-27`, `2026-08-03`, and
 `2026-08-10`; no newer weekly set beginning `2026-08-17` was observed on
-`2026-08-20`. The newest verified Search Console date rows remain through
+`2026-08-21`. The newest verified Search Console date rows remain through
 `2026-08-15`, which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
@@ -31,17 +32,16 @@ The 28-day comparison also remains unavailable because the verified export
 history is not long enough.
 
 GA4 landing-page files are weekly aggregates without a date dimension. The
-complete `2026-08-10` through `2026-08-16` aggregate remains outside the
-configured three-day finalization lag and is usable as a finalized source-native
-weekly comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4
-set was observed on `2026-08-20`. The landing-page exports still do not provide
-complete acquisition, conversion, or outbound behavior coverage by themselves.
+complete `2026-08-10` through `2026-08-16` aggregate is outside the configured
+three-day finalization lag and is usable as a finalized source-native weekly
+comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4 set
+was observed on `2026-08-21`. The landing-page exports do not provide complete
+acquisition, conversion, or outbound behavior coverage by themselves.
 
-These constraints never justify skipping the daily operation. Each run must use
-the available Google exports, live-site evidence, public GitHub evidence, and
-public primary-source evidence; missing coverage must never be converted into
-zero. Every run must still publish one new Daily Report under the current
-repository contract.
+These constraints never justify skipping the daily operation or stopping its
+recurring schedule. Each run uses the available Google exports, live-site
+evidence, public GitHub evidence, and public primary-source evidence; missing
+coverage is never converted into zero.
 
 Remove or narrow a blocker in the next daily pull request after the external
 condition is verified as resolved.

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,8 +1,7 @@
 # Human-only blockers
 
-Only unresolved external conditions belong here. The daily operations schedule is
-configured, enabled, and recurring; it is not a blocker and is not paused when a
-run encounters another blocker.
+Only unresolved external conditions belong here. The daily ChatGPT scheduler is
+already configured and enabled; it is not a blocker.
 
 ## Cloudflare analytics is not configured
 
@@ -38,10 +37,11 @@ comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4 set
 was observed on `2026-08-21`. The landing-page exports do not provide complete
 acquisition, conversion, or outbound behavior coverage by themselves.
 
-These constraints never justify skipping the daily operation or stopping its
-recurring schedule. Each run uses the available Google exports, live-site
-evidence, public GitHub evidence, and public primary-source evidence; missing
-coverage is never converted into zero.
+These constraints never justify skipping the daily operation. Each run must use
+the available Google exports, live-site evidence, public GitHub evidence, and
+public primary-source evidence; missing coverage must never be converted into
+zero. Every run must still publish one new Daily Report under the current
+repository contract.
 
 Remove or narrow a blocker in the next daily pull request after the external
 condition is verified as resolved.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -37,9 +37,16 @@ that candidate and continue research on another question in the approved roadmap
 until one passes. Prefer changing the question over padding weak evidence or
 inventing novelty.
 
-A daily report must still provide a concrete reader problem, primary-source
-evidence, a non-trivial gap, a reasoned conclusion, a small number of implementable
-research directions, and a discriminating evaluation or boundary condition.
+A daily report must still provide:
+
+- a concrete reader problem;
+- primary-source evidence;
+- a non-trivial gap or unresolved mechanism;
+- a reasoned technical conclusion;
+- a small number of implementable research directions with academic and
+  production value;
+- a discriminating evaluation or evidence that would change the conclusion;
+- a thesis that does not duplicate an existing report.
 
 ## Series rules
 
@@ -58,11 +65,41 @@ research directions, and a discriminating evaluation or boundary condition.
 - Search Console, GA4, GitHub activity, reader pathways, and technical releases
   can influence ordering inside the roadmap, but short-lived popularity does not
   override the editorial mix or technical quality standard.
+- After a series has at least three strong reports, consider a public series hub
+  and stronger internal linking. Do not create thin hub pages in advance.
 
 ## Active series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
+
+The `2026-08-18` report starts this series with **page-level memory attribution**:
+how to distinguish allocation from pages that were actually touched, faulted,
+reclaimed, migrated, or responsible for sampled memory cost while preserving
+provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
+
+The `2026-08-19` report is a deliberate **adjacent profiling detour** on sampling
+bias. Its central mechanism is general profiler measurement design, not eBPF, so
+it is classified as adjacent systems. It closes the first ten-report window at
+7 eBPF / 2 Agent / 1 adjacent without relabeling an eBPF-essential question.
+
+The first `2026-08-20` report is a second adjacent profiling detour required by
+the rolling-window arithmetic. It asks whether a late CUDA kernel start came from
+host scheduling, runtime/command-buffer work, a dependency, or device
+availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
+host tracing can be an optional evidence source but is not essential, so this
+report is also adjacent systems rather than eBPF-centered.
+
+The second `2026-08-20` report follows the same adjacent-systems boundary from a
+causality angle. It asks how host API work, runtime handoffs, CUDA Graph replay,
+and device execution can retain a trustworthy causal identity. CUPTI/CUDA
+dependency semantics are central while eBPF is one possible host observer.
+
+The `2026-08-21` report returns to an eBPF-essential question: how dynamic probes
+can observe application-defined pools, queues, caches, and credits without
+silently turning stale program semantics into confident diagnoses. It develops a
+versioned semantics manifest, runtime semantic validation, and a mutation
+benchmark for software evolution.
 
 ### Published progress
 
@@ -71,49 +108,54 @@ unanswerable with today's eBPF observability stack?**
    sampled memory cost, then develops a lifetime-aware provenance ledger,
    access-weighted attribution with explicit confidence, and a ground-truth
    benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
-   migration. **Classification: eBPF-centered.**
+   migration.
 2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
-   untrustworthy and develops sampling-schedule diagnostics, independent profile
-   epochs, and uncertainty-triggered selective instrumentation. The mechanism is
-   general profiler design rather than eBPF. **Classification: adjacent systems.**
+   untrustworthy. It compares randomized sampling history, current Linux perf
+   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
+   develops a sampling-schedule contract with aliasing diagnostics, independent
+   profile epochs with uncertainty and rank stability, and uncertainty-triggered
+   selective instrumentation. Because the mechanism applies to profilers in
+   general and does not require eBPF, this report is adjacent systems rather than
+   eBPF-centered.
 3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
    command-buffer queue/submission, dependency readiness, device availability,
-   and kernel execution. CUPTI/CUDA are central; eBPF host tracing is optional.
-   **Classification: adjacent systems.**
-4. `2026-08-20`: `/research/gpu-host-device-causality/` develops generation-scoped
-   host/device causal identity, dependency-aware critical-path reasoning, explicit
-   unknown/loss states, and a ground-truth causality benchmark. CUPTI/CUDA
-   dependency semantics are essential while eBPF is one possible host observer.
-   **Classification: adjacent systems.**
-5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF can
-   dynamically observe application-defined pools, queues, caches, and credits
-   without hard-coding stale semantics. It develops a versioned resource-semantics
-   manifest compiled into eBPF attachments, runtime semantic validation with
-   explicit confidence loss, and a software-mutation benchmark. Dynamic no-rebuild
-   eBPF instrumentation and independent cross-layer validation are central to the
-   mechanism. **Classification: eBPF-centered.**
+   and kernel execution. It develops an explicit launch-state ledger, a
+   cross-domain launch identity that survives host handoffs and graph replay, and
+   a ground-truth launch-delay attribution benchmark. The central question is GPU
+   profiling, so it is adjacent systems.
+4. `2026-08-20`: `/research/gpu-host-device-causality/` develops
+   generation-scoped host/device causal identity, dependency-aware critical-path
+   reasoning, explicit unknown/loss states, and a ground-truth causality benchmark.
+   CUPTI/CUDA dependency semantics are essential while eBPF is one possible host
+   observer, so this report is adjacent systems.
+5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF
+   can dynamically observe application-defined resources without hard-coding
+   stale semantics. It develops a versioned resource-semantics manifest compiled
+   into eBPF attachments, runtime semantic validation with explicit confidence
+   loss, and a software-mutation benchmark. Dynamic no-rebuild instrumentation
+   and independent cross-layer validation are central, so this report is
+   eBPF-centered.
 
-Before the August 21 publication, the newest ten already contained **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems** because the August 20
-host-device causality report had landed after the earlier operating-state update.
-Publishing the August 21 eBPF-centered report ages the oldest eBPF report out of
-the rolling ten, so the newest ten remain **7 eBPF / 0 pure Agent / 3 adjacent**.
-The publication therefore remains within the required 5–7 eBPF ceiling without
-reclassification.
+Before the August 21 publication, the actually published newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems** because the second August 20
+report landed after earlier operating-state files were written. Publishing the
+August 21 eBPF-centered report ages an eBPF-centered report out of the rolling
+ten, so the window remains **7 eBPF / 0 pure Agent / 3 adjacent** and stays
+within the 5–7 rule.
 
 ### Preferred next questions
 
-The active series remains the default source. The next publication may still be
-eBPF-centered if it materially advances the series, because another eBPF report
-would again age an eBPF report out of the newest ten and keep the count at seven.
-Prefer, in order after fresh novelty review:
+The active eBPF series remains the default topic source. Another eBPF-centered
+report is arithmetically possible because it would again age an eBPF report out
+of the newest ten, but the evidence and novelty gates still decide whether it is
+publishable. Prefer, after fresh review:
 
 1. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
-2. online confidence and adaptive collection for semantic eBPF profilers when
-   trace loss, missing probes, or stale schemas make an explanation uncertain;
-3. GPU host-side and megakernel profiling only when eBPF is genuinely essential
-   to the mechanism rather than an optional evidence source;
+2. online confidence and adaptive collection when trace loss, missing probes, or
+   stale schemas make a semantic eBPF explanation uncertain;
+3. causal profiling for GPU host-side bottlenecks and megakernel execution only
+   where eBPF is genuinely essential to the mechanism;
 4. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
 
@@ -129,26 +171,49 @@ execution placement. It reached the normal six-report series boundary on
 
 ### Published progress
 
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/`
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/`
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/`
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/`
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/`
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/`
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
+   first-class userspace eBPF needs explicit attachment, capability, state,
+   lifetime, and attribution contracts above ISA compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
+   multi-program problem beyond dispatch and ordering to effect visibility,
+   outcome resolution, shared-state ownership, and versioned hook composition.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
+   object-level replacement from application-level upgrade and developed an
+   explicit prepare / migrate / commit / retire generation protocol for programs,
+   links, maps, pinned state, controller recovery, and rollback.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
+   execution from logical-work causality and developed typed, lifetime-aware
+   handoff edges, an edge-versus-context measurement budget, and a ground-truth
+   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
+   application-defined resources.
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
+   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
+   path, then developed a typed capability contract, versioned ring policy
+   generations, explicit provenance, and a comparative control-boundary benchmark.
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
+   backend compatibility from execution placement and developed a target manifest,
+   generation-scoped state ownership, and a ground-truth placement/provenance
+   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
 
 The Daily Report index already exposes the sequence. Report-level acquisition and
 navigation evidence is still too young to justify a dedicated public series hub.
+Revisit that decision only when evidence shows a retrieval benefit.
 
 ## Queued series — eBPF Networking and Security
 
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-Candidate topics include transactional policy updates; multi-tenant policy
-composition; zero-copy programmable I/O across XDP, AF_XDP, io_uring, DPDK, and
-userspace eBPF; information-flow enforcement across process/file/socket/encrypted
-boundaries; richer verifier/runtime interfaces; and portable policy execution
-across kernel, userspace, NIC, and DPU targets.
+Candidate topics:
+
+1. transactional policy updates across programs, maps, links, and control planes;
+2. multi-tenant network-policy composition and conflict resolution;
+3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
+   userspace eBPF;
+4. information-flow enforcement across process, file, socket, and encrypted
+   application boundaries;
+5. verifier and runtime interfaces for richer stateful policies;
+6. portable policy execution between kernel, userspace, NIC, and DPU targets.
 
 ## Queued series — GPU and Heterogeneous Runtime Systems
 
@@ -160,8 +225,12 @@ observability, programmable device-side instrumentation, distributed GPU
 coordination, utilization versus allocatability, host-side scheduling noise, and
 eBPF-like programmable monitors near GPU or DPU execution.
 
-Reports here count toward the eBPF share only when eBPF or an eBPF-like runtime
-is central to the mechanism being evaluated.
+Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
+runtime is central to the mechanism being evaluated.
+
+The two August 20 reports are focused adjacent-systems contributions to this
+roadmap. They do not promote this queued series to active; the active series
+remains eBPF Observability and Profiling.
 
 ## Queued series — Agent Systems (limited)
 
@@ -174,10 +243,14 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-Neither pure-Agent report is currently inside the newest ten after the August 21
-publication. Pure-Agent work remains allowed by the cap but is not required; the
-active eBPF series remains stronger unless fresh evidence establishes a better
-Agent-systems question.
+Neither pure-Agent report remains inside the newest ten after the August 21
+publication. Pure-Agent publication is allowed by the cap but is not required;
+prefer the technically stronger question after applying the evidence, novelty,
+and editorial-mix gates.
+
+Future Agent reports should preferentially connect back to eBPF or systems
+infrastructure, for example OS-level effect tracing, eBPF policy enforcement,
+sandbox escape visibility, syscall/tool causality, or runtime resource control.
 
 ## Choosing the next report
 
@@ -193,5 +266,5 @@ Each daily run should:
 7. record the chosen series, topic classification, rejected candidates when
    useful, and why the report materially advances the roadmap.
 
-A temporary out-of-series detour should be recorded here so the repository, not
-chat history, remains authoritative.
+A temporary out-of-series detour should be recorded in the daily operating record
+and in this file so the repository, not chat history, remains authoritative.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -37,16 +37,9 @@ that candidate and continue research on another question in the approved roadmap
 until one passes. Prefer changing the question over padding weak evidence or
 inventing novelty.
 
-A daily report must still provide:
-
-- a concrete reader problem;
-- primary-source evidence;
-- a non-trivial gap or unresolved mechanism;
-- a reasoned technical conclusion;
-- a small number of implementable research directions with academic and
-  production value;
-- a discriminating evaluation or evidence that would change the conclusion;
-- a thesis that does not duplicate an existing report.
+A daily report must still provide a concrete reader problem, primary-source
+evidence, a non-trivial gap, a reasoned conclusion, a small number of implementable
+research directions, and a discriminating evaluation or boundary condition.
 
 ## Series rules
 
@@ -65,30 +58,11 @@ A daily report must still provide:
 - Search Console, GA4, GitHub activity, reader pathways, and technical releases
   can influence ordering inside the roadmap, but short-lived popularity does not
   override the editorial mix or technical quality standard.
-- After a series has at least three strong reports, consider a public series hub
-  and stronger internal linking. Do not create thin hub pages in advance.
 
 ## Active series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
-
-The `2026-08-18` report starts this series with **page-level memory attribution**:
-how to distinguish allocation from pages that were actually touched, faulted,
-reclaimed, migrated, or responsible for sampled memory cost while preserving
-provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
-
-The `2026-08-19` report is a deliberate **adjacent profiling detour** on sampling
-bias. Its central mechanism is general profiler measurement design, not eBPF, so
-it is classified as adjacent systems. It closes the first ten-report window at
-7 eBPF / 2 Agent / 1 adjacent without relabeling an eBPF-essential question.
-
-The `2026-08-20` report is a second adjacent profiling detour required by the
-rolling-window arithmetic. It asks whether a late CUDA kernel start came from
-host scheduling, runtime/command-buffer work, a dependency, or device
-availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
-host tracing can be an optional evidence source but is not essential, so this
-report is also adjacent systems rather than eBPF-centered.
 
 ### Published progress
 
@@ -97,48 +71,51 @@ report is also adjacent systems rather than eBPF-centered.
    sampled memory cost, then develops a lifetime-aware provenance ledger,
    access-weighted attribution with explicit confidence, and a ground-truth
    benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
-   migration.
+   migration. **Classification: eBPF-centered.**
 2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
-   untrustworthy. It compares randomized sampling history, current Linux perf
-   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
-   develops a sampling-schedule contract with aliasing diagnostics, independent
-   profile epochs with uncertainty and rank stability, and uncertainty-triggered
-   selective instrumentation. Because the mechanism applies to profilers in
-   general and does not require eBPF, this report is adjacent systems rather than
-   eBPF-centered.
+   untrustworthy and develops sampling-schedule diagnostics, independent profile
+   epochs, and uncertainty-triggered selective instrumentation. The mechanism is
+   general profiler design rather than eBPF. **Classification: adjacent systems.**
 3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
    command-buffer queue/submission, dependency readiness, device availability,
-   and kernel execution. It develops an explicit launch-state ledger, a
-   cross-domain launch identity that survives host handoffs and graph replay, and
-   a ground-truth launch-delay attribution benchmark. The central question is GPU
-   profiling, so it is adjacent systems.
+   and kernel execution. CUPTI/CUDA are central; eBPF host tracing is optional.
+   **Classification: adjacent systems.**
+4. `2026-08-20`: `/research/gpu-host-device-causality/` develops generation-scoped
+   host/device causal identity, dependency-aware critical-path reasoning, explicit
+   unknown/loss states, and a ground-truth causality benchmark. CUPTI/CUDA
+   dependency semantics are essential while eBPF is one possible host observer.
+   **Classification: adjacent systems.**
+5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF can
+   dynamically observe application-defined pools, queues, caches, and credits
+   without hard-coding stale semantics. It develops a versioned resource-semantics
+   manifest compiled into eBPF attachments, runtime semantic validation with
+   explicit confidence loss, and a software-mutation benchmark. Dynamic no-rebuild
+   eBPF instrumentation and independent cross-layer validation are central to the
+   mechanism. **Classification: eBPF-centered.**
 
-After the August 20 report, the rolling ten-report window is **7 eBPF-centered /
-1 pure Agent / 2 adjacent systems**. The oldest report still inside that window
-is the remaining pure-Agent parallel-effect report. Therefore the next
-publication must again be non-eBPF: immediately adding an eBPF-centered report
-would create 8 eBPF reports in the rolling ten and violate the 5–7 requirement.
-Once the oldest eBPF reports start aging out, an eBPF-centered report can return
-without exceeding the cap.
+Before the August 21 publication, the newest ten already contained **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems** because the August 20
+host-device causality report had landed after the earlier operating-state update.
+Publishing the August 21 eBPF-centered report ages the oldest eBPF report out of
+the rolling ten, so the newest ten remain **7 eBPF / 0 pure Agent / 3 adjacent**.
+The publication therefore remains within the required 5–7 eBPF ceiling without
+reclassification.
 
 ### Preferred next questions
 
-The active eBPF-series questions remain valuable but are deferred while the
-rolling window is at its eBPF ceiling:
+The active series remains the default source. The next publication may still be
+eBPF-centered if it materially advances the series, because another eBPF report
+would again age an eBPF report out of the newest ten and keep the count at seven.
+Prefer, in order after fresh novelty review:
 
 1. always-on semantic compression that preserves diagnostic evidence instead of
    raw event volume;
-2. application-defined resource profiling that combines static discovery,
-   runtime eBPF evidence, and online validation;
-3. causal profiling for GPU host-side bottlenecks and megakernel execution where
-   eBPF is genuinely essential to the mechanism;
+2. online confidence and adaptive collection for semantic eBPF profilers when
+   trace loss, missing probes, or stale schemas make an explanation uncertain;
+3. GPU host-side and megakernel profiling only when eBPF is genuinely essential
+   to the mechanism rather than an optional evidence source;
 4. revisit async and syscall causal profiling only when new mechanism or
    evaluation evidence materially extends the published causal-profiler report.
-
-For the next run, choose a genuine adjacent-systems question or an unusually
-strong pure-Agent systems question after fresh evidence and novelty review. Do
-not relabel one of the eBPF-essential candidates just to continue the active
-series one day earlier.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
@@ -152,49 +129,26 @@ execution placement. It reached the normal six-report series boundary on
 
 ### Published progress
 
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
-   first-class userspace eBPF needs explicit attachment, capability, state,
-   lifetime, and attribution contracts above ISA compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
-   multi-program problem beyond dispatch and ordering to effect visibility,
-   outcome resolution, shared-state ownership, and versioned hook composition.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
-   object-level replacement from application-level upgrade and developed an
-   explicit prepare / migrate / commit / retire generation protocol for programs,
-   links, maps, pinned state, controller recovery, and rollback.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
-   execution from logical-work causality and developed typed, lifetime-aware
-   handoff edges, an edge-versus-context measurement budget, and a ground-truth
-   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
-   application-defined resources.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
-   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
-   path, then developed a typed capability contract, versioned ring policy
-   generations, explicit provenance, and a comparative control-boundary benchmark.
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed a target manifest,
-   generation-scoped state ownership, and a ground-truth placement/provenance
-   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/`
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/`
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/`
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/`
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/`
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/`
 
 The Daily Report index already exposes the sequence. Report-level acquisition and
 navigation evidence is still too young to justify a dedicated public series hub.
-Revisit that decision only when evidence shows a retrieval benefit.
 
 ## Queued series — eBPF Networking and Security
 
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-Candidate topics:
-
-1. transactional policy updates across programs, maps, links, and control planes;
-2. multi-tenant network-policy composition and conflict resolution;
-3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
-   userspace eBPF;
-4. information-flow enforcement across process, file, socket, and encrypted
-   application boundaries;
-5. verifier and runtime interfaces for richer stateful policies;
-6. portable policy execution between kernel, userspace, NIC, and DPU targets.
+Candidate topics include transactional policy updates; multi-tenant policy
+composition; zero-copy programmable I/O across XDP, AF_XDP, io_uring, DPDK, and
+userspace eBPF; information-flow enforcement across process/file/socket/encrypted
+boundaries; richer verifier/runtime interfaces; and portable policy execution
+across kernel, userspace, NIC, and DPU targets.
 
 ## Queued series — GPU and Heterogeneous Runtime Systems
 
@@ -206,13 +160,8 @@ observability, programmable device-side instrumentation, distributed GPU
 coordination, utilization versus allocatability, host-side scheduling noise, and
 eBPF-like programmable monitors near GPU or DPU execution.
 
-Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
-runtime is central to the mechanism being evaluated.
-
-The August 20 launch-latency report is a focused adjacent-systems contribution to
-this roadmap. It does not promote this queued series to active; the active series
-remains eBPF Observability and Profiling once the rolling mix permits another
-eBPF-centered report.
+Reports here count toward the eBPF share only when eBPF or an eBPF-like runtime
+is central to the mechanism being evaluated.
 
 ## Queued series — Agent Systems (limited)
 
@@ -225,20 +174,16 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-After the August 20 report, only the parallel-effect report remains inside the
-rolling ten-report window. Pure-Agent publication is allowed by the cap, but is
-not required; prefer a technically stronger adjacent-systems question when one
-passes the evidence and novelty gates.
-
-Future Agent reports should preferentially connect back to eBPF or systems
-infrastructure, for example OS-level effect tracing, eBPF policy enforcement,
-sandbox escape visibility, syscall/tool causality, or runtime resource control.
+Neither pure-Agent report is currently inside the newest ten after the August 21
+publication. Pure-Agent work remains allowed by the cap but is not required; the
+active eBPF series remains stronger unless fresh evidence establishes a better
+Agent-systems question.
 
 ## Choosing the next report
 
 Each daily run should:
 
-1. calculate the current rolling topic mix;
+1. calculate the current rolling topic mix from the actually published index;
 2. start inside the active series when the mix permits it;
 3. research multiple candidate questions if necessary;
 4. reject candidates that do not pass the evidence and novelty gates;
@@ -248,5 +193,5 @@ Each daily run should:
 7. record the chosen series, topic classification, rejected candidates when
    useful, and why the report materially advances the roadmap.
 
-A temporary out-of-series detour should be recorded in the daily operating record
-and in this file so the repository, not chat history, remains authoritative.
+A temporary out-of-series detour should be recorded here so the repository, not
+chat history, remains authoritative.

--- a/.github/seo-data/daily/2026-08-21.md
+++ b/.github/seo-data/daily/2026-08-21.md
@@ -113,13 +113,13 @@ The report develops three mechanisms:
 ## Delivery state
 
 - Fresh branch: `daily/2026-08-21-ebpf-resource-semantics`
+- Non-draft daily PR: `#167`
 - One new bilingual Daily Report topic added
 - English and Chinese Daily Report indexes updated
 - Rolling series state repaired to include the already-published August 20
   host-device causality report
 - Stale unmerged PR #166 was marked superseded and closed; it was not counted as a completed daily delivery
 - Missing closeout for merged PR #165 was repaired with one compact comment after verifying the exact static export commit and both deployed language artifacts
-- Main daily PR: pending creation after operating-state updates
 - CI, final diff review, squash merge, exact deployment, production verification,
   and one merged-PR closeout comment: pending
 

--- a/.github/seo-data/daily/2026-08-21.md
+++ b/.github/seo-data/daily/2026-08-21.md
@@ -1,0 +1,138 @@
+# Daily SEO and Daily Report record — 2026-08-21
+
+## Scope and source coverage
+
+- Canonical site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Google Drive folder: configured weekly export folder, read-only
+- Google Search Console: newest verified weekly export is `2026-08-10` through `2026-08-16`; finalized date rows end on `2026-08-15`; the `2026-08-09` row remains absent
+- GA4: newest verified organic landing-page aggregate is `2026-08-10` through `2026-08-16` and is finalized under the configured three-day lag
+- New weekly Google set beginning `2026-08-17`: not observed on `2026-08-21`
+- Cloudflare: disabled by repository configuration; not interpreted as zero
+- Public-safe operating brief: refreshed `2026-08-21 08:02 UTC`
+- Public web, GitHub repository evidence, kernel documentation, libbpf documentation, and primary research: available
+- `seo-skills` submodule: remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`; upstream is newer but the repository still requires compatibility work before a pointer update
+
+## Analytics
+
+### Search Console
+
+The complete required 7-day and 28-day comparisons remain unavailable. The
+`2026-08-09` date row is absent across adjacent weekly exports, and verified
+history is not long enough for a complete 28-day comparison. Missing coverage is
+not converted into zero.
+
+The valid equal-duration six-day comparison is:
+
+| Window | Clicks | Impressions | CTR | Avg. position |
+| --- | ---: | ---: | ---: | ---: |
+| 2026-08-10..15 | 393 | 66,510 | 0.591% | 9.91 |
+| 2026-08-03..08 | 478 | 69,053 | 0.692% | 9.42 |
+
+Clicks are about 17.8% lower, impressions about 3.7% lower, CTR about 0.101
+percentage points lower, and average position about 0.49 positions worse. The
+older slice includes the 24,516-impression spike on `2026-08-05`, and the current
+exports do not provide date-by-page or date-by-query evidence that would justify
+attributing that spike to one page, query family, or report.
+
+Page-level movement is heterogeneous rather than a single site-wide failure. For
+example, homepage clicks changed from 26 to 11 while impressions changed from
+1,077 to 885; the Chinese CUDA architecture page rose from 19/242 to 21/297;
+and several high-impression technical pages continue to have low CTR. These
+signals are useful monitoring evidence but do not establish a crawl, canonical,
+metadata, title, navigation, or content defect by themselves.
+
+### GA4
+
+The finalized `2026-08-10` through `2026-08-16` organic landing-page aggregate
+contains **970 sessions** at about **44.95%** session-weighted engagement versus
+**991 sessions** at about **44.90%** for `2026-08-03` through `2026-08-09`.
+Sessions are about 2.1% lower while engagement is effectively flat. `(not set)`
+is 134 versus 116 sessions; excluding it, sessions are 836 versus 875.
+
+These are source-native acquisition and engagement signals. They do not justify
+a speculative search-facing site change.
+
+## Public and repository signals
+
+The `2026-08-21` public-safe brief reports:
+
+- homepage HTTP 200 in 140 ms;
+- `robots.txt` HTTP 200 and sitemap HTTP 200;
+- 682 sitemap entries;
+- homepage canonical `https://eunomia.dev/`;
+- 98 active non-fork repositories, 9,786 stars, 1,281 forks, 271 open issue/PR records;
+- 60 DEV articles, 43 public reactions, and 4 comments;
+- no recorded collection gap.
+
+Compared with the previous public-safe brief, the site and portfolio moved
+incrementally rather than showing a technical incident. No evidence-backed
+technical SEO/GEO code change is warranted today.
+
+## Technical SEO/GEO audit decision
+
+The current evidence does not establish a new crawl, robots, sitemap, canonical,
+hreflang, structured-data, redirect, broken-link, rendering, accessibility,
+performance, or deployment defect. The public change remains limited to the
+mandatory Daily Report and directly coupled report index and operating state.
+
+## Daily Report selection
+
+Before topic selection, the actually published newest-ten window is **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. The prior operating files
+were stale because the August 20 host-device causality report had landed after
+they were written.
+
+Selected report:
+
+- Title: **Can eBPF Understand Application-Defined Resources?**
+- Chinese title: **eBPF 能理解应用自己定义的资源吗？**
+- Route: `/research/ebpf-application-resource-semantics/`
+- Series: **eBPF Observability and Profiling**
+- Classification: **eBPF-centered**
+
+Publishing it keeps the newest-ten window at **7 eBPF / 0 pure Agent / 3
+adjacent**, because the report that ages out is also eBPF-centered.
+
+The evidence base includes the OSDI 2026 application-defined-resource profiling
+paper and current Linux `user_events`, uprobe/USDT, libbpf multi-uprobe cookie,
+and BPF ring-buffer interfaces. The report does not claim that eBPF replaces
+source-defined semantic instrumentation. It asks a narrower question: whether a
+versioned semantic contract can be dynamically attached through eBPF and then
+checked independently against real application and OS behavior.
+
+The report develops three mechanisms:
+
+1. a versioned resource-semantics manifest compiled into eBPF attachment plans;
+2. runtime semantic validation with explicit `validated -> suspect -> stale`
+   confidence loss instead of treating probe success as semantic correctness;
+3. a mutation benchmark that separately scores event correctness, lifetime
+   identity, stale-model detection, cross-layer attribution, diagnosis, and
+   overhead across software upgrades.
+
+## Delivery state
+
+- Fresh branch: `daily/2026-08-21-ebpf-resource-semantics`
+- One new bilingual Daily Report topic added
+- English and Chinese Daily Report indexes updated
+- Rolling series state repaired to include the already-published August 20
+  host-device causality report
+- Stale unmerged PR #166 was marked superseded and closed; it was not counted as a completed daily delivery
+- Missing closeout for merged PR #165 was repaired with one compact comment after verifying the exact static export commit and both deployed language artifacts
+- Main daily PR: pending creation after operating-state updates
+- CI, final diff review, squash merge, exact deployment, production verification,
+  and one merged-PR closeout comment: pending
+
+## Follow-up evidence
+
+1. Keep the full GSC 7-day and 28-day comparisons unavailable until source
+   history supports them.
+2. Obtain date-by-page or date-by-query evidence before explaining the August 5
+   impression spike.
+3. Monitor the click/CTR movement through another finalized weekly set before
+   changing search-facing titles or navigation.
+4. Continue the active eBPF Observability and Profiling series; always-on semantic
+   compression is the preferred next question after fresh novelty review.
+5. Keep the recurring operations schedule enabled even when a future run is
+   blocked; repository or external blockers are reported rather than converted
+   into a stopped schedule.

--- a/.github/seo-data/daily/2026-08-21.md
+++ b/.github/seo-data/daily/2026-08-21.md
@@ -116,6 +116,8 @@ Directly coupled work:
 - First `Validate SEO Operations` attempt found this daily record did not use the
   pinned validator's required heading schema; the record was corrected on the
   same branch
+- Reader-facing self-review removed editorial classification language from the
+  public report prose while keeping the classification in this operating record
 - Required CI, final generated-output review, squash merge, exact deployment, and
   public bilingual verification remain required before completion
 
@@ -123,7 +125,7 @@ Directly coupled work:
 
 - Pull request: `#167`
 - Exactly one new bilingual Daily Report topic: yes
-- CI: rerunning after daily-record schema correction
+- CI: rerunning after final self-review corrections
 - Squash merge: pending clean CI and final review
 - Exact-merge production deployment: pending merge
 - Public EN/ZH verification: pending exact deployment
@@ -139,5 +141,3 @@ Directly coupled work:
    search-facing titles, navigation, or site structure.
 4. Continue **eBPF Observability and Profiling**. Always-on semantic compression
    is the preferred next question after fresh evidence and novelty review.
-5. Keep the recurring operations schedule enabled even when a future run is
-   blocked; report the blocker instead of stopping the schedule.

--- a/.github/seo-data/daily/2026-08-21.md
+++ b/.github/seo-data/daily/2026-08-21.md
@@ -1,28 +1,27 @@
-# Daily SEO and Daily Report record — 2026-08-21
+# SEO operations — 2026-08-21
 
-## Scope and source coverage
+## Scope
 
 - Canonical site: `https://eunomia.dev`
 - Site timezone: `America/Los_Angeles`
-- Google Drive folder: configured weekly export folder, read-only
-- Google Search Console: newest verified weekly export is `2026-08-10` through `2026-08-16`; finalized date rows end on `2026-08-15`; the `2026-08-09` row remains absent
+- Google Drive weekly exports: enabled and read-only
+- Google Search Console, GA4, public web, public GitHub, live-site evidence, kernel/libbpf documentation, and primary research: used where available
+- Cloudflare: disabled by repository configuration; never interpreted as zero
+- `seo-skills` remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`; upstream is newer but the consuming repository still requires compatibility work before a pointer update
+
+## Data window
+
+- Search Console: newest verified weekly export is `2026-08-10` through `2026-08-16`; finalized date rows end on `2026-08-15`; `2026-08-09` remains absent
 - GA4: newest verified organic landing-page aggregate is `2026-08-10` through `2026-08-16` and is finalized under the configured three-day lag
 - New weekly Google set beginning `2026-08-17`: not observed on `2026-08-21`
-- Cloudflare: disabled by repository configuration; not interpreted as zero
+- Complete GSC 7-day comparison: unavailable because `2026-08-09` is missing
+- Complete GSC 28-day comparison: unavailable because verified history is insufficient
+- Valid equal-duration GSC comparison: `2026-08-10..15` versus `2026-08-03..08`
 - Public-safe operating brief: refreshed `2026-08-21 08:02 UTC`
-- Public web, GitHub repository evidence, kernel documentation, libbpf documentation, and primary research: available
-- `seo-skills` submodule: remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`; upstream is newer but the repository still requires compatibility work before a pointer update
 
-## Analytics
+## Evidence collected
 
 ### Search Console
-
-The complete required 7-day and 28-day comparisons remain unavailable. The
-`2026-08-09` date row is absent across adjacent weekly exports, and verified
-history is not long enough for a complete 28-day comparison. Missing coverage is
-not converted into zero.
-
-The valid equal-duration six-day comparison is:
 
 | Window | Clicks | Impressions | CTR | Avg. position |
 | --- | ---: | ---: | ---: | ---: |
@@ -31,108 +30,114 @@ The valid equal-duration six-day comparison is:
 
 Clicks are about 17.8% lower, impressions about 3.7% lower, CTR about 0.101
 percentage points lower, and average position about 0.49 positions worse. The
-older slice includes the 24,516-impression spike on `2026-08-05`, and the current
-exports do not provide date-by-page or date-by-query evidence that would justify
-attributing that spike to one page, query family, or report.
+older slice contains the 24,516-impression spike on `2026-08-05`; current exports
+do not contain date-by-page or date-by-query evidence that would support assigning
+that spike to one page, query family, or report.
 
-Page-level movement is heterogeneous rather than a single site-wide failure. For
-example, homepage clicks changed from 26 to 11 while impressions changed from
-1,077 to 885; the Chinese CUDA architecture page rose from 19/242 to 21/297;
-and several high-impression technical pages continue to have low CTR. These
-signals are useful monitoring evidence but do not establish a crawl, canonical,
-metadata, title, navigation, or content defect by themselves.
+Page movement is heterogeneous. Homepage clicks changed from 26 to 11 while
+impressions changed from 1,077 to 885; the Chinese CUDA architecture page changed
+from 19/242 to 21/297; several high-impression technical pages still have low
+CTR. This is monitoring evidence, not proof of one site-wide technical defect.
 
 ### GA4
 
-The finalized `2026-08-10` through `2026-08-16` organic landing-page aggregate
-contains **970 sessions** at about **44.95%** session-weighted engagement versus
-**991 sessions** at about **44.90%** for `2026-08-03` through `2026-08-09`.
-Sessions are about 2.1% lower while engagement is effectively flat. `(not set)`
-is 134 versus 116 sessions; excluding it, sessions are 836 versus 875.
+The finalized `2026-08-10..16` organic landing-page aggregate contains **970
+sessions** at about **44.95%** session-weighted engagement versus **991 sessions**
+at about **44.90%** for `2026-08-03..09`. Sessions are about 2.1% lower while
+engagement is effectively flat. `(not set)` is 134 versus 116 sessions; excluding
+it, sessions are 836 versus 875.
 
-These are source-native acquisition and engagement signals. They do not justify
-a speculative search-facing site change.
+### Public and repository signals
 
-## Public and repository signals
+The current public-safe brief reports homepage HTTP 200 in 140 ms, `robots.txt`
+HTTP 200, sitemap HTTP 200, 682 sitemap entries, homepage canonical
+`https://eunomia.dev/`, 98 active non-fork repositories, 9,786 stars, 1,281
+forks, 271 open issue/PR records, 60 DEV articles, 43 public reactions, and 4
+comments. No collection gap is recorded.
 
-The `2026-08-21` public-safe brief reports:
-
-- homepage HTTP 200 in 140 ms;
-- `robots.txt` HTTP 200 and sitemap HTTP 200;
-- 682 sitemap entries;
-- homepage canonical `https://eunomia.dev/`;
-- 98 active non-fork repositories, 9,786 stars, 1,281 forks, 271 open issue/PR records;
-- 60 DEV articles, 43 public reactions, and 4 comments;
-- no recorded collection gap.
-
-Compared with the previous public-safe brief, the site and portfolio moved
-incrementally rather than showing a technical incident. No evidence-backed
-technical SEO/GEO code change is warranted today.
-
-## Technical SEO/GEO audit decision
-
-The current evidence does not establish a new crawl, robots, sitemap, canonical,
+The technical audit does not establish a new crawl, robots, sitemap, canonical,
 hreflang, structured-data, redirect, broken-link, rendering, accessibility,
-performance, or deployment defect. The public change remains limited to the
-mandatory Daily Report and directly coupled report index and operating state.
+performance, or deployment defect. No unrelated technical SEO/GEO code change is
+supported today.
 
-## Daily Report selection
+Before topic selection, the actually published newest-ten Daily Report window is
+**7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. Earlier operating files
+were stale because the August 20 host-device causality report landed after those
+files were written.
 
-Before topic selection, the actually published newest-ten window is **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The prior operating files
-were stale because the August 20 host-device causality report had landed after
-they were written.
+## Work performed
 
-Selected report:
+Selected one new bilingual report in the active **eBPF Observability and
+Profiling** series:
 
-- Title: **Can eBPF Understand Application-Defined Resources?**
-- Chinese title: **eBPF 能理解应用自己定义的资源吗？**
+- English: **Can eBPF Understand Application-Defined Resources?**
+- Chinese: **eBPF 能理解应用自己定义的资源吗？**
 - Route: `/research/ebpf-application-resource-semantics/`
-- Series: **eBPF Observability and Profiling**
 - Classification: **eBPF-centered**
+
+The report uses the OSDI 2026 application-defined-resource profiler and current
+Linux `user_events`, uprobe/USDT, libbpf multi-uprobe cookie, BPF maps, and BPF
+ring-buffer interfaces as primary implementation/research evidence. It develops:
+
+1. a versioned resource-semantics manifest compiled into eBPF attachment plans;
+2. runtime semantic validation with explicit `validated -> suspect -> stale`
+   confidence loss;
+3. a software-mutation benchmark that separately scores event correctness,
+   lifetime identity, stale-model detection, cross-layer attribution, diagnosis,
+   and overhead.
+
+The eBPF classification is based on the actual mechanism: dynamic no-rebuild
+semantic instrumentation plus independent cross-layer runtime validation. The
+report explicitly does not claim eBPF should replace stable source-defined
+semantic interfaces.
 
 Publishing it keeps the newest-ten window at **7 eBPF / 0 pure Agent / 3
 adjacent**, because the report that ages out is also eBPF-centered.
 
-The evidence base includes the OSDI 2026 application-defined-resource profiling
-paper and current Linux `user_events`, uprobe/USDT, libbpf multi-uprobe cookie,
-and BPF ring-buffer interfaces. The report does not claim that eBPF replaces
-source-defined semantic instrumentation. It asks a narrower question: whether a
-versioned semantic contract can be dynamically attached through eBPF and then
-checked independently against real application and OS behavior.
+Directly coupled work:
 
-The report develops three mechanisms:
+- added English and Chinese report pages;
+- updated both Daily Report indexes;
+- repaired `content-series.md`, `status.md`, `plan.md`, `block.md`, and `site.md`
+  to match current published/data state;
+- marked stale unmerged PR #166 superseded and closed it rather than reusing a
+  branch based on pre-#165 state;
+- repaired the missing closeout record on merged PR #165 after verifying its exact
+  static export commit and both deployed language artifacts.
 
-1. a versioned resource-semantics manifest compiled into eBPF attachment plans;
-2. runtime semantic validation with explicit `validated -> suspect -> stale`
-   confidence loss instead of treating probe success as semantic correctness;
-3. a mutation benchmark that separately scores event correctness, lifetime
-   identity, stale-model detection, cross-layer attribution, diagnosis, and
-   overhead across software upgrades.
-
-## Delivery state
+## Validation and self-review
 
 - Fresh branch: `daily/2026-08-21-ebpf-resource-semantics`
-- Non-draft daily PR: `#167`
-- One new bilingual Daily Report topic added
-- English and Chinese Daily Report indexes updated
-- Rolling series state repaired to include the already-published August 20
-  host-device causality report
-- Stale unmerged PR #166 was marked superseded and closed; it was not counted as a completed daily delivery
-- Missing closeout for merged PR #165 was repaired with one compact comment after verifying the exact static export commit and both deployed language artifacts
-- CI, final diff review, squash merge, exact deployment, production verification,
-  and one merged-PR closeout comment: pending
+- Non-draft PR: `#167`
+- Branch started from current `main` at `845c40a8d883c5031bab8248ffe0fbd75b89b3ad`
+- Scope review: ten changed files, all limited to one bilingual report, its two
+  indexes, and directly coupled operating records
+- Technical SEO decision: no unrelated site implementation patch
+- First `Validate SEO Operations` attempt found this daily record did not use the
+  pinned validator's required heading schema; the record was corrected on the
+  same branch
+- Required CI, final generated-output review, squash merge, exact deployment, and
+  public bilingual verification remain required before completion
 
-## Follow-up evidence
+## Delivery
 
-1. Keep the full GSC 7-day and 28-day comparisons unavailable until source
-   history supports them.
+- Pull request: `#167`
+- Exactly one new bilingual Daily Report topic: yes
+- CI: rerunning after daily-record schema correction
+- Squash merge: pending clean CI and final review
+- Exact-merge production deployment: pending merge
+- Public EN/ZH verification: pending exact deployment
+- Merged-PR closeout comment: pending exact deployment and public verification
+
+## Decisions and follow-ups
+
+1. Keep full GSC 7-day and 28-day comparisons unavailable until source history
+   supports them; never treat the missing `2026-08-09` row as zero.
 2. Obtain date-by-page or date-by-query evidence before explaining the August 5
    impression spike.
-3. Monitor the click/CTR movement through another finalized weekly set before
-   changing search-facing titles or navigation.
-4. Continue the active eBPF Observability and Profiling series; always-on semantic
-   compression is the preferred next question after fresh novelty review.
+3. Monitor click/CTR movement through another finalized weekly set before changing
+   search-facing titles, navigation, or site structure.
+4. Continue **eBPF Observability and Profiling**. Always-on semantic compression
+   is the preferred next question after fresh evidence and novelty review.
 5. Keep the recurring operations schedule enabled even when a future run is
-   blocked; repository or external blockers are reported rather than converted
-   into a stopped schedule.
+   blocked; report the blocker instead of stopping the schedule.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -37,8 +37,9 @@ durable goals and constraints, not duplicated scheduler instructions.
 
 ## Operating constraints
 
-- The external scheduler is already configured and only invokes the repository;
-  the repository owns all operational policy and current state.
+- The external scheduler is already configured and remains enabled and recurring;
+  repository or external blockers are reported rather than converted into a
+  stopped schedule.
 - Data analysis runs every day. A missing private source is marked unavailable,
   never inferred as zero.
 - Raw analytics, private identifiers, credentials, and personal information stay
@@ -52,9 +53,6 @@ durable goals and constraints, not duplicated scheduler instructions.
   the Daily Report may not be skipped.
 - Keep the rolling topic mix compliant and classify by the report's actual central
   mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the
-  daily pull request incoherent; put unrelated durable SEO work in this plan for a
-  focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review
   and squash merge.
 - Every daily report is a public change, so the exact squash commit must deploy
@@ -71,45 +69,39 @@ priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically as reports age out. After the
-   `2026-08-20` GPU launch-latency report, the most recent ten reports are **7
-   eBPF-centered / 1 pure Agent / 2 adjacent systems**. The oldest remaining
-   report in that window is the pure-Agent parallel-effect report, so the next
-   publication must again be non-eBPF; adding an eBPF-centered report immediately
-   would produce 8 eBPF reports in the rolling ten and violate the 5–7 rule.
-2. Keep **eBPF Observability and Profiling** as the active series, but defer its
-   eBPF-essential questions until the rolling window permits them again. The
-   August 20 report is a GPU-profiling adjacent-systems detour about launch-delay
-   attribution, distinct from the August 19 sampling-bias detour. For the next
-   run, prefer a genuine adjacent systems question or a strong pure-Agent systems
-   question rather than relabeling an eBPF mechanism. Once the oldest eBPF report
-   starts aging out, return to always-on semantic compression,
-   application-defined resource profiling, or GPU host/device causal profiling
-   with eBPF as an essential mechanism only when the mix remains compliant.
+1. Preserve the rolling ten-report mix mechanically from the actually published
+   archive rather than stale operating notes. Before and after the `2026-08-21`
+   eBPF application-resource semantics report, the newest ten are **7
+   eBPF-centered / 0 pure Agent / 3 adjacent systems** because an eBPF report
+   ages out when today's eBPF report enters. Another eBPF-centered report remains
+   arithmetically possible on the next run if it passes the quality and novelty
+   gates.
+2. Keep **eBPF Observability and Profiling** active. After page-level memory
+   attribution and application-resource semantics, prefer **always-on semantic
+   compression under an explicit evidence budget** as the next eBPF-centered
+   question after fresh evidence review. Require a concrete retention/diagnosis
+   trade-off, not generic “compress traces with AI.”
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-20`, no newer weekly set than `2026-08-10` through `2026-08-16`
-   was observed. That GA4 aggregate remains finalized under the three-day lag.
-   Search Console still lacks the `2026-08-09` date row, so keep the required
-   complete 7-day and 28-day comparisons unavailable until source history really
-   supports them.
-4. Obtain or generate date-by-page or date-by-query Search Console evidence before
-   attributing the `2026-08-05` impression spike to a specific page or query family.
-5. Monitor the current Search Console click/CTR decline and homepage/branded
-   softness across another finalized period before changing titles, copy, or site
-   structure; the current movement is not uniform enough to justify a speculative
-   SEO patch.
+   On `2026-08-21`, no newer weekly set than `2026-08-10` through `2026-08-16`
+   was observed. GA4 for that week is finalized. Search Console still lacks the
+   `2026-08-09` date row, so keep complete 7-day and 28-day comparisons
+   unavailable until source history actually supports them.
+4. Obtain date-by-page or date-by-query Search Console evidence before attributing
+   the `2026-08-05` impression spike to a specific page or query family.
+5. Monitor the current Search Console click/CTR softness through another finalized
+   weekly set before changing titles, copy, navigation, or site structure. Page
+   movement is heterogeneous and does not establish one technical SEO defect.
 6. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and
    technical SEO questions that require richer source-native evidence rather than
-   as reasons to steer report topics.
+   as reasons to steer Daily Report topics.
 7. Add Cloudflare coverage only when a supported read-only route is enabled in
    repository configuration.
 8. Use search behavior, GitHub activity, primary research, kernel changes, and
-   production evidence to order questions inside the approved eBPF and adjacent
+   production evidence to order questions inside approved eBPF and adjacent
    systems series.
 9. Revisit a dedicated public hub for the completed eBPF runtime series only after
    report-level acquisition or navigation evidence shows that it would improve
    retrieval beyond the existing Daily Report index.
 10. Migrate the consuming SEO contract before moving the pinned `seo-skills`
-    submodule to a newer upstream layout that removed interfaces this repository
-    still calls. Upstream movement alone is not evidence that a pointer-only bump
-    is safe.
+    submodule to the newer upstream layout. Upstream movement alone is not
+    evidence that a pointer-only bump is safe.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -37,9 +37,8 @@ durable goals and constraints, not duplicated scheduler instructions.
 
 ## Operating constraints
 
-- The external scheduler is already configured and remains enabled and recurring;
-  repository or external blockers are reported rather than converted into a
-  stopped schedule.
+- The external scheduler is already configured and only invokes the repository;
+  the repository owns all operational policy and current state.
 - Data analysis runs every day. A missing private source is marked unavailable,
   never inferred as zero.
 - Raw analytics, private identifiers, credentials, and personal information stay
@@ -53,6 +52,9 @@ durable goals and constraints, not duplicated scheduler instructions.
   the Daily Report may not be skipped.
 - Keep the rolling topic mix compliant and classify by the report's actual central
   mechanism, not by superficial keyword mentions.
+- Do not combine unrelated technical SEO and content work when that makes the
+  daily pull request incoherent; put unrelated durable SEO work in this plan for a
+  focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review
   and squash merge.
 - Every daily report is a public change, so the exact squash commit must deploy

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -52,13 +52,14 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
-`2026-08-16`; no newer weekly set was observed in the configured Drive folder on
-`2026-08-20`. Search Console rows through `2026-08-15` are usable. The
-`2026-08-09` Search Console date row is still absent across the adjacent files,
-so a complete latest-7-days versus previous-7-days comparison remains
-unavailable. A valid equal-duration six-day comparison is `2026-08-10` through
-`2026-08-15` versus `2026-08-03` through `2026-08-08`. The 28-day comparison is
-also unavailable because the export history is not long enough.
+`2026-08-16`; no newer weekly set beginning `2026-08-17` was observed in the
+configured Drive folder on `2026-08-21`. Search Console rows through
+`2026-08-15` are usable. The `2026-08-09` Search Console date row is still absent
+across the adjacent files, so a complete latest-7-days versus previous-7-days
+comparison remains unavailable. A valid equal-duration six-day comparison is
+`2026-08-10` through `2026-08-15` versus `2026-08-03` through `2026-08-08`. The
+28-day comparison is also unavailable because verified export history is not
+long enough.
 
 GA4 weekly landing-page exports have no date dimension for trimming a partial or
 unfinalized day within a file. Every day in the newest `2026-08-10` through

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -6,59 +6,55 @@
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
-- Scheduler timing: daily, flexible around 08:00 in `America/Los_Angeles`
-- Last completed daily run: `2026-08-19`
 - Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`
-- Latest daily record: `2026-08-20`
-- Last completed public-change pull request: `#163`
-- Last verified production publication from a daily run: static export commit `a0ab9aed6af348eb8d85634339f407eca2122616` for squash commit `38d50fd8584293490cf845f2c4ff710c368dbe88`
-- Current daily branch: `daily/2026-08-20-gpu-launch-latency`
+- Latest daily record: `2026-08-21`
+- Last completed Daily Report pull request before the current run: `#165`
+- Last verified production publication from a Daily Report run: static export commit `f57e7d96296e36b98aadbe7f6d54e5b88d550e6e` for squash commit `08c1770391e952defacde8e3d4da0aff50c77c8e`
+- Current daily branch: `daily/2026-08-21-ebpf-resource-semantics`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#163` is fully closed out. It squash-merged as
-`38d50fd8584293490cf845f2c4ff710c368dbe88`; final PR-head `Deploy Static App`
-run `32274536861` and `Validate SEO Operations` run `32274536879` succeeded. The
-production `new` branch contains static export commit
-`a0ab9aed6af348eb8d85634339f407eca2122616` with exact message `deploy static
-app for 38d50fd8584293490cf845f2c4ff710c368dbe88`. Its generated English and
-Chinese profiler-sampling pages contain the correct titles, canonical URLs,
-reciprocal language alternates plus `x-default`, Article JSON-LD, Daily Report
-navigation, and report content. The merged PR has one compact closeout comment.
+PR `#165` is now closed out. It squash-merged as
+`08c1770391e952defacde8e3d4da0aff50c77c8e`; the production `new` branch contains
+static export commit `f57e7d96296e36b98aadbe7f6d54e5b88d550e6e` with exact message `deploy static
+app for 08c1770391e952defacde8e3d4da0aff50c77c8e`. The deployed English and Chinese
+GPU host-device causality pages contain locale-correct canonical URLs, reciprocal
+`en`/`zh` language alternates plus `x-default`, Article JSON-LD, and Daily Report
+navigation. One compact closeout comment records the verification.
+
+The stale unmerged application-resource PR `#166` was based on pre-`#165` state,
+used obsolete rolling-mix arithmetic, and was closed rather than reused. The
+current run starts from the latest default branch.
 
 ## Current Daily Report mix
 
-Before today's publication, the completed archive contains ten reports:
+Immediately before the `2026-08-21` report, the actually published newest ten
+reports are:
 
 - eBPF-centered: **7 of 10**
-- pure Agent-centered: **2 of 10**
-- adjacent systems: **1 of 10**
+- pure Agent-centered: **0 of 10**
+- adjacent systems: **3 of 10**
 
-Today's GPU launch-latency report is a genuine adjacent-systems report. Its
-central mechanisms are CUDA/CUPTI launch-state attribution, cross-domain launch
-lineage, dependency uncertainty, and a ground-truth launch-delay benchmark.
-eBPF can contribute host scheduling evidence on Linux but is not required for
-the mechanism, so the report is not classified eBPF-centered.
-
-After publication, the rolling ten-report window becomes **7 eBPF / 1 pure Agent
-/ 2 adjacent**. The next run must remain non-eBPF because adding an eBPF report
-while the oldest remaining report is the pure-Agent parallel-effect report would
-raise the eBPF count to 8 of 10. Keep the active eBPF Observability and Profiling
-series but defer its eBPF-essential questions until the rolling window permits
-another eBPF-centered publication.
+The earlier operating files were stale because they did not yet include the
+August 20 host-device causality report. Today's
+`/research/ebpf-application-resource-semantics/` report is genuinely
+eBPF-centered: its central property is dynamic no-rebuild semantic instrumentation
+plus independent cross-layer runtime validation using eBPF. Publishing it ages an
+eBPF report out of the rolling ten, so the new rolling window remains **7 eBPF /
+0 pure Agent / 3 adjacent** and stays within the 5–7 rule.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-20 08:02 UTC`
-- Homepage: HTTP 200 in **189 ms** in the current operating brief
+- Repository-generated public-safe operating brief: refreshed `2026-08-21 08:02 UTC`
+- Homepage: HTTP 200 in **140 ms**
 - `robots.txt`: HTTP 200; sitemap: HTTP 200
-- Sitemap entries observed: **674**
+- Sitemap entries observed: **682**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 97 active non-fork repositories, 9,775 stars, 1,280 forks, and 284 open issue/PR records
+- Public GitHub portfolio snapshot: 98 active non-fork repositories, 9,786 stars, 1,281 forks, and 271 open issue/PR records
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
-- Google Analytics 4: weekly organic landing-page exports available through `2026-08-16`; the newest complete aggregate is finalized under the three-day lag
-- Google Search Console: weekly export sets available through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
-- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-20`
+- Google Analytics 4: finalized weekly organic landing-page exports through `2026-08-16`
+- Google Search Console: weekly export set through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
+- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-21`
 - Cloudflare: disabled by repository configuration
 
 For the valid equal-duration Search Console comparison, `2026-08-10` through
@@ -69,54 +65,48 @@ impressions**, **0.692%** CTR, and position about **9.42**. Clicks are about
 **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage
 points lower**, and average position about **0.49 positions worse**. The older
 slice includes the unusual `2026-08-05` impression spike, so the movement remains
-monitored rather than attributed to one page, query, or Daily Report.
+monitored rather than attributed to one page, query, or report.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison remains
-unavailable because the `2026-08-09` date row is absent across the adjacent
-weekly files. The required 28-day comparison is also unavailable rather than
-inferred.
+unavailable because the `2026-08-09` date row is absent. The required 28-day
+comparison is also unavailable because verified export history is too short.
 
 The finalized GA4 organic landing-page export for `2026-08-10` through
 `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted
 engagement, versus **991 sessions** at about **44.90%** for `2026-08-03` through
 `2026-08-09`. Sessions are about **2.1% lower** while engagement is effectively
 flat. `(not set)` is **134 versus 116 sessions**; excluding it, sessions are
-**836 versus 875**. These are source-native acquisition and measurement signals,
-not evidence for a speculative title, copy, navigation, or site-structure
-change.
+**836 versus 875**.
 
 ## Current technical baseline
 
 The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
-structured data, legacy redirect stubs, and HTTP audit artifacts. Production
+structured data, legacy redirect stubs, and static audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The `2026-08-20` public-safe operating brief and current repository evidence do
-not establish a new crawl, canonical, hreflang, structured-data, redirect,
-broken-link, rendering, accessibility, performance, or deployment defect. The
-appropriate public site change today is therefore the mandatory bilingual Daily
-Report and directly coupled report-index/series updates, not an unrelated
-technical SEO patch.
+The August 21 public-safe brief, current repository output, and available Google
+evidence do not establish a new crawl, canonical, hreflang, structured-data,
+redirect, broken-link, rendering, accessibility, performance, or deployment
+defect. The appropriate public change is therefore the mandatory bilingual Daily
+Report and its directly coupled index/series updates, not a speculative technical
+SEO patch.
 
-Today's research asks whether a CUDA kernel was slow or merely started late.
-Current CUPTI exposes API timing and correlation plus optional kernel `queued`
-and `submitted` latency timestamps; Nsight Systems exposes API/queue/kernel
-phases but documents that its queue interval is an approximation. The report
-therefore treats timestamps as evidence about states rather than automatic proof
-of one cause. It develops an explicit launch-state ledger with unknown states,
-a launch identity that survives host handoffs and CUDA Graph replay, and a
-controlled benchmark with independently injected delay causes.
+Today's report uses the OSDI 2026 application-defined-resource profiler as the
+main research comparison and current Linux `user_events`, uprobe/USDT, libbpf
+multi-uprobe cookies, BPF maps, and ring-buffer semantics as implementation
+evidence. It develops a versioned resource-semantics manifest, runtime stale-model
+validation with explicit confidence loss, and a software-mutation benchmark that
+separates semantic correctness from final diagnosis.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream remains at
-`f42128a3f05c73cf10c786a2711c488bb3a14839`, while the consuming repository still
-names interfaces from the pinned layout. A pointer-only update is therefore not
-mixed into this daily delivery.
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream is newer, but the consuming
+repository still names interfaces from the pinned layout. A pointer-only update is
+not mixed into this daily delivery.
 
 ## Current focus
 
-1. Complete the `2026-08-20` GPU launch-latency Daily Report through CI, complete diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. Keep the next publication non-eBPF while the rolling window remains at the seven-report eBPF ceiling; select a genuine adjacent-systems or unusually strong pure-Agent systems question rather than relabeling an eBPF mechanism.
+1. Complete the `2026-08-21` eBPF application-resource semantics Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Continue **eBPF Observability and Profiling**. The next eBPF-centered report remains permitted by rolling-window arithmetic; prefer always-on semantic compression after fresh evidence/novelty review.
 3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
 5. Monitor Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
@@ -124,4 +114,4 @@ mixed into this daily delivery.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.
 
-Detailed history belongs in `.github/seo-data/daily/` and the merged daily pull requests.
+Detailed history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/docs/research/ebpf-application-resource-semantics.md
+++ b/docs/research/ebpf-application-resource-semantics.md
@@ -1,0 +1,219 @@
+---
+date: 2026-08-21
+title: "Can eBPF Understand Application-Defined Resources?"
+description: "eBPF can trace internal pools, queues, and caches without rebuilding apps, but raw probes lack semantics. This report develops a versioned resource contract."
+tags:
+  - Daily Report
+  - eBPF
+  - Profiling
+  - Observability
+  - Uprobes
+  - USDT
+research_question: "How can an eBPF profiler observe application-defined resources without hard-coding stale application semantics, while preserving resource identity, lifetime, and cross-layer effects?"
+source_cutoff: 2026-08-21
+status: daily-report
+---
+
+# Can eBPF Understand Application-Defined Resources?
+
+A MySQL buffer pool can be full of the wrong pages while Linux still reports normal process memory. A work queue can be overloaded while CPU utilization looks modest. A query cache, connection pool, token bucket, temporary table, or application-level credit can decide whether a request is fast even though none of those objects is a first-class OS resource.
+
+That is the uncomfortable boundary for a system profiler: eBPF is very good at observing *what code and the operating system do*, but it does not automatically know *what an application object means*.
+
+<!-- more -->
+
+The OSDI 2026 paper [Diagnosing Performance Issues in Application-Defined Resources](https://www.usenix.org/conference/osdi26/presentation/hu-yigong) makes the visibility gap concrete. Its study found 38 distinct application-defined resources across 45 real performance issues. The paper reduces many resource interactions to four semantic events: `WAIT`, `ACQUIRE`, `USE`, and `RELEASE`. Its profiler, gigiprofiler, combines LLM-based semantic discovery with static validation, instruments the selected locations with an LLVM pass, then uses runtime evidence to diagnose 15 reproduced issues and two previously unknown MariaDB bugs.
+
+The paper also provides an unusually useful warning for any dynamic profiler. LLM-only event discovery has 45–60% false-positive rates in its evaluation. Static validation improves precision, and post-profiling validation reduces false positives again. Yet an exhaustive MySQL buffer-pool study still finds that the resulting pipeline misses about 23% of usage events on average. The measured runtime overhead averages 3.7% and never exceeds 7.8% in the nine cases where end-to-end comparison is meaningful.
+
+This is strong evidence that application-resource semantics are both useful and fallible. It also exposes a narrower eBPF research question: **can the semantic model be separated from the instrumentation mechanism, then checked continuously at runtime rather than compiled into one profiler build?**
+
+This report argues for a **versioned application-resource contract consumed by eBPF**. Static analysis, an LLM, developer annotations, or existing USDT/user-events metadata may propose resource semantics. eBPF then becomes the deployment and validation substrate: attach to existing binaries, carry a typed descriptor into each probe, correlate resource events with scheduler/I/O/memory effects, and explicitly downgrade confidence when the observed runtime no longer satisfies the descriptor.
+
+That makes this report eBPF-centered. The target property is not merely “trace four events.” It is **dynamic, no-rebuild semantic instrumentation plus cross-boundary validation against the running system**. If eBPF cannot provide that property more reliably than compile-time instrumentation, the proposed direction should fail.
+
+## What current systems already give us
+
+### gigiprofiler gives a useful semantic event model
+
+gigiprofiler's most reusable idea is not one specific detector. It is the observation that diverse application resources can often be described through a compact interaction vocabulary.
+
+- `WAIT(resource_id, wait)` records a slow acquisition path.
+- `ACQUIRE(resource_id, units)` records obtaining capacity or an object.
+- `USE(resource_id, use_type, target_id)` records work performed through the resource.
+- `RELEASE(resource_id, units)` records capacity or an object returning to the resource.
+
+Those events are expressive enough to expose several pathologies. Long `WAIT` intervals reveal contention. Frequent acquire/release without useful work can reveal an inefficient policy. An unmatched acquire/release balance can reveal unbounded growth or leakage. A resource held by one request can explain why later requests are forced onto a slow path.
+
+The important point is that these are **semantic events**. A function entry is not an `ACQUIRE` event merely because it returns a pointer. A mutex wait is not necessarily waiting for the application resource that matters. The event meaning has to be derived from application behavior.
+
+### Linux already exposes multiple transport mechanisms
+
+Linux has several ways to transport application-level evidence.
+
+[`user_events`](https://docs.kernel.org/6.18/trace/user_events.html) lets a process register typed trace events that existing tools such as ftrace and perf can consume. Current kernels support multiple formats for one logical event name through `USER_EVENT_REG_MULTI_FORMAT`, which is useful when an application's event schema evolves.
+
+[uprobes](https://docs.kernel.org/trace/uprobetracer.html) can observe an existing executable or shared library at selected offsets without requiring the application to emit a trace event. In libbpf, [`bpf_program__attach_uprobe_multi`](https://docs.ebpf.io/ebpf-library/libbpf/userspace/bpf_program__attach_uprobe_multi/) can attach one BPF program to many functions or offsets and assign a different attach cookie to each site. [`bpf_program__attach_usdt`](https://docs.ebpf.io/ebpf-library/libbpf/userspace/bpf_program__attach_usdt/) provides the corresponding path for USDT probes.
+
+The BPF ring buffer adds another useful property: events emitted from BPF programs preserve ordering across CPUs in one shared FIFO. BPF maps can retain compact lifetime and correlation state while a userspace analyzer consumes only the evidence needed for diagnosis.
+
+These interfaces solve **where to observe and how to transport state**. They do not solve **what a pool, queue, cache entry, lease, or credit means**.
+
+### Dynamic attachment is not the same as dynamic semantics
+
+It is tempting to say that uprobes make the problem solved: find the resource's functions and attach BPF programs to them. That only moves the instrumentation point.
+
+Suppose version A of an application uses `pool_get()` to return one reusable object. Version B changes the function so it sometimes returns a borrowed object that must not be counted as an acquisition. The symbol may still exist. A uprobe may still fire. The trace may still look internally consistent. The *semantic contract* is now stale.
+
+A raw address is equally dangerous. If a pointer is reused after an object is destroyed, a profiler that treats the address as a stable resource identifier can merge two lifetimes. The resulting trace is precise at the machine level and wrong at the application level.
+
+So the problem is not just probe placement. It is **semantic versioning and runtime validation**.
+
+## Where current work is still weak
+
+### The semantic model is usually coupled to one build or one analysis run
+
+gigiprofiler performs static analysis for an application version and injects lightweight probes through an LLVM pass. That is reasonable for on-demand diagnosis, but the discovered resource model is tied to the code version that was analyzed and instrumented.
+
+Production observability often has a different constraint: the profiler may need to attach to a binary that was already built, packaged, or supplied by another team. Re-running a compiler pass is not always possible. Even when source is available, fleets can contain several builds at once.
+
+The missing artifact is a portable contract that says *which build this semantic claim applies to*, *where the event lives*, and *how to derive stable resource identity and lifetime from runtime values*.
+
+### A probe can remain valid syntactically after becoming wrong semantically
+
+Symbol resolution, attach success, and argument decoding are weak health checks. They prove that a probe can execute, not that the event still means `ACQUIRE`, `USE`, `WAIT`, or `RELEASE`.
+
+A production profiler therefore needs a semantic health signal. For example, if an `ACQUIRE` descriptor says that a returned object should later appear in `USE`, but a new build produces thousands of acquisitions that are never used and never released, the collector should not silently publish the same interpretation with high confidence.
+
+The correct response may be “model stale,” not “resource leak.”
+
+### System effects and application-resource effects are still separate evidence planes
+
+An application-defined resource matters because it eventually changes real execution. A buffer-pool miss may trigger I/O. A full queue may delay runnable work. A depleted credit may stall a request. A cache eviction may cause page faults or CPU work elsewhere.
+
+The site's earlier [async eBPF profiler report](https://eunomia.dev/research/async-ebpf-causal-profiler/) argued that causal topology must survive thread boundaries. The [page-level memory report](https://eunomia.dev/research/page-level-ebpf-memory-attribution/) argued that memory attribution needs lifetime-aware provenance. Application-resource profiling needs both ideas at once: resource identity must survive its own lifetime, and its events must be connectable to scheduler, I/O, memory, and request-level consequences.
+
+A compiler-inserted event stream can describe application semantics accurately while still missing those system-level effects. A pure system profiler can see the effects while not knowing the resource semantics. The open problem is the join.
+
+### Evaluation usually rewards the final diagnosis, not semantic-contract correctness
+
+A system can produce the correct bottleneck label for the wrong reason. If an event site is stale but correlated with the same workload phase, aggregate diagnosis may still look good.
+
+For a reusable semantic instrumentation layer, evaluation should score at least four separate properties:
+
+1. event-site precision and recall;
+2. resource-instance and lifetime identity accuracy;
+3. stale-contract detection;
+4. end-to-end diagnosis accuracy under a fixed overhead budget.
+
+Without these dimensions, it is hard to tell whether a portable profiler learned a real application resource or merely a workload-specific proxy.
+
+## Promising directions with academic and production value
+
+### 1. A versioned resource-semantics manifest compiled into eBPF attachments
+
+**Gap.** Resource discovery tools can identify candidate semantics, and eBPF can attach dynamically, but there is no common artifact connecting a semantic claim to a specific binary and probe plan.
+
+**Mechanism.** Define a compact `resource.manifest` with entries such as:
+
+```yaml
+resource: mysql.buffer_pool.page
+build_id: 9f2c…
+event: ACQUIRE
+site: buf_LRU_get_free_block+0x1a4
+instance_key: arg0
+unit_key: retval
+generation: allocation_epoch
+confidence: validated
+```
+
+The real schema should also encode resource class, units/capacity, optional `target_id`, expected lifetime transitions, symbol/offset provenance, and the evidence used to derive the descriptor.
+
+A loader resolves the manifest against the target build. Many sites can share one `uprobe_multi` program; attach cookies index the per-site descriptor. USDT sites can use the same semantic descriptor while libbpf handles their argument locations. BPF maps store only the compact state needed to turn raw arguments into stable `(resource_class, instance, generation)` identities.
+
+The loader rejects a build-ID mismatch by default. An operator may allow a best-effort symbol re-resolution mode, but that mode begins with degraded confidence rather than silently inheriting the old semantic status.
+
+**Delta.** Existing semantic profilers discover and instrument events; existing eBPF loaders dynamically attach programs. The new object is a versioned boundary between the two, so resource semantics can be regenerated, audited, distributed, attached, and revoked independently from the application binary.
+
+**Artifact.** A manifest compiler, libbpf loader, reusable BPF event program, and a small analyzer that emits the four canonical resource events with generation-scoped identity.
+
+**Evaluation.** Build manifests for MySQL, PostgreSQL, Apache, and one runtime-heavy application such as llama.cpp. Compare manifest attach coverage and event correctness with compiler-inserted instrumentation and with manually written USDT/user-events probes. Measure load time, event overhead, probe count, and event-site precision/recall.
+
+**Academic value.** This asks whether application semantics can become a versioned interface between program analysis and dynamic instrumentation rather than being embedded in one profiler implementation.
+
+**Production value.** A fleet can deploy resource-aware profiling to existing binaries and can roll semantic descriptors forward or back without rebuilding the target application.
+
+**Failure condition.** If realistic resource events cannot be represented without arbitrary per-application BPF code, the manifest is only a thin configuration wrapper and does not provide a useful abstraction.
+
+### 2. Runtime semantic validation with explicit confidence loss
+
+**Gap.** A dynamically attached probe can continue firing after its meaning changes. Existing attach success and event counts cannot distinguish a real pathology from a stale semantic model.
+
+**Mechanism.** Compile validation invariants alongside each manifest entry. Examples include:
+
+- an acquired instance should belong to an active resource generation;
+- a released unit should not remain in the active ownership set;
+- a `USE` event should usually refer to an instance previously acquired or otherwise declared externally owned;
+- instance keys should not be reused across overlapping generations;
+- value distributions and transition ratios should stay within broad training envelopes, with envelopes used only as warning evidence rather than correctness proof.
+
+BPF maps maintain the bounded online state needed for these checks. Violations increment typed counters and optionally emit compact samples through the ring buffer. The userspace controller turns repeated violations into a confidence transition such as `validated -> suspect -> stale`.
+
+The important design choice is **not** to mutate the semantic definition automatically when a violation appears. Runtime evidence says the current contract no longer explains execution; it does not tell us the correct replacement. A new static/LLM analysis or human review must produce the next candidate manifest.
+
+Because the same eBPF program can also observe scheduler, block-I/O, page-fault, and process events, the validator can ask whether a resource event has the cross-layer consequence its model predicts. That makes eBPF more than a transport: it is an independent runtime checker spanning application and OS boundaries.
+
+**Delta.** gigiprofiler already uses post-profiling validation to remove false event candidates. The proposed mechanism promotes that idea into a persistent, versioned health state for each deployed semantic descriptor and combines it with independent OS evidence.
+
+**Artifact.** A BPF validation library plus a controller that records per-descriptor confidence, evidence counts, and the exact invariant that failed.
+
+**Evaluation.** Create version mutations that preserve symbols while changing semantics: borrowed versus owned returns, changed queue capacity units, handle reuse, moved release paths, inlined or split functions, and changed resource ownership. Measure stale-model detection latency, false alarms, and how often the system avoids a wrong diagnosis compared with an attach-only baseline.
+
+**Academic value.** The general systems problem is how to validate inferred semantic instrumentation against a running program without assuming that successful observation implies semantic correctness.
+
+**Production value.** Operators get a visible distinction between “resource contention observed” and “the profiler's model of this resource is no longer trustworthy.”
+
+**Failure condition.** If useful invariants require so much per-resource state that they erase eBPF's deployment/overhead advantage, validation belongs in a heavier application-specific runtime instead.
+
+### 3. A mutation benchmark for semantic profiling
+
+**Gap.** Existing profiler evaluations rarely separate event correctness from diagnosis correctness, and they rarely test how semantic instrumentation survives software evolution.
+
+**Mechanism.** Build a ground-truth benchmark around real application resources. For each resource, define a correct event/lifetime trace and then introduce controlled mutations:
+
+- rename or move the operator function;
+- preserve the symbol but change ownership semantics;
+- change the unit from objects to bytes;
+- reuse handles after destruction;
+- add an asynchronous handoff before `USE`;
+- create a system-level side effect, such as I/O or scheduler delay, that is caused by one resource event but appears on another thread.
+
+Run four instrumentation strategies against the same workload: compiler-inserted semantic events, explicit `user_events`/USDT, versioned eBPF manifests, and system-only tracing. The benchmark scores event-site accuracy, lifetime identity, stale-model detection, cross-layer causal attribution, final diagnosis, and overhead.
+
+**Delta.** A normal benchmark asks whether a profiler finds known bugs. This one asks whether the profiler knows when its semantic assumptions have stopped matching the program.
+
+**Artifact.** A reproducible suite of application versions, workload generators, ground-truth event traces, and scoring scripts. It can begin with a small set of MySQL buffer-pool mutations and then expand to queues, caches, connection pools, and runtime schedulers.
+
+**Evaluation.** The benchmark is itself the evaluation artifact. Report per-mutation confusion matrices and confidence calibration, not only aggregate diagnosis accuracy.
+
+**Academic value.** It creates a measurable target for semantic observability under software evolution, a property current profiling benchmarks largely hide.
+
+**Production value.** Teams can test whether an observability rule survives a release before rolling it across a fleet.
+
+**Failure condition.** If the benchmark's mutations do not predict failures seen across real version upgrades, it becomes a synthetic stale-probe test rather than a useful semantic-profiler benchmark.
+
+## What would change this conclusion?
+
+The strongest conclusion here is deliberately narrower than “eBPF should replace source instrumentation.” It should not.
+
+If an application already exports stable, well-versioned `user_events`, USDT probes, metrics, or tracing spans with explicit resource identities and lifetimes, those interfaces are better semantic sources than reverse-engineering raw function calls. eBPF can still correlate them with OS effects, but it does not need to rediscover semantics the application already publishes.
+
+The proposed eBPF layer is most valuable when three conditions hold together:
+
+1. the application-defined resource materially controls performance;
+2. the running binary does not expose a sufficient stable semantic interface;
+3. operators need dynamic attachment and independent system-level correlation without rebuilding the application.
+
+A decisive experiment would compare the versioned eBPF manifest against gigiprofiler's compiler instrumentation across several real software upgrades. If the eBPF path has lower semantic precision, fails to detect stale contracts, or costs similar engineering effort while providing no better cross-layer diagnosis, then compile-time or source-defined instrumentation is the better design.
+
+But if a small semantic manifest can survive deployment boundaries while eBPF verifies its assumptions against real execution, application-defined resources become something system observability can reason about without pretending that a pointer or a function name is the resource itself.

--- a/docs/research/ebpf-application-resource-semantics.md
+++ b/docs/research/ebpf-application-resource-semantics.md
@@ -30,7 +30,7 @@ This is strong evidence that application-resource semantics are both useful and 
 
 This report argues for a **versioned application-resource contract consumed by eBPF**. Static analysis, an LLM, developer annotations, or existing USDT/user-events metadata may propose resource semantics. eBPF then becomes the deployment and validation substrate: attach to existing binaries, carry a typed descriptor into each probe, correlate resource events with scheduler/I/O/memory effects, and explicitly downgrade confidence when the observed runtime no longer satisfies the descriptor.
 
-That makes this report eBPF-centered. The target property is not merely “trace four events.” It is **dynamic, no-rebuild semantic instrumentation plus cross-boundary validation against the running system**. If eBPF cannot provide that property more reliably than compile-time instrumentation, the proposed direction should fail.
+The target property is not merely “trace four events.” It is **dynamic, no-rebuild semantic instrumentation plus cross-boundary validation against the running system**. If eBPF cannot provide that property more reliably than compile-time instrumentation, the proposed direction should fail.
 
 ## What current systems already give us
 

--- a/docs/research/ebpf-application-resource-semantics.zh.md
+++ b/docs/research/ebpf-application-resource-semantics.zh.md
@@ -30,7 +30,7 @@ OSDI 2026 的 [Diagnosing Performance Issues in Application-Defined Resources](h
 
 本文主张建立一个**由 eBPF 消费的 versioned application-resource contract**。静态分析、LLM、开发者 annotation，或者已有的 USDT/user_events 都可以提出资源语义；eBPF 负责部署与验证：动态挂到现有二进制、把类型化描述传到探针、把资源事件与 scheduler/I/O/memory 等系统效果关联起来，并在真实运行已经不符合描述时明确降低 confidence。
 
-因此这是一篇 eBPF-centered report。目标不是简单地“用 eBPF 采四类事件”，而是实现一种**不重编应用的动态语义插桩，以及跨应用/OS 边界的独立运行时校验**。如果 eBPF 做不到这个性质，或者还不如编译期插桩可靠，这条方向就应该失败。
+目标不是简单地“用 eBPF 采四类事件”，而是实现一种**不重编应用的动态语义插桩，以及跨应用/OS 边界的独立运行时校验**。如果 eBPF 做不到这个性质，或者还不如编译期插桩可靠，这条方向就应该失败。
 
 ## 现有系统已经给了我们什么
 

--- a/docs/research/ebpf-application-resource-semantics.zh.md
+++ b/docs/research/ebpf-application-resource-semantics.zh.md
@@ -1,0 +1,217 @@
+---
+date: 2026-08-21
+title: "eBPF 能理解应用自己定义的资源吗？"
+description: "eBPF 可以在不重建应用的情况下追踪内部池、队列与缓存，但原始探针并不知道这些对象的语义。本文提出带版本和运行时校验的资源契约。"
+tags:
+  - 每日报告
+  - eBPF
+  - 性能分析
+  - 可观测性
+  - Uprobe
+  - USDT
+research_question: "eBPF profiler 怎样在不把应用语义硬编码成过期探针的前提下，追踪应用自定义资源，并保留资源身份、生命周期与跨系统层的真实影响？"
+source_cutoff: 2026-08-21
+status: daily-report
+---
+
+# eBPF 能理解应用自己定义的资源吗？
+
+MySQL 的 buffer pool 可能已经塞满了不该留下的页面，但 Linux 看到的进程内存仍然完全正常。一个 work queue 可能已经过载，CPU utilization 却并不高。query cache、connection pool、token bucket、临时表或者应用内部的 credit，都可能直接决定请求为什么变慢，却都不是操作系统原生认识的资源。
+
+这正是系统 profiler 很容易踩到的边界：eBPF 很擅长观察**代码和操作系统实际做了什么**，但它不会自动知道**一个应用对象到底代表什么**。
+
+<!-- more -->
+
+OSDI 2026 的 [Diagnosing Performance Issues in Application-Defined Resources](https://www.usenix.org/conference/osdi26/presentation/hu-yigong) 把这个可见性缺口量化得很清楚。论文从 45 个真实性能问题中整理出 38 种不同的 application-defined resource，并把很多资源交互压缩成四类语义事件：`WAIT`、`ACQUIRE`、`USE` 和 `RELEASE`。它实现的 gigiprofiler 用 LLM 找语义候选，再用静态分析验证，通过 LLVM pass 插入探针，最后根据运行时证据诊断 15 个复现问题，还找到了两个后来被 MariaDB 开发者确认的新 bug。
+
+这篇论文同时给动态 profiler 一个很重要的警告。它的实验里，单独依赖 LLM 找资源事件时 false positive 高达 45–60%。静态验证会进一步提高精度，post-profiling validation 还能继续去掉错误候选；但在对 MySQL buffer pool 做穷举检查时，最终 pipeline 平均仍漏掉大约 23% 的 usage event。九个可以做端到端性能比较的 case 里，运行时 overhead 平均 3.7%，最高 7.8%。
+
+这些结果说明两件事：应用资源语义非常有价值，而且一定会出错。于是问题可以进一步收窄成一个 eBPF 研究问题：**能不能把“资源语义”与“插桩机制”分开，让语义作为一个可版本化契约，再由 eBPF 在运行时持续检查这个契约是否还成立？**
+
+本文主张建立一个**由 eBPF 消费的 versioned application-resource contract**。静态分析、LLM、开发者 annotation，或者已有的 USDT/user_events 都可以提出资源语义；eBPF 负责部署与验证：动态挂到现有二进制、把类型化描述传到探针、把资源事件与 scheduler/I/O/memory 等系统效果关联起来，并在真实运行已经不符合描述时明确降低 confidence。
+
+因此这是一篇 eBPF-centered report。目标不是简单地“用 eBPF 采四类事件”，而是实现一种**不重编应用的动态语义插桩，以及跨应用/OS 边界的独立运行时校验**。如果 eBPF 做不到这个性质，或者还不如编译期插桩可靠，这条方向就应该失败。
+
+## 现有系统已经给了我们什么
+
+### gigiprofiler 给出了一个很有用的资源事件模型
+
+gigiprofiler 最容易复用的部分并不是某一个 detector，而是一个更简单的观察：很多完全不同的应用资源，都可以用一组小而明确的交互事件来描述。
+
+- `WAIT(resource_id, wait)`：任务走到慢 acquire path 并等待。
+- `ACQUIRE(resource_id, units)`：任务取得资源或者某种容量。
+- `USE(resource_id, use_type, target_id)`：任务真正使用资源，还可以标记关联的另一个资源。
+- `RELEASE(resource_id, units)`：资源或容量被归还。
+
+这个接口已经足够表达几类常见病理。长时间 `WAIT` 可以暴露 contention；反复 acquire/release 却没有有效 work，可能说明 policy 很低效；`ACQUIRE` 与 `RELEASE` 长期不平衡，可能暴露 unbounded growth 或 leak；某个请求长期占有资源，也可以解释为什么后续请求被迫走 slow path。
+
+关键是：这些是**语义事件**。一个函数返回 pointer，并不意味着它就是 `ACQUIRE`；一次 mutex wait，也不一定是在等待真正造成问题的应用资源。事件含义必须来自应用本身的行为。
+
+### Linux 已经有多种传输 application-level evidence 的机制
+
+Linux 本身并不缺“怎么把事件送出来”的接口。
+
+[`user_events`](https://docs.kernel.org/6.18/trace/user_events.html) 允许用户进程注册带类型的 trace event，ftrace、perf 等现有工具可以直接消费。当前接口还支持 `USER_EVENT_REG_MULTI_FORMAT`，让同一个逻辑事件名同时存在多种 format，这对 schema 会随版本变化的应用很有用。
+
+[uprobes](https://docs.kernel.org/trace/uprobetracer.html) 可以直接挂到已有 executable 或 shared library 的指定位置，而不需要应用主动写 trace event。libbpf 的 [`bpf_program__attach_uprobe_multi`](https://docs.ebpf.io/ebpf-library/libbpf/userspace/bpf_program__attach_uprobe_multi/) 可以让一个 BPF program 同时挂很多函数或 offset，并给每个 attach point 配不同 cookie；[`bpf_program__attach_usdt`](https://docs.ebpf.io/ebpf-library/libbpf/userspace/bpf_program__attach_usdt/) 则提供 USDT 对应的 attach path。
+
+BPF ring buffer 还有一个适合因果记录的性质：同一个 shared FIFO 能保留跨 CPU 的事件顺序。BPF map 则可以只保存生命周期、identity 与 join 所需要的小量状态，让用户态 analyzer 不必保留整份机器事件流。
+
+这些接口解决了**在哪观察、怎样传输状态**。它们并没有解决**pool、queue、cache entry、lease 或 credit 到底是什么**。
+
+### 动态 attach 不等于动态语义
+
+最容易出现的误判是：既然 uprobe 能动态挂函数，问题是不是已经解决了？其实这只解决了探针位置。
+
+假设版本 A 里的 `pool_get()` 每次都返回一个真正归当前请求拥有的对象。版本 B 改成某些路径返回 borrowed object，这种返回不应该计作 acquire。函数名可能没变，uprobe 仍然能成功 attach，参数也完全能读出来，但原来的**语义契约已经过期**。
+
+直接用 pointer 当 identity 同样危险。对象被销毁后，地址可能很快被新对象复用。如果 profiler 把 raw address 当成永不变化的资源 ID，它会把两个生命周期拼成一个。机器层面的 trace 可以精确到每一个地址，却在应用层得到错误结论。
+
+所以真正的问题不是 attach，而是**semantic versioning 与 runtime validation**。
+
+## 当前工作仍然薄弱的地方
+
+### 语义模型通常和一次 build 或一次分析绑在一起
+
+gigiprofiler 会针对一个 application version 做静态分析，再通过 LLVM pass 注入轻量探针。对 on-demand diagnosis 来说这是合理的，但资源模型自然会绑定到当时分析和 instrument 的代码版本。
+
+生产环境经常不满足这个假设。profiler 可能面对已经构建、打包甚至由别的团队交付的 binary；源码未必就在现场，fleet 里也可能同时跑几个不同 build。
+
+这里缺少的是一个可携带的 artifact：它应该明确写出**这个语义 claim 对哪个 build 有效、事件在哪里、resource instance 怎样从运行时值派生、生命周期怎样划分**。
+
+### 探针在语法上仍然有效，语义上却可能已经错了
+
+symbol resolve 成功、attach 成功、argument decode 成功，都只能证明 probe 能执行，不能证明它仍然代表 `ACQUIRE`、`USE`、`WAIT` 或 `RELEASE`。
+
+生产 profiler 因此需要 semantic health signal。比如一个 `ACQUIRE` descriptor 说返回对象之后应该进入 `USE`，新版本却出现成千上万个从来没有被使用或释放的 acquisition。collector 不应该直接宣布“发现资源 leak”。更合理的状态可能是“model stale”。
+
+### application-resource effect 与 system effect 仍然是两套证据
+
+应用资源之所以影响性能，是因为它最后一定改变真实执行。buffer-pool miss 会带来 I/O，满队列会推迟 runnable work，credit 用完会让请求 stall，cache eviction 会把别的线程推到 page fault 或额外 CPU work 上。
+
+站点之前的 [异步 eBPF profiler 报告](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/) 已经讨论过 causal topology 怎样跨线程保持；[逐页内存归因报告](https://eunomia.dev/zh/research/page-level-ebpf-memory-attribution/) 则讨论了 lifetime-aware provenance。application-resource profiling 实际上需要两者一起成立：资源自己要有正确的 lifetime identity，它造成的效果还要能 join 到 scheduler、I/O、memory 和 request。
+
+编译期插进去的 event stream 可以很准确地讲应用语义，却可能看不到这些系统效果；纯 system profiler 能看到效果，却不知道应用资源是什么。真正开放的问题是怎样把两者连起来。
+
+### 评测往往只奖励最终 diagnosis，不评 semantic contract 本身
+
+一个系统可能因为错误的 probe 仍然和某个 workload phase 高度相关，于是最后碰巧给出正确 bottleneck label。只看 diagnosis accuracy 会把这种问题隐藏起来。
+
+如果要做可复用的 semantic instrumentation layer，至少应该分开评四件事：
+
+1. event-site precision / recall；
+2. resource instance 与 lifetime identity accuracy；
+3. stale-contract detection；
+4. 固定 overhead budget 下的端到端 diagnosis accuracy。
+
+没有这些维度，很难判断 profiler 真正理解了 application resource，还是只学会一个 workload-specific proxy。
+
+## 值得继续做的研究与生产方向
+
+### 1. 把 versioned resource-semantics manifest 编译成 eBPF attach plan
+
+**Gap。** 资源发现工具可以给出 candidate semantics，eBPF 可以动态 attach，但缺少一个把 semantic claim、目标 binary 与具体 probe plan 连起来的公共 artifact。
+
+**Mechanism。** 定义一个小型 `resource.manifest`，例如：
+
+```yaml
+resource: mysql.buffer_pool.page
+build_id: 9f2c…
+event: ACQUIRE
+site: buf_LRU_get_free_block+0x1a4
+instance_key: arg0
+unit_key: retval
+generation: allocation_epoch
+confidence: validated
+```
+
+真正 schema 还应该包含 resource class、units/capacity、可选 `target_id`、预期 lifetime transition、symbol/offset provenance，以及这个 descriptor 是根据什么证据生成的。
+
+loader 先把 manifest 与目标 build 对齐。大量 site 可以共用一个 `uprobe_multi` program，用 attach cookie 索引不同 descriptor；USDT site 也可以沿用同一份 semantic descriptor，只把 argument decode 交给 libbpf。BPF map 只保存从 raw argument 推导 `(resource_class, instance, generation)` 所需的 compact state。
+
+默认情况下，build-ID 不匹配就拒绝加载。也可以提供 best-effort symbol re-resolution，但这个模式应该从 degraded confidence 开始，而不是把旧版本的“validated”状态无条件继承过去。
+
+**Delta。** 现有 semantic profiler 会发现并 instrument event，eBPF loader 会动态挂 program。新对象把两者拆开，让资源语义本身可以独立生成、审计、分发、attach、撤销和版本化。
+
+**Artifact。** manifest compiler、libbpf loader、可复用的 BPF resource-event program，以及把四类事件输出成 generation-scoped identity 的小型 analyzer。
+
+**Evaluation。** 给 MySQL、PostgreSQL、Apache，再加一个类似 llama.cpp 的 runtime-heavy application 建 manifest。与 compiler-inserted instrumentation、手写 USDT/user_events 比较 attach coverage 与 event correctness，同时测 load time、event overhead、probe 数和 event-site precision/recall。
+
+**Academic value。** 核心问题是：application semantics 能不能成为 program analysis 与 dynamic instrumentation 之间可版本化的接口，而不是永远埋在某一个 profiler 里。
+
+**Production value。** fleet 可以直接给现有 binary 部署 resource-aware profiling，也可以单独升级或 rollback semantic descriptor，而不用重建目标应用。
+
+**Failure condition。** 如果真实资源事件必须写大量 per-application BPF 特例才能表达，这个 manifest 就只是一层 config wrapper，不构成有效抽象。
+
+### 2. 带显式 confidence loss 的运行时语义校验
+
+**Gap。** 动态 attach 的 probe 在语义变化后仍然可能一直 firing。attach success 与 event count 都无法区分真实 pathology 和 stale model。
+
+**Mechanism。** 每个 manifest entry 同时编译一组 validation invariant，例如：
+
+- acquire 的 instance 必须属于当前 active resource generation；
+- release 后的 unit 不应该继续留在 active ownership set；
+- `USE` 通常应该指向之前 acquire 的 instance，或者被明确声明为 externally owned；
+- 同一个 instance key 不应该在两个重叠 generation 里被复用；
+- value distribution 与 transition ratio 可以和宽松的训练区间对比，但只能作为 warning evidence，不能当 correctness proof。
+
+BPF map 保存这些检查所需的有界在线状态。违反 invariant 时先增加 typed counter，必要时通过 ring buffer 送少量 sample。用户态 controller 再把持续 violation 转成 `validated -> suspect -> stale` 这样的 confidence transition。
+
+一个很重要的限制是：看到 violation **不能直接让系统自己改语义定义**。运行时证据只能证明旧 contract 已经解释不了现实，并不能告诉我们新的正确 contract 是什么。下一版 descriptor 仍然要通过新的静态/LLM 分析或人工 review 生成。
+
+同一个 eBPF 系统还能独立观察 scheduler、block-I/O、page fault 与 process event，因此 validator 可以检查某类 resource event 是否真的带来模型预测的系统效果。这让 eBPF 不只是 transport，而是横跨应用和 OS 边界的 independent checker。
+
+**Delta。** gigiprofiler 已经使用 post-profiling validation 去掉错误 event candidate。这里进一步把这个思路变成每个 deployed semantic descriptor 都有的持久、可版本化 health state，并加入独立 OS evidence。
+
+**Artifact。** 一套 BPF validation library，以及记录 per-descriptor confidence、evidence count 与具体 failed invariant 的 controller。
+
+**Evaluation。** 构造 symbol 不变但语义变化的版本 mutation：owned return 变 borrowed return、queue capacity 单位改变、handle reuse、release path 移动、函数被 inline/split、resource ownership 改变。比较 stale-model detection latency、false alarm，以及相比 attach-only baseline 能避免多少错误 diagnosis。
+
+**Academic value。** 更一般的问题是：怎样在不把“观测成功”误当成“语义正确”的情况下，用运行程序本身持续验证 inferred instrumentation。
+
+**Production value。** 运维人员能明确区分“观察到了资源 contention”和“profiler 对这个资源的模型已经不可信”。
+
+**Failure condition。** 如果有效 invariant 需要保存太多 per-resource state，最终抹掉 eBPF 的部署与 overhead 优势，那么这类验证应该留给更重的 application-specific runtime。
+
+### 3. 面向 semantic profiling 的 mutation benchmark
+
+**Gap。** 现有 profiler 评测很少把 event correctness 与 diagnosis correctness 分开，也很少检查 semantic instrumentation 在软件升级后是否仍然可靠。
+
+**Mechanism。** 围绕真实 application resource 建一套 ground-truth benchmark。每个 resource 都先定义正确的 event/lifetime trace，再做可控 mutation：
+
+- rename 或移动 operator function；
+- symbol 保留，但 ownership semantics 改变；
+- unit 从 object 改成 byte；
+- 对象销毁后复用 handle；
+- `USE` 之前增加一次 async handoff；
+- 让某个 resource event 在另一个线程上引起 I/O 或 scheduler delay。
+
+对同一个 workload 跑四种 instrumentation：compiler-inserted semantic event、显式 `user_events`/USDT、versioned eBPF manifest，以及只看系统事件的 tracing。benchmark 分别评 event-site accuracy、lifetime identity、stale-model detection、cross-layer causal attribution、final diagnosis 和 overhead。
+
+**Delta。** 普通 benchmark 问 profiler 能不能找到已知 bug；这里问的是 profiler 能不能知道**自己的语义假设什么时候已经不再匹配程序**。
+
+**Artifact。** 一组可复现 application version、workload generator、ground-truth event trace 和 scoring script。第一版可以从 MySQL buffer-pool mutation 开始，再扩展到 queue、cache、connection pool 与 runtime scheduler。
+
+**Evaluation。** benchmark 本身就是 evaluation artifact。结果应该按 mutation 给 confusion matrix 和 confidence calibration，而不是只汇总一个 diagnosis accuracy。
+
+**Academic value。** 它把“软件演进中的 semantic observability”变成一个可测性质，而这正是现有 profiling benchmark 经常隐藏的部分。
+
+**Production value。** 团队在把 observability rule 推到 fleet 之前，可以先检查它是否能撑过一次真实 release。
+
+**Failure condition。** 如果这些 mutation 与真实升级中出现的 profiler failure 没有相关性，它就只是一套 synthetic stale-probe test，而不是有价值的 semantic profiler benchmark。
+
+## 什么情况会改变这个结论？
+
+这里最强的结论并不是“eBPF 应该替代 source instrumentation”。它不应该。
+
+如果应用本身已经提供稳定、版本化良好的 `user_events`、USDT、metrics 或 tracing span，并且里面直接有 resource identity 与 lifetime，这些接口就是比 reverse-engineering function call 更好的语义来源。eBPF 仍然可以把它们与 OS effect 关联起来，但没有必要重新猜一遍应用已经公开的语义。
+
+本文提出的 eBPF layer 只有在三个条件同时成立时最有价值：
+
+1. application-defined resource 确实决定性能；
+2. 运行 binary 没有足够稳定的 semantic interface；
+3. operator 需要在不重建应用的情况下动态 attach，并独立关联 system-level evidence。
+
+最能否定本文的实验，是让 versioned eBPF manifest 与 gigiprofiler 的 compiler instrumentation 跨多个真实软件版本直接比较。如果 eBPF 路径的 semantic precision 更低、检测不出 stale contract，或者花了差不多的工程成本却没有更好的 cross-layer diagnosis，那么编译期或者 source-defined instrumentation 才是更好的设计。
+
+反过来，如果一份很小的 semantic manifest 能跨部署边界稳定存在，而 eBPF 又能用真实执行持续验证它的假设，那么 system observability 就终于可以讨论 application-defined resource，而不需要假装一个 pointer 或一个 function name 本身就是资源。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can eBPF Understand Application-Defined Resources?](https://eunomia.dev/research/ebpf-application-resource-semantics/)
+
+Internal pools, queues, caches, and credits can determine performance while remaining invisible as OS resources. This report develops a versioned resource-semantics manifest compiled into eBPF attachments, runtime confidence loss for stale contracts, and a mutation benchmark that tests semantic correctness across software upgrades.
+
 ### [Was the GPU Kernel Slow, or Did It Just Start Late?](https://eunomia.dev/research/gpu-kernel-launch-latency/)
 
 A late CUDA kernel start can come from host scheduling, runtime work, command-buffer queueing, dependencies, or device availability even when kernel execution itself is unchanged. This report develops an explicit launch-state ledger, cross-domain launch lineage, and a ground-truth benchmark for deciding which delay cause the trace actually proves.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 能理解应用自己定义的资源吗？](https://eunomia.dev/zh/research/ebpf-application-resource-semantics/)
+
+应用内部的 pool、queue、cache 和 credit 可以直接决定性能，却不一定是操作系统资源。本文提出可版本化的 resource-semantics manifest，把语义编译成 eBPF attach plan，并用运行时 confidence loss 与 mutation benchmark 检查软件升级后这些语义是否仍然可信。
+
 ### [GPU 内核是真的慢，还是只是启动晚了？](https://eunomia.dev/zh/research/gpu-kernel-launch-latency/)
 
 CUDA kernel 启动晚可能来自 host scheduling、runtime、command-buffer queueing、dependency 或 device availability，即使 kernel 本身的执行时间完全没变。本文提出带显式未知状态的 launch-state ledger、跨 host/device 的 launch lineage，以及以已知 delay source 为 ground truth 的归因 benchmark。


### PR DESCRIPTION
## Evidence

- GSC source coverage remains finalized through 2026-08-15 with `2026-08-09` absent. The valid equal-duration comparison is 2026-08-10..15 vs 2026-08-03..08: 393 vs 478 clicks, 66,510 vs 69,053 impressions, 0.591% vs 0.692% CTR, and ~9.91 vs ~9.42 average position. Full 7-day and 28-day comparisons remain unavailable rather than inferred.
- Finalized GA4 2026-08-10..16 is 970 organic sessions at ~44.95% engagement vs 991 at ~44.90% for 2026-08-03..09.
- The 2026-08-21 public-safe brief reports HTTP 200 for homepage/robots/sitemap, 682 sitemap entries, and no technical defect requiring an unrelated SEO patch.
- The OSDI 2026 application-defined-resource profiler shows that resource semantics are useful but error-prone; current Linux user_events, uprobes/USDT, libbpf multi-uprobe cookies, BPF maps, and ring buffers provide the dynamic observation substrate for a narrower eBPF research question.

## Scope

Publishes exactly one new bilingual Daily Report: `ebpf-application-resource-semantics`.

The report develops:
1. a versioned resource-semantics manifest compiled into eBPF attachment plans;
2. runtime semantic validation with explicit confidence loss for stale contracts;
3. a mutation benchmark that separately scores event correctness, lifetime identity, stale-model detection, cross-layer attribution, diagnosis, and overhead.

This is eBPF-centered because dynamic no-rebuild instrumentation and independent cross-layer runtime validation are central to the proposed property. The actual newest-ten mix before publication is 7 eBPF / 0 pure Agent / 3 adjacent; publishing this report ages an eBPF report out, so the newest ten remain 7/0/3.

Also updates both Daily Report indexes and directly coupled operating state (`daily`, `site`, `status`, `plan`, `block`, `content-series`). No unrelated technical SEO implementation change is included.

## Validation

Repository CI is authoritative. Expected checks include SEO-data validation, Daily Report/content validation, generated metadata/static export/link checks, and PR deployment-readiness. After all expected checks succeed, the complete final diff and generated output will be self-reviewed before squash merge.

## Deployment

Production target: GitHub Pages through `Deploy Static App`.

After squash merge, the exact merge commit must deploy successfully. Acceptance requires both:
- `https://eunomia.dev/research/ebpf-application-resource-semantics/`
- `https://eunomia.dev/zh/research/ebpf-application-resource-semantics/`

to expose the expected visible report, canonical URL, reciprocal `en`/`zh` hreflang plus `x-default`, Article JSON-LD, Daily Report navigation/internal links, explicit gap section, developed directions, and conclusion/falsifier boundary.

## SEO skill submodule

No pointer update. The repository remains pinned to `516e9e2dcf012506a677a749049d64c5914643e9`; the current operating plan records compatibility work required before moving to the newer upstream layout.