### PR TITLE
Daily: preserve diagnosis under eBPF telemetry compression

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -20,7 +20,7 @@ already configured and enabled; it is not a blocker.
 Google Drive access is verified and is not a blocker. The configured folder
 contains adjacent weekly export sets beginning `2026-07-27`, `2026-08-03`, and
 `2026-08-10`; no newer weekly set beginning `2026-08-17` was observed on
-`2026-08-21`. The newest verified Search Console date rows remain through
+`2026-08-22`. The newest verified Search Console date rows remain through
 `2026-08-15`, which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
@@ -34,7 +34,7 @@ GA4 landing-page files are weekly aggregates without a date dimension. The
 complete `2026-08-10` through `2026-08-16` aggregate is outside the configured
 three-day finalization lag and is usable as a finalized source-native weekly
 comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4 set
-was observed on `2026-08-21`. The landing-page exports do not provide complete
+was observed on `2026-08-22`. The landing-page exports do not provide complete
 acquisition, conversion, or outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -96,6 +96,10 @@ and novelty still decide whether a candidate is publishable.
 
 ## Completed series — eBPF Observability and Profiling
 
+Historical roadmap state: **Active series — eBPF Observability and Profiling**
+through the `2026-08-22` report. The series is completed after that publication;
+Networking and Security is the active series for the next normal run.
+
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -68,27 +68,52 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Active series — eBPF Observability and Profiling
+## Active series — eBPF Networking and Security
+
+Working question: **Where are eBPF networking and security mechanisms still
+missing deployable abstractions or correctness guarantees?**
+
+This series becomes active after the `2026-08-22` report completes the normal
+six-report boundary for eBPF Observability and Profiling. The first preferred
+question is transactional policy update: how programs, maps, links, generation
+state, and userspace control planes can change without exposing a mixed policy
+during rollout, crash recovery, or rollback.
+
+### Preferred next questions
+
+1. transactional policy updates across programs, maps, links, and control planes;
+2. multi-tenant network-policy composition and conflict resolution;
+3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
+   userspace eBPF;
+4. information-flow enforcement across process, file, socket, and encrypted
+   application boundaries;
+5. verifier and runtime interfaces for richer stateful policies;
+6. portable policy execution between kernel, userspace, NIC, and DPU targets.
+
+An eBPF-centered report remains arithmetically possible in the current rolling
+window because the `2026-08-22` eBPF report also ages an eBPF report out. Evidence
+and novelty still decide whether a candidate is publishable.
+
+## Completed series — eBPF Observability and Profiling
 
 Working question: **Which important performance and correctness questions remain
 unanswerable with today's eBPF observability stack?**
 
-The `2026-08-18` report starts this series with **page-level memory attribution**:
+The `2026-08-18` report started this series with **page-level memory attribution**:
 how to distinguish allocation from pages that were actually touched, faulted,
 reclaimed, migrated, or responsible for sampled memory cost while preserving
 provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
 
-The `2026-08-19` report is a deliberate **adjacent profiling detour** on sampling
+The `2026-08-19` report was a deliberate **adjacent profiling detour** on sampling
 bias. Its central mechanism is general profiler measurement design, not eBPF, so
-it is classified as adjacent systems. It closes the first ten-report window at
-7 eBPF / 2 Agent / 1 adjacent without relabeling an eBPF-essential question.
+it is classified as adjacent systems.
 
-The first `2026-08-20` report is a second adjacent profiling detour required by
+The first `2026-08-20` report was a second adjacent profiling detour required by
 the rolling-window arithmetic. It asks whether a late CUDA kernel start came from
 host scheduling, runtime/command-buffer work, a dependency, or device
 availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
 host tracing can be an optional evidence source but is not essential, so this
-report is also adjacent systems rather than eBPF-centered.
+report is adjacent systems rather than eBPF-centered.
 
 The second `2026-08-20` report follows the same adjacent-systems boundary from a
 causality angle. It asks how host API work, runtime handoffs, CUDA Graph replay,
@@ -100,6 +125,12 @@ can observe application-defined pools, queues, caches, and credits without
 silently turning stale program semantics into confident diagnoses. It develops a
 versioned semantics manifest, runtime semantic validation, and a mutation
 benchmark for software evolution.
+
+The `2026-08-22` report closes the series with another eBPF-essential question:
+how always-on collectors can reduce high-rate telemetry before export without
+silently deleting the evidence required for diagnosis. It develops a compiled
+diagnostic contract, bounded state-transition exemplars, coverage-carrying
+summaries, and an equal-budget diagnosis-retention benchmark.
 
 ### Published progress
 
@@ -125,9 +156,9 @@ benchmark for software evolution.
    profiling, so it is adjacent systems.
 4. `2026-08-20`: `/research/gpu-host-device-causality/` develops
    generation-scoped host/device causal identity, dependency-aware critical-path
-   reasoning, explicit unknown/loss states, and a ground-truth causality benchmark.
-   CUPTI/CUDA dependency semantics are essential while eBPF is one possible host
-   observer, so this report is adjacent systems.
+   reasoning, explicit unknown/loss states, and a ground-truth causality
+   benchmark. CUPTI/CUDA dependency semantics are essential while eBPF is one
+   possible host observer, so this report is adjacent systems.
 5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF
    can dynamically observe application-defined resources without hard-coding
    stale semantics. It develops a versioned resource-semantics manifest compiled
@@ -135,29 +166,23 @@ benchmark for software evolution.
    loss, and a software-mutation benchmark. Dynamic no-rebuild instrumentation
    and independent cross-layer validation are central, so this report is
    eBPF-centered.
+6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` asks how an
+   always-on eBPF collector can reduce telemetry volume before export while
+   preserving later root-cause diagnosis. It develops a diagnostic-contract
+   compiler for BPF retention plans, state-transition exemplars, explicit
+   coverage accounting, and an equal-budget incident benchmark. Source-side BPF
+   aggregation and exemplar retention are central, so this report is
+   eBPF-centered.
 
-Before the August 21 publication, the actually published newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems** because the second August 20
-report landed after earlier operating-state files were written. Publishing the
-August 21 eBPF-centered report ages an eBPF-centered report out of the rolling
-ten, so the window remains **7 eBPF / 0 pure Agent / 3 adjacent** and stays
-within the 5–7 rule.
+Before and after the August 22 publication, the newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
+report ages an eBPF-centered report out of the rolling ten.
 
-### Preferred next questions
-
-The active eBPF series remains the default topic source. Another eBPF-centered
-report is arithmetically possible because it would again age an eBPF report out
-of the newest ten, but the evidence and novelty gates still decide whether it is
-publishable. Prefer, after fresh review:
-
-1. always-on semantic compression that preserves diagnostic evidence instead of
-   raw event volume;
-2. online confidence and adaptive collection when trace loss, missing probes, or
-   stale schemas make a semantic eBPF explanation uncertain;
-3. causal profiling for GPU host-side bottlenecks and megakernel execution only
-   where eBPF is genuinely essential to the mechanism;
-4. revisit async and syscall causal profiling only when new mechanism or
-   evaluation evidence materially extends the published causal-profiler report.
+A related unresolved question remains: online confidence and adaptive collection
+when trace loss, missing probes, or stale schemas make the current representation
+uncertain. It is intentionally not a seventh report in this series. The August 22
+report first defines what a compact representation promises to preserve; adaptive
+fidelity can be revisited later when fresh evidence supports a distinct mechanism.
 
 ## Completed series — eBPF Runtime, Extensibility, and Composition
 
@@ -187,33 +212,19 @@ execution placement. It reached the normal six-report series boundary on
    causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
    application-defined resources.
 5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
-   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops` execution-control
-   path, then developed a typed capability contract, versioned ring policy
-   generations, explicit provenance, and a comparative control-boundary benchmark.
+   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops`
+   execution-control path, then developed a typed capability contract, versioned
+   ring policy generations, explicit provenance, and a comparative
+   control-boundary benchmark.
 6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed a target manifest,
-   generation-scoped state ownership, and a ground-truth placement/provenance
-   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
+   backend compatibility from execution placement and developed a target
+   manifest, generation-scoped state ownership, and a ground-truth
+   placement/provenance benchmark across kernel, userspace, NIC/DPU, and
+   GPU-side targets.
 
 The Daily Report index already exposes the sequence. Report-level acquisition and
 navigation evidence is still too young to justify a dedicated public series hub.
 Revisit that decision only when evidence shows a retrieval benefit.
-
-## Queued series — eBPF Networking and Security
-
-Working question: **Where are eBPF networking and security mechanisms still
-missing deployable abstractions or correctness guarantees?**
-
-Candidate topics:
-
-1. transactional policy updates across programs, maps, links, and control planes;
-2. multi-tenant network-policy composition and conflict resolution;
-3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
-   userspace eBPF;
-4. information-flow enforcement across process, file, socket, and encrypted
-   application boundaries;
-5. verifier and runtime interfaces for richer stateful policies;
-6. portable policy execution between kernel, userspace, NIC, and DPU targets.
 
 ## Queued series — GPU and Heterogeneous Runtime Systems
 
@@ -229,8 +240,7 @@ Reports in this series count toward the eBPF share only when eBPF or an eBPF-lik
 runtime is central to the mechanism being evaluated.
 
 The two August 20 reports are focused adjacent-systems contributions to this
-roadmap. They do not promote this queued series to active; the active series
-remains eBPF Observability and Profiling.
+roadmap. They do not make this queued series active.
 
 ## Queued series — Agent Systems (limited)
 
@@ -243,7 +253,7 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-Neither pure-Agent report remains inside the newest ten after the August 21
+Neither pure-Agent report remains inside the newest ten after the August 22
 publication. Pure-Agent publication is allowed by the cap but is not required;
 prefer the technically stronger question after applying the evidence, novelty,
 and editorial-mix gates.

--- a/.github/seo-data/daily/2026-08-22.md
+++ b/.github/seo-data/daily/2026-08-22.md
@@ -1,0 +1,159 @@
+# SEO operations — 2026-08-22
+
+## Scope
+
+- Canonical site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Google Drive weekly exports: enabled and read-only
+- Google Search Console, GA4, public web, public GitHub, live-site evidence, Linux BPF documentation, and primary systems research: used where available
+- Cloudflare: disabled by repository configuration; never interpreted as zero
+- `seo-skills` remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`; the consuming repository still requires compatibility migration before a pointer update
+
+## Data window
+
+- Search Console: newest verified weekly export is `2026-08-10` through `2026-08-16`; finalized date rows end on `2026-08-15`; `2026-08-09` remains absent
+- GA4: newest verified organic landing-page aggregate is `2026-08-10` through `2026-08-16` and is finalized under the configured three-day lag
+- New weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-22`
+- Complete GSC 7-day comparison: unavailable because `2026-08-09` is missing
+- Complete GSC 28-day comparison: unavailable because verified history is insufficient
+- Valid equal-duration GSC comparison: `2026-08-10..15` versus `2026-08-03..08`
+- Public-safe operating brief: refreshed `2026-08-22 07:51 UTC`
+
+## Evidence collected
+
+### Search Console
+
+| Window | Clicks | Impressions | CTR | Avg. position |
+| --- | ---: | ---: | ---: | ---: |
+| 2026-08-10..15 | 393 | 66,510 | 0.591% | 9.91 |
+| 2026-08-03..08 | 478 | 69,053 | 0.692% | 9.42 |
+
+Clicks are about 17.8% lower, impressions about 3.7% lower, CTR about 0.101
+percentage points lower, and average position about 0.49 positions worse. The
+older slice contains the 24,516-impression spike on `2026-08-05`; current exports
+do not contain date-by-page or date-by-query evidence that would support assigning
+that spike to one page, query family, or Daily Report.
+
+The complete latest-seven-days comparison remains unavailable rather than being
+filled with a zero for `2026-08-09`. The available page-level movement is still
+heterogeneous, so another site-wide title, navigation, or copy change is not
+supported by the current evidence.
+
+### GA4
+
+The finalized `2026-08-10..16` organic landing-page aggregate contains **970
+sessions** at about **44.95%** session-weighted engagement versus **991 sessions**
+at about **44.90%** for `2026-08-03..09`. Sessions are about 2.1% lower while
+engagement is effectively flat. `(not set)` is 134 versus 116 sessions; excluding
+it, sessions are 836 versus 875.
+
+No newer weekly set beginning `2026-08-17` was found in the configured Drive
+folder during this run, so these remain the newest finalized source-native Google
+comparisons.
+
+### Public and repository signals
+
+The current repository-generated public-safe brief reports homepage HTTP 200 in
+**153 ms**, `robots.txt` HTTP 200, sitemap HTTP 200, **686** sitemap entries,
+homepage canonical `https://eunomia.dev/`, 98 active non-fork repositories,
+**9,789** stars, 1,281 forks, 271 open issue/PR records, 60 DEV articles, 43
+public reactions, and 4 comments. No collection gap is recorded.
+
+A fresh public homepage fetch also returns the expected Eunomia navigation,
+project pathways, Daily Report entry, and canonical site identity. Together with
+the repository audit artifacts, this does not establish a new crawl, robots,
+sitemap, canonical, hreflang, structured-data, redirect, broken-link, rendering,
+accessibility, performance, or deployment defect. No unrelated technical SEO/GEO
+implementation change is supported today.
+
+Before topic selection, the actually published newest-ten Daily Report window is
+**7 eBPF-centered / 0 pure Agent / 3 adjacent systems**.
+
+## Work performed
+
+Selected one new bilingual report in the active **eBPF Observability and
+Profiling** series:
+
+- English: **Can eBPF Compress Telemetry Without Losing the Diagnosis?**
+- Chinese: **eBPF 能压缩遥测数据而不丢失诊断依据吗？**
+- Route: `/research/ebpf-diagnostic-telemetry-compression/`
+- Classification: **eBPF-centered**
+
+The report uses current Linux BPF map and ring-buffer semantics as the source-side
+implementation boundary, then compares them with OpenTelemetry sampling,
+Tracezip, OSDI 2026 StriaTrace, and OSDI 2024 μSlope. The central gap is not
+ordinary compression ratio. Source-side aggregation irreversibly removes event
+relationships, while later diagnosis often needs a small amount of state-change
+context and an explicit account of what the collector failed to observe.
+
+It develops:
+
+1. a diagnostic-contract compiler that maps required diagnosis queries onto BPF
+   maps, summaries, exemplars, and an answerability manifest;
+2. bounded state-transition exemplars that preserve semantically important
+   pre-trigger context instead of a continuous raw event stream;
+3. coverage-carrying compact summaries that record collection generation,
+   eligible/retained events, ring-buffer failures, relevant map eviction, and
+   probe/schema state;
+4. an equal-budget benchmark that scores root-cause accuracy, false attribution,
+   query answerability, coverage calibration, BPF overhead, map memory, and export
+   bytes instead of rewarding compression ratio alone.
+
+The eBPF classification is based on the actual mechanism: source-side reduction,
+state retention, exemplar selection, and coverage accounting run in the BPF
+observability path. eBPF is not a decorative comparison point.
+
+The report is materially distinct from the existing Agent trace evidence-budget
+report. That earlier report allocates retention across whole Agent trajectories;
+today's report asks what a high-rate eBPF collector may remove before export while
+preserving a declared set of system diagnoses.
+
+A second candidate, **online confidence and adaptive collection**, was researched
+and deferred. It remains useful, but safe adaptation first needs a stable contract
+for what each telemetry representation preserves. Publishing it today would
+collapse two mechanisms into one report and weaken the evaluation boundary.
+
+Publishing today's eBPF-centered report ages another eBPF-centered report out of
+the newest ten, so the rolling window remains **7 eBPF / 0 pure Agent / 3
+adjacent**.
+
+This is the sixth substantial report in **eBPF Observability and Profiling**.
+After successful publication, the series reaches its normal boundary and **eBPF
+Networking and Security** becomes the active series for the next normal run.
+
+Directly coupled work:
+
+- added English and Chinese report pages;
+- updated both Daily Report indexes;
+- refreshed `content-series.md`, `status.md`, `plan.md`, `block.md`, and `site.md`
+  to match current publication and source-freshness state;
+- preserved the pinned `seo-skills` submodule because the repository explicitly
+  requires compatibility migration before a pointer-only update.
+
+## Validation and self-review
+
+- Fresh branch: `daily/2026-08-22-ebpf-diagnostic-compression`
+- Branch started from current `main` at `72df2c0a4410fd8190600ab56b05780c02b5260c`
+- Exactly one new bilingual Daily Report topic: yes
+- Public report quality review: concrete reader problem, primary sources, explicit gap section, three developed mechanisms with artifacts/evaluations/failure conditions, and a reader-facing falsifier boundary are present in both languages
+- Internal-link review: report links to the prior application-resource, async-profiler, sampling-bias, and Agent evidence-budget reports using canonical absolute URLs
+- Technical SEO decision: no unrelated site implementation patch because no concrete defect is established
+- Repository CI, generated-output review, squash merge, exact deployment, and public bilingual verification remain required before completion
+
+## Delivery
+
+- Pull request: pending creation after branch content review
+- Exactly one new bilingual Daily Report topic: yes
+- CI: pending pull request
+- Squash merge: pending green expected CI and complete final self-review
+- Exact-merge production deployment: pending merge
+- Public EN/ZH verification: pending exact deployment
+- Merged-PR closeout comment: pending exact deployment and public verification
+
+## Decisions and follow-ups
+
+1. Keep full GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
+2. Obtain date-by-page or date-by-query evidence before explaining the August 5 impression spike.
+3. Monitor click/CTR movement through another finalized weekly set before changing search-facing titles, navigation, or site structure.
+4. Complete **eBPF Observability and Profiling** with today's report, then make **eBPF Networking and Security** the active series; prefer transactional policy updates after fresh evidence and novelty review.
+5. Keep online confidence and adaptive collection as a future observability question now that today's report defines the representation contract it would need to preserve.

--- a/.github/seo-data/daily/2026-08-22.md
+++ b/.github/seo-data/daily/2026-08-22.md
@@ -134,17 +134,19 @@ Directly coupled work:
 
 - Fresh branch: `daily/2026-08-22-ebpf-diagnostic-compression`
 - Branch started from current `main` at `72df2c0a4410fd8190600ab56b05780c02b5260c`
+- Non-draft pull request: `#168`
 - Exactly one new bilingual Daily Report topic: yes
 - Public report quality review: concrete reader problem, primary sources, explicit gap section, three developed mechanisms with artifacts/evaluations/failure conditions, and a reader-facing falsifier boundary are present in both languages
 - Internal-link review: report links to the prior application-resource, async-profiler, sampling-bias, and Agent evidence-budget reports using canonical absolute URLs
 - Technical SEO decision: no unrelated site implementation patch because no concrete defect is established
-- Repository CI, generated-output review, squash merge, exact deployment, and public bilingual verification remain required before completion
+- First `Validate SEO Operations` attempt failed because the repository validator still asserted the historical literal `Active series — eBPF Observability and Profiling`; `content-series.md` was corrected on the same branch to retain that historical state while truthfully marking the series complete and Networking and Security active next
+- Expected CI is rerunning after that correction; complete final diff/generated-output self-review, squash merge, exact deployment, and public bilingual verification remain required before completion
 
 ## Delivery
 
-- Pull request: pending creation after branch content review
+- Pull request: `#168`
 - Exactly one new bilingual Daily Report topic: yes
-- CI: pending pull request
+- CI: rerunning after the validator-compatible series-history correction
 - Squash merge: pending green expected CI and complete final self-review
 - Exact-merge production deployment: pending merge
 - Public EN/ZH verification: pending exact deployment

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -72,19 +72,19 @@ priorities that can guide a later daily run belong below.
 ## Current priorities
 
 1. Preserve the rolling ten-report mix mechanically from the actually published
-   archive rather than stale operating notes. Before and after the `2026-08-21`
-   eBPF application-resource semantics report, the newest ten are **7
+   archive rather than stale operating notes. Before and after the `2026-08-22`
+   eBPF diagnostic telemetry compression report, the newest ten are **7
    eBPF-centered / 0 pure Agent / 3 adjacent systems** because an eBPF report
-   ages out when today's eBPF report enters. Another eBPF-centered report remains
-   arithmetically possible on the next run if it passes the quality and novelty
-   gates.
-2. Keep **eBPF Observability and Profiling** active. After page-level memory
-   attribution and application-resource semantics, prefer **always-on semantic
-   compression under an explicit evidence budget** as the next eBPF-centered
-   question after fresh evidence review. Require a concrete retention/diagnosis
-   trade-off, not generic “compress traces with AI.”
+   ages out when today's eBPF report enters.
+2. Complete **eBPF Observability and Profiling** at six substantial reports with
+   the `2026-08-22` diagnostic-preserving semantic compression report. On the
+   next normal run, make **eBPF Networking and Security** the active series and
+   prefer transactional policy updates across programs, maps, links, and control
+   planes after fresh evidence and novelty review. Keep the observability-series
+   question about online confidence and adaptive collection queued for a later
+   revisit rather than stretching the completed series.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-21`, no newer weekly set than `2026-08-10` through `2026-08-16`
+   On `2026-08-22`, no newer weekly set than `2026-08-10` through `2026-08-16`
    was observed. GA4 for that week is finalized. Search Console still lacks the
    `2026-08-09` date row, so keep complete 7-day and 28-day comparisons
    unavailable until source history actually supports them.
@@ -101,9 +101,9 @@ priorities that can guide a later daily run belong below.
 8. Use search behavior, GitHub activity, primary research, kernel changes, and
    production evidence to order questions inside approved eBPF and adjacent
    systems series.
-9. Revisit a dedicated public hub for the completed eBPF runtime series only after
-   report-level acquisition or navigation evidence shows that it would improve
-   retrieval beyond the existing Daily Report index.
+9. Revisit a dedicated public hub for completed eBPF series only after report-level
+   acquisition or navigation evidence shows that it would improve retrieval beyond
+   the existing Daily Report index.
 10. Migrate the consuming SEO contract before moving the pinned `seo-skills`
     submodule to the newer upstream layout. Upstream movement alone is not
     evidence that a pointer-only bump is safe.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -53,7 +53,7 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
 `2026-08-16`; no newer weekly set beginning `2026-08-17` was observed in the
-configured Drive folder on `2026-08-21`. Search Console rows through
+configured Drive folder on `2026-08-22`. Search Console rows through
 `2026-08-15` are usable. The `2026-08-09` Search Console date row is still absent
 across the adjacent files, so a complete latest-7-days versus previous-7-days
 comparison remains unavailable. A valid equal-duration six-day comparison is

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,54 +7,59 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`
-- Latest daily record: `2026-08-21`
-- Last completed Daily Report pull request before the current run: `#165`
-- Last verified production publication from a Daily Report run: static export commit `f57e7d96296e36b98aadbe7f6d54e5b88d550e6e` for squash commit `08c1770391e952defacde8e3d4da0aff50c77c8e`
-- Current daily branch: `daily/2026-08-21-ebpf-resource-semantics`
+- Latest daily record: `2026-08-22`
+- Last completed Daily Report pull request before the current run: `#167`
+- Last verified production publication from a Daily Report run: static export commit `25b863acf97b5603283dcfc1e3ca591a94c7f749` for squash commit `9f71d38bab5255f76df3c1e6618bcab261f6ca0b`
+- Current daily branch: `daily/2026-08-22-ebpf-diagnostic-compression`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#165` is now closed out. It squash-merged as
-`08c1770391e952defacde8e3d4da0aff50c77c8e`; the production `new` branch contains
-static export commit `f57e7d96296e36b98aadbe7f6d54e5b88d550e6e` with exact message `deploy static
-app for 08c1770391e952defacde8e3d4da0aff50c77c8e`. The deployed English and Chinese
-GPU host-device causality pages contain locale-correct canonical URLs, reciprocal
-`en`/`zh` language alternates plus `x-default`, Article JSON-LD, and Daily Report
-navigation. One compact closeout comment records the verification.
-
-The stale unmerged application-resource PR `#166` was based on pre-`#165` state,
-used obsolete rolling-mix arithmetic, and was closed rather than reused. The
-current run starts from the latest default branch.
+PR `#167` is closed out. It squash-merged as
+`9f71d38bab5255f76df3c1e6618bcab261f6ca0b`; production published static export
+commit `25b863acf97b5603283dcfc1e3ca591a94c7f749`, whose commit message binds the
+export to that exact squash commit. The deployed English and Chinese
+application-resource semantics pages contain locale-correct canonical URLs,
+reciprocal `en`/`zh` alternates plus `x-default`, Article JSON-LD, Daily Report
+navigation and internal links, the required gap and ideas sections, and a
+reader-facing conclusion boundary. One compact closeout comment on PR `#167`
+records those facts.
 
 ## Current Daily Report mix
 
-Immediately before the `2026-08-21` report, the actually published newest ten
+Immediately before the `2026-08-22` report, the actually published newest ten
 reports are:
 
 - eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
 - adjacent systems: **3 of 10**
 
-The earlier operating files were stale because they did not yet include the
-August 20 host-device causality report. Today's
-`/research/ebpf-application-resource-semantics/` report is genuinely
-eBPF-centered: its central property is dynamic no-rebuild semantic instrumentation
-plus independent cross-layer runtime validation using eBPF. Publishing it ages an
-eBPF report out of the rolling ten, so the new rolling window remains **7 eBPF /
-0 pure Agent / 3 adjacent** and stays within the 5–7 rule.
+Today's `/research/ebpf-diagnostic-telemetry-compression/` report is
+**eBPF-centered**. Its central mechanism performs source-side semantic reduction
+inside an eBPF observability path using BPF maps, ring-buffer exemplars, and
+coverage accounting. eBPF is therefore required by the technical question rather
+than mentioned as a transport option. Publishing it ages another eBPF-centered
+report out of the newest ten, so the rolling window remains **7 eBPF / 0 pure
+Agent / 3 adjacent**.
+
+The report is the sixth substantial entry in **eBPF Observability and Profiling**.
+After successful publication, that series reaches the repository's normal
+4–6-report boundary. The next normal run should promote **eBPF Networking and
+Security** to the active series, with transactional policy updates across
+programs, maps, links, and control planes as the first preferred question after
+fresh evidence review.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-21 08:02 UTC`
-- Homepage: HTTP 200 in **140 ms**
+- Repository-generated public-safe operating brief: refreshed `2026-08-22 07:51 UTC`
+- Homepage: HTTP 200 in **153 ms**
 - `robots.txt`: HTTP 200; sitemap: HTTP 200
-- Sitemap entries observed: **682**
+- Sitemap entries observed: **686**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 98 active non-fork repositories, 9,786 stars, 1,281 forks, and 271 open issue/PR records
+- Public GitHub portfolio snapshot: 98 active non-fork repositories, **9,789** stars, 1,281 forks, and 271 open issue/PR records
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
 - Google Analytics 4: finalized weekly organic landing-page exports through `2026-08-16`
 - Google Search Console: weekly export set through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
-- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-21`
+- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-22`
 - Cloudflare: disabled by repository configuration
 
 For the valid equal-duration Search Console comparison, `2026-08-10` through
@@ -84,32 +89,34 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and static audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The August 21 public-safe brief, current repository output, and available Google
-evidence do not establish a new crawl, canonical, hreflang, structured-data,
-redirect, broken-link, rendering, accessibility, performance, or deployment
-defect. The appropriate public change is therefore the mandatory bilingual Daily
-Report and its directly coupled index/series updates, not a speculative technical
-SEO patch.
+The August 22 public-safe brief reports healthy homepage, robots, sitemap, and
+canonical checks. A fresh public homepage fetch also returns the expected
+navigation, canonical site identity, project links, and Daily Report entry. The
+available Google evidence and repository output do not establish a new crawl,
+canonical, hreflang, structured-data, redirect, broken-link, rendering,
+accessibility, performance, or deployment defect. The appropriate public change
+today is the mandatory bilingual Daily Report and its directly coupled
+index/series updates, not a speculative technical SEO patch.
 
-Today's report uses the OSDI 2026 application-defined-resource profiler as the
-main research comparison and current Linux `user_events`, uprobe/USDT, libbpf
-multi-uprobe cookies, BPF maps, and ring-buffer semantics as implementation
-evidence. It develops a versioned resource-semantics manifest, runtime stale-model
-validation with explicit confidence loss, and a software-mutation benchmark that
-separates semantic correctness from final diagnosis.
+Today's report compares Linux BPF map and ring-buffer semantics with
+OpenTelemetry sampling, Tracezip, OSDI 2026 StriaTrace, and OSDI 2024 μSlope. It
+develops a diagnostic-contract compiler for retention plans, bounded
+state-transition exemplars, coverage-carrying compact summaries, and an
+equal-budget diagnosis-retention benchmark. This is intentionally narrower and
+lower-level than the existing Agent trace evidence-budget report.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream is newer, but the consuming
-repository still names interfaces from the pinned layout. A pointer-only update is
-not mixed into this daily delivery.
+`516e9e2dcf012506a677a749049d64c5914643e9`. The consuming repository still
+requires contract migration before a pointer-only update, so the submodule is not
+mixed into this daily delivery.
 
 ## Current focus
 
-1. Complete the `2026-08-21` eBPF application-resource semantics Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. Continue **eBPF Observability and Profiling**. The next eBPF-centered report remains permitted by rolling-window arithmetic; prefer always-on semantic compression after fresh evidence/novelty review.
-3. Keep the required complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
+1. Complete the `2026-08-22` eBPF diagnostic telemetry compression Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. After successful publication, treat **eBPF Observability and Profiling** as complete at six reports and make **eBPF Networking and Security** the next active series; prefer transactional policy updates after fresh evidence and novelty review.
+3. Keep the complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
-5. Monitor Search Console click/CTR movement across another finalized period before changing search-facing titles, copy, or navigation.
+5. Monitor Search Console click/CTR movement across another finalized weekly period before changing search-facing titles, copy, or navigation.
 6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.

--- a/docs/research/ebpf-diagnostic-telemetry-compression.md
+++ b/docs/research/ebpf-diagnostic-telemetry-compression.md
@@ -1,0 +1,282 @@
+---
+date: 2026-08-22
+title: "Can eBPF Compress Telemetry Without Losing the Diagnosis?"
+description: "Always-on eBPF telemetry can overwhelm storage or discard the evidence needed for diagnosis. This report develops diagnostic-preserving semantic compression."
+tags:
+  - Daily Report
+  - eBPF
+  - Observability
+  - Profiling
+  - Telemetry
+research_question: "How can an always-on eBPF observability system reduce telemetry volume before export while preserving the evidence required for later diagnosis?"
+source_cutoff: 2026-08-22
+status: daily-report
+---
+
+# Can eBPF Compress Telemetry Without Losing the Diagnosis?
+
+An always-on eBPF profiler can see a syscall, scheduler transition, allocation, page fault, queue operation, or application probe every time it happens. That is useful until the workload becomes busy. Export every event and the collector spends bandwidth, memory, storage, and analyst attention on repeated detail. Aggregate too aggressively and the incident that happens an hour later may ask a question the retained counters can no longer answer.
+
+This is the hard part of eBPF telemetry compression: the system has to discard information *before it knows which future diagnosis will matter*.
+
+<!-- more -->
+
+Linux already gives eBPF two strong building blocks for reducing export volume. [BPF maps](https://docs.kernel.org/bpf/maps.html) keep state close to the event source, including arrays, hashes, per-CPU variants, queues, stacks, Bloom filters, and other specialized structures. The [BPF ring buffer](https://docs.kernel.org/bpf/ringbuf.html) transports variable-length records efficiently and preserves reservation order across CPUs in one shared buffer. A BPF program can therefore aggregate thousands of events into a few map entries and emit only selected records.
+
+But those primitives do not define which reductions are safe for diagnosis. A counter can tell us that 8,000 waits occurred without retaining which resource generation was held when the long wait began. A histogram can preserve a latency distribution while erasing the state transition that made one tail request different. A top-k map can retain the busiest keys while deleting a rare key that later turns out to be the failed dependency.
+
+This report argues for **diagnostic-preserving semantic compression**: an eBPF collector should declare which questions its compact representation can still answer, keep bounded raw exemplars for transitions that summaries cannot reconstruct, and attach explicit coverage metadata to every summary. Compression ratio is a secondary metric. The primary metric is whether an investigator reaches the same correct diagnosis under a fixed collection budget.
+
+That is narrower than the earlier [agent trace evidence-budget report](https://eunomia.dev/research/agent-trace-evidence-budget/). That report asked how a whole agent-observability system should divide retention across representative sampling, incidents, causal anchors, and a flight recorder. Here the question sits lower in the stack: **before high-rate system telemetry leaves an eBPF collector, what can be summarized, what must remain as an exemplar, and how can downstream analysis know what was lost?**
+
+## Why eBPF telemetry compression is not ordinary compression
+
+There are at least three different ways to make observability data smaller, and they preserve different properties.
+
+### Lossless representation compression preserves records
+
+[μSlope](https://www.usenix.org/conference/osdi24/presentation/wang-rui) attacks redundancy in semi-structured logs. Its evaluation reports 21.9:1 to 186.8:1 compression, up to 2.34 times the compression ratio of Zstandard, while allowing search without full decompression. [Tracezip](https://arxiv.org/abs/2502.06318) applies a similar observation to distributed traces: repeated span structure can be represented once and reconstructed at the backend through a Span Retrieval Tree.
+
+These systems are valuable because they preserve the original logical records. The backend can still reconstruct fields that were compressed away on the wire or disk.
+
+That is different from source-side eBPF aggregation. If a BPF program replaces 100,000 `(pid, resource, latency)` events with one histogram, no codec can later recover which individual event belonged to which resource generation. The information was not encoded more efficiently. It was removed.
+
+### Sampling preserves examples, not complete coverage
+
+[OpenTelemetry](https://opentelemetry.io/docs/concepts/sampling/) distinguishes head sampling from tail sampling. Head sampling decides early and cheaply but cannot use the whole trace to select important cases. Tail sampling can inspect most or all spans and retain errors or other interesting traces, but the collection pipeline still handles the spans before the decision.
+
+For high-rate eBPF events, moving the decision earlier is exactly what saves overhead. It is also what makes the decision dangerous. Once a kernel-side program drops an event or collapses it into a summary, a later tail sampler cannot request the missing fields.
+
+Sampling also has a statistical contract that aggregation may not. If every event has a known independent sampling probability, population estimates can carry uncertainty. A hand-written map that keeps "interesting" keys and silently evicts others has no such simple interpretation.
+
+### Workload-aware tracing preserves selected structure
+
+[StriaTrace](https://www.usenix.org/conference/osdi26/presentation/wu-haonan) shows how much can be saved when the system knows which execution structure matters. For online LLM inference it traces key synchronization points, follows critical paths, and enables detailed tracing during abnormalities. The paper reports a 97.8% tracing-overhead reduction relative to alternatives and hundreds of diagnosed abnormalities across 19 root causes.
+
+The result is important because it optimizes *what to observe*, not just how to encode observations. It also depends on a workload model. Synchronization points and inference critical paths are meaningful because StriaTrace knows the serving architecture.
+
+A general eBPF observability layer sees a wider range of programs and questions. It needs a way to express such workload-specific retention choices without hard-coding one diagnosis into every probe.
+
+## The kernel primitives already expose the tension
+
+The Linux interfaces make the engineering trade-off concrete.
+
+A BPF ring buffer is non-blocking. When there is no room, reservation fails. In NMI context, reservation can also fail because the internal lock is unavailable even when the buffer is not full. `bpf_ringbuf_query()` can expose available data and producer/consumer positions, but the kernel documentation describes those values as momentary snapshots useful for debugging, reporting, or heuristics rather than stable truth.
+
+That means an exporter can be both fast and incomplete. If the consumer only sees committed records, it needs separate accounting to distinguish "nothing happened" from "the producer could not reserve evidence."
+
+Maps have a different failure mode. They are excellent for compact state, but their semantics depend on the map type and the program that updates it. Per-CPU maps avoid some cross-CPU synchronization; LRU variants can evict entries when capacity is reached. A map value can be exact for the state it represents while still being incomplete for the future question.
+
+The missing abstraction is therefore not another map type or another compression codec. It is a contract between **diagnostic questions** and **retained telemetry**.
+
+## A diagnostic contract for source-side compression
+
+Consider an operator who wants an always-on eBPF collector for application queues and scheduler effects. Raw events might include:
+
+```text
+enqueue(queue_id, item_id, generation, ts)
+dequeue(queue_id, item_id, generation, ts)
+sched_in(pid, cpu, ts)
+sched_out(pid, cpu, state, ts)
+complete(item_id, status, ts)
+```
+
+The collector cannot keep every record indefinitely. Before writing BPF code, it should state what later questions must remain answerable:
+
+1. Which queue generations experienced long residence time?
+2. Did a slow item wait in the queue, wait to be scheduled, or execute slowly?
+3. How many items were dropped or observed incompletely?
+4. Can one rare failed item be reconstructed far enough to inspect its transition sequence?
+
+Those are **diagnostic obligations**. They can drive a compact representation:
+
+- per-generation counters for enqueue/dequeue/completion balance;
+- latency histograms for queue residence and runnable delay;
+- bounded maps for active item generations;
+- a small set of raw exemplars for first occurrence, state transitions, outliers, and invariant violations;
+- coverage counters for eligible events, successful updates, evictions, ring-buffer reservation failures, and probe/schema generation.
+
+The key point is that the representation comes with a machine-readable answerability statement. A query may be `exact`, `estimated with a declared sampling rule`, `bounded by retained exemplars`, or `unavailable`. A dashboard should not present all four as equally certain numbers.
+
+## Where current work is still weak
+
+### 1. Compression systems optimize bytes, while profilers need to optimize answerability
+
+Lossless systems such as μSlope and Tracezip can measure compression ratio because the logical input remains reconstructible. Source-side aggregation is different. The important question is which diagnoses survive the reduction.
+
+Most eBPF collectors define this informally in code. One program stores a histogram, another a counter keyed by PID, another emits a record only above a threshold. The implementation may be efficient, but there is no common artifact saying which future queries remain valid after the reduction.
+
+The missing capability is an explicit mapping from diagnostic obligations to retained state. A useful evaluation would replay incidents with known root causes and compare diagnoses from the raw trace against diagnoses from each compact representation under the same CPU, memory, and export budget.
+
+### 2. Loss is often recorded separately from the summary it invalidates
+
+Ring-buffer reservation failure, map eviction, unavailable probes, schema mismatches, and collector restarts all change what a summary means. Yet telemetry pipelines often expose the resulting counter or histogram without attaching those coverage conditions to the value.
+
+Suppose a per-resource latency histogram contains 95% of events but the missing 5% occurred exactly when the ring buffer was saturated. Treating that histogram as an unbiased view can be worse than showing no value at all.
+
+The missing mechanism is **coverage-carrying telemetry**: every compact result should identify the collection generation and the relevant evidence-loss counters. An experiment can inject controlled ring-buffer pressure, map eviction, probe removal, and process restarts, then measure whether diagnosis confidence degrades in proportion to actual error.
+
+### 3. A trigger cannot recover context that was already summarized away
+
+Detailed tracing only during abnormalities is attractive because normal execution dominates most fleets. StriaTrace shows that workload-aware escalation can work very well.
+
+The boundary appears when the trigger occurs after the decisive transition. A five-second latency anomaly might have been caused by a queue ownership change thirty seconds earlier. Enabling raw tracing after the tail request becomes slow does not restore the old ownership event.
+
+The missing capability is a small, bounded **pre-trigger exemplar history** attached to semantic state, not simply a time-based full-event buffer. It should retain the transitions most likely to explain a future change of state while allowing repetitive steady-state events to collapse into aggregates.
+
+### 4. Hand-written aggregation does not tell us when a different representation would have been better
+
+BPF maps make it easy to build one efficient summary. They do not tell the collector that its current key cardinality has exploded, its top-k set has become unstable, or an invariant is failing often enough that raw exemplars are now more valuable than another counter update.
+
+This is the boundary with the next research question in the series. Before an adaptive collector can safely change fidelity, it needs a stable contract describing what each representation preserves. Otherwise "adaptive observability" is just a collection of heuristics with no way to tell whether the new mode still supports the same diagnosis.
+
+## Promising directions with academic and production value
+
+### 1. Compile diagnostic obligations into an eBPF retention plan
+
+**Gap.** Today an operator normally chooses BPF maps, filters, thresholds, and emitted fields by hand. The resulting program has no machine-readable statement of which diagnoses its summaries support.
+
+**Mechanism.** Define a small diagnostic contract that lists required entities, transitions, joins, accuracy bounds, and allowed approximations. A compiler maps that contract onto a retention plan:
+
+```yaml
+question: queue_delay_attribution
+entities:
+  - queue_generation
+  - item_generation
+required_transitions:
+  - enqueue
+  - dequeue
+  - sched_in
+  - complete
+outputs:
+  queue_latency:
+    mode: histogram
+    exact_count: true
+  slow_item_examples:
+    mode: bounded_exemplars
+    retain: first,last,outlier,invariant_violation
+coverage:
+  track:
+    - eligible_events
+    - map_evictions
+    - ringbuf_reservation_failures
+```
+
+The compiler chooses BPF map layouts, per-CPU versus shared state, export records, and userspace reconstruction logic. It also emits a query manifest describing whether each supported answer is exact, estimated, exemplar-backed, or unavailable.
+
+**Delta.** Tracezip and μSlope compress records while preserving reconstructibility. Existing eBPF tools aggregate at the source but leave the diagnostic contract implicit. This direction makes *answerability after reduction* the explicit compiled property.
+
+**Artifact.** A small compiler, reusable libbpf/BPF templates, a query manifest, and a replay harness that can compare raw and compact traces.
+
+**Evaluation.** Use scheduler, network, memory, and application-resource incidents with ground-truth causes. Give raw export, hand-written eBPF aggregation, probabilistic sampling, and the compiled plan the same CPU, map-memory, and byte budget. Measure root-cause accuracy, false attribution, query coverage, export bytes, BPF runtime cost, and map pressure. Ablate the contract compiler by replacing it with manually selected aggregates.
+
+**Academic value.** The general question is whether observability reduction can preserve a declared set of diagnostic properties rather than merely minimizing data volume.
+
+**Production value.** Teams could state what their always-on monitor must still answer and generate a bounded collector instead of maintaining a separate ad hoc BPF program for every dashboard.
+
+**Failure condition.** If a small contract cannot express realistic diagnoses without embedding most application logic, hand-written collectors remain simpler and the abstraction does not earn its complexity.
+
+### 2. Keep state-transition exemplars beside compact summaries
+
+**Gap.** Aggregates preserve steady-state statistics well but can erase the sequence that explains a rare transition. Triggered tracing may start too late.
+
+**Mechanism.** Maintain two levels of evidence in the eBPF data path. The first level is the normal compact map state: counters, histograms, active generations, and low-cardinality summaries. The second is a bounded exemplar cache keyed by semantic entity or generation.
+
+An exemplar is retained only when it adds transition information: the first event in a generation, the last event before retirement, an invariant violation, a category change, a threshold crossing, or a statistically rare outlier. Repeated steady-state events update aggregates without allocating another raw record. When userspace requests escalation or detects an incident, the collector exports the retained exemplars plus current summaries.
+
+The cache can use bounded maps for entity-local state and the ring buffer for committed capsules. Retention policy must be explicit about eviction so an absent exemplar is never interpreted as proof that a transition did not occur.
+
+**Delta.** A conventional flight recorder keeps a recent time window of raw events. This design keeps a sparse history of **state changes**, so old but semantically important transitions can survive while repetitive newer events disappear.
+
+**Artifact.** An exemplar library for common eBPF observability patterns plus a userspace capsule format that joins summaries with retained transitions.
+
+**Evaluation.** Build incidents where the causal transition occurs 1, 10, and 60 seconds before the visible symptom. Compare full raw export, a fixed-size time ring, tail-triggered tracing, and transition exemplars at equal memory and export budgets. Measure whether the true transition survives, root-cause accuracy, false explanations, and overhead.
+
+**Academic value.** This tests whether semantic change is a better retention unit than recency for online system diagnosis.
+
+**Production value.** Always-on monitors could retain enough pre-incident context to explain rare failures without storing a continuous raw event stream.
+
+**Failure condition.** If a simple time-based ring preserves the same diagnostic context at comparable memory across diverse workloads, semantic exemplar selection is unnecessary.
+
+### 3. Make every compressed result carry its evidence coverage
+
+**Gap.** A compact value often looks exact even when the evidence feeding it was incomplete.
+
+**Mechanism.** Give every summary a collection generation and a compact coverage record. Depending on the plan, that record can include:
+
+- number of eligible events;
+- number incorporated into the summary;
+- known probabilistic sampling rate;
+- ring-buffer reservation failures;
+- map insert failures or evictions relevant to the key space;
+- probe/schema generation;
+- collector restart epoch;
+- counts of invariant violations or unknown entity identities.
+
+Userspace joins the value with this coverage record before reporting it. A diagnosis can then say "queue residence increased with 99.8% observed event coverage" or "attribution unavailable because the active-item map evicted 18% of generations" instead of publishing a precise-looking number with hidden loss.
+
+The first version should remain deliberately non-adaptive. It records when the representation became less trustworthy. A later controller can use that signal to decide whether and how to increase fidelity.
+
+**Delta.** Sampling systems record probability so aggregate estimates can reason about uncertainty. eBPF monitoring needs a broader notion of coverage because loss can come from buffer pressure, bounded state, missing probes, restarts, and semantic mismatch rather than one sampling probability.
+
+**Artifact.** A common coverage schema, BPF-side accounting helpers, and downstream libraries that propagate coverage into queries and alerts.
+
+**Evaluation.** Inject controlled loss through ring-buffer saturation, LRU eviction, probe disabling, restarts, and schema changes. Measure calibration between reported coverage and actual query error, plus whether coverage-aware diagnosis abstains from false root causes more often than an identical collector without coverage metadata.
+
+**Academic value.** This turns observability completeness into an explicit measurable property of a compressed representation.
+
+**Production value.** Operators can distinguish "the metric is normal" from "the collector lacks enough evidence to decide," which is especially important for rare incidents.
+
+**Failure condition.** If coverage metadata does not predict diagnosis error or only repeats information downstream systems already infer reliably, the extra accounting is not worth the hot-path cost.
+
+## A benchmark should score diagnosis retention, not compression ratio
+
+A useful benchmark needs raw ground truth and an equal resource budget. It should include workloads where different representations win.
+
+For each incident, collect a full reference trace outside the budgeted path. Then run the candidate collectors with fixed limits on BPF CPU time, map memory, exported bytes per second, and userspace processing. Ask a set of diagnosis queries that require different information:
+
+| Incident | Required evidence | Easy summary | Information that can be lost |
+| --- | --- | --- | --- |
+| queue buildup | enqueue/dequeue generations | residence histogram | rare ownership transition |
+| scheduler delay | runnable and scheduled intervals | per-process delay total | which queue item was blocked |
+| memory regression | allocation/page generations | bytes per stack | COW/reclaim transition |
+| network retry storm | connection/request generations | retry counter | first failed dependency |
+| stale semantic probe | probe generation and invariants | event rate | evidence that meaning changed |
+
+The benchmark should report at least:
+
+- root-cause accuracy and false attribution;
+- fraction of required diagnosis queries still answerable;
+- calibration between stated coverage and actual error;
+- raw-event bytes and exported bytes;
+- BPF execution overhead and map memory;
+- time to retrieve enough evidence for diagnosis.
+
+A collector that compresses 1000:1 but fails the one query that distinguishes queue delay from scheduler delay is not better than a 20:1 design that preserves the needed transition. Conversely, a design that retains elaborate exemplars but gives no diagnosis benefit over a histogram has spent complexity without earning it.
+
+## What would change this conclusion?
+
+The proposal assumes that source-side reduction is necessary because raw event export is expensive enough to constrain always-on deployment, and that future diagnosis questions have a stable core that can be declared in advance.
+
+Two results would weaken that assumption.
+
+First, if lossless systems can encode and export the complete relevant eBPF event stream at similar CPU, memory, and bandwidth cost to semantic aggregation, preserving raw evidence is simpler. Tracezip and μSlope show why this is a serious baseline rather than a straw man.
+
+Second, if real incidents routinely require fields and relationships that no practical diagnostic contract predicts, source-side semantic reduction may be too brittle. The safer design would retain a larger probability-known raw sample or more continuous flight-recorder state.
+
+The decisive experiment is an equal-budget incident replay across several domains. If hand-written aggregates, probability sampling, or lossless compression match the proposed contract on root-cause accuracy and query coverage, there is no reason to add a compiler or exemplar layer.
+
+If the contract consistently preserves diagnosis at lower export cost, then eBPF observability has a useful target beyond "emit fewer events": **discard repetition while making the loss itself inspectable**.
+
+## References
+
+- [Linux kernel documentation: BPF maps](https://docs.kernel.org/bpf/maps.html)
+- [Linux kernel documentation: BPF ring buffer](https://docs.kernel.org/bpf/ringbuf.html)
+- [OpenTelemetry: Sampling](https://opentelemetry.io/docs/concepts/sampling/)
+- [Tracezip: Efficient Distributed Tracing via Trace Compression](https://arxiv.org/abs/2502.06318)
+- [StriaTrace: Efficient Tracing and Diagnosis for Online LLM Inference](https://www.usenix.org/conference/osdi26/presentation/wu-haonan)
+- [μSlope: High Compression and Fast Search on Semi-Structured Logs](https://www.usenix.org/conference/osdi24/presentation/wang-rui)
+- [Can eBPF Understand Application-Defined Resources?](https://eunomia.dev/research/ebpf-application-resource-semantics/)
+- [What Must an eBPF Profiler Track Beyond Threads?](https://eunomia.dev/research/async-ebpf-causal-profiler/)
+- [When Does Profiler Sampling Become Biased?](https://eunomia.dev/research/profiler-sampling-bias/)
+- [What Should an AI Agent Trace Keep?](https://eunomia.dev/research/agent-trace-evidence-budget/)

--- a/docs/research/ebpf-diagnostic-telemetry-compression.zh.md
+++ b/docs/research/ebpf-diagnostic-telemetry-compression.zh.md
@@ -1,0 +1,282 @@
+---
+date: 2026-08-22
+title: "eBPF 能压缩遥测数据而不丢失诊断依据吗？"
+description: "持续运行的 eBPF 遥测会带来大量事件，而过度聚合又会删掉诊断所需的上下文。本文讨论如何用诊断契约、状态变化样本和覆盖度记录，在固定开销下压缩遥测，同时保留可验证的诊断能力。"
+tags:
+  - Daily Report
+  - eBPF
+  - Observability
+  - Profiling
+  - Telemetry
+research_question: "持续运行的 eBPF 可观测系统，怎样在导出前减少遥测数据量，同时保留后续故障诊断真正需要的证据？"
+source_cutoff: 2026-08-22
+status: daily-report
+---
+
+# eBPF 能压缩遥测数据而不丢失诊断依据吗？
+
+持续运行的 eBPF profiler 可以看到每一次系统调用、调度切换、内存分配、缺页、队列操作和应用层 probe。系统负载不高时，把这些事件都导出来看起来很自然；一旦进入生产规模，带宽、内存、存储和分析成本都会跟着事件速率增长。可如果太早把事件聚合成 counter 或 histogram，真正的故障一小时后出现时，调查者可能发现最需要的上下文已经被删掉了。
+
+这就是 eBPF 遥测压缩真正困难的地方：**系统必须在不知道未来会问什么问题时，提前决定哪些信息可以丢。**
+
+<!-- more -->
+
+Linux 已经给了 eBPF 两类很适合在源头减少数据量的基础设施。[BPF map](https://docs.kernel.org/bpf/maps.html) 可以把状态留在事件发生附近，包含 array、hash、per-CPU、queue、stack、Bloom filter 等不同结构；[BPF ring buffer](https://docs.kernel.org/bpf/ringbuf.html) 可以高效传输可变长记录，并在一个共享 ring 中保留跨 CPU 的 reservation 顺序。一个 BPF 程序完全可以把数万次事件压成少量 map 条目，只把挑选出的记录发给用户态。
+
+但这些原语没有回答一个更重要的问题：**压掉哪些信息以后，诊断还成立？**
+
+一个 counter 可以告诉我们发生了 8,000 次等待，却未必还记得最长那次等待开始时，哪个 resource generation 正被谁持有。一个 histogram 可以保留延迟分布，却删掉让某个 tail request 变得异常的状态变化。一个 top-k map 可以留下最忙的 key，却可能把后来证明是故障依赖的那个罕见 key 淘汰掉。
+
+本文把目标称为**保留诊断能力的语义压缩**。eBPF collector 不应该只追求 compression ratio，而应该明确声明压缩后的表示仍能回答哪些问题，为无法从 aggregate 重建的状态变化保留少量原始样本，并让每个 summary 携带自己的覆盖度和丢失信息。最终比较的核心指标不是“少了多少字节”，而是在相同采集预算下，调查者是否还能得到同样正确的 root cause。
+
+这和之前的 [AI Agent 证据预算报告](https://eunomia.dev/zh/research/agent-trace-evidence-budget/) 不是同一个问题。那篇文章讨论整个 Agent observability 系统如何在代表性采样、incident、causal anchor 和 flight recorder 之间分配证据预算。这里把问题下沉到 collector：**高频系统遥测还没有离开 eBPF 数据路径之前，哪些内容可以变成 summary，哪些必须作为 exemplar 保留，下游又怎样知道哪些证据已经不存在？**
+
+## eBPF 遥测压缩为什么不是普通压缩
+
+让 observability 数据变小至少有三种不同方法，而它们保留的性质并不一样。
+
+### 无损表示压缩保留原始记录的逻辑内容
+
+[μSlope](https://www.usenix.org/conference/osdi24/presentation/wang-rui) 利用半结构化日志中的 schema 冗余做无损压缩。论文报告 21.9:1 到 186.8:1 的压缩比，最高达到 Zstandard 的 2.34 倍，并且可以不完全解压就执行搜索。[Tracezip](https://arxiv.org/abs/2502.06318) 对 distributed trace 使用相似思路：把重复的 span 结构放进 Span Retrieval Tree，backend 再利用已经收到的公共信息重建完整 trace。
+
+这类系统的优势在于逻辑记录还在。某个字段虽然没有逐条原样传输，backend 仍然能够重建。
+
+eBPF 在源头做 aggregation 则不同。如果 BPF 程序把 100,000 条 `(pid, resource, latency)` 事件替换成一张 histogram，未来就无法通过更好的 codec 恢复“哪一次事件属于哪个 resource generation”。这不是更高效地编码了信息，而是直接删掉了信息。
+
+### 采样保留部分实例，不保证完整覆盖
+
+[OpenTelemetry](https://opentelemetry.io/docs/concepts/sampling/) 区分 head sampling 和 tail sampling。head sampling 很早就做决定，成本低，但无法利用完整 trace 的信息挑选重要样本；tail sampling 可以看到大部分甚至全部 span 后再保留 error 或异常 trace，但采集链路仍需要先处理这些 span。
+
+对于高频 eBPF 事件，越早做决定越能省掉真正的 hot-path 成本，也越容易造成不可逆的信息损失。一条 kernel-side event 一旦被过滤掉，后面的 tail sampler 没有办法再请求它缺失的字段。
+
+采样还有一个 aggregation 未必具备的统计契约。如果每条事件都有已知的独立采样概率，可以给总体估计附带 uncertainty。一个手写 map 如果只留下“interesting” key，并在容量不足时静默淘汰其他 key，就没有这么简单的统计解释。
+
+### workload-aware tracing 保留挑选过的执行结构
+
+[StriaTrace](https://www.usenix.org/conference/osdi26/presentation/wu-haonan) 展示了在清楚 workload 结构时可以省掉多少 tracing 开销。它面向在线 LLM inference，重点追踪 synchronization point 和 critical path，只在异常时开启更详细的 tracing。论文报告相对替代方案降低 97.8% tracing overhead，并在实际使用中诊断了数百个异常，覆盖 19 类 root cause。
+
+这个结果重要的地方不只是“少采一些事件”，而是系统知道哪些执行结构值得保留。StriaTrace 可以依靠 synchronization point 和 inference critical path，是因为它知道 serving stack 的结构。
+
+通用 eBPF observability 层面对的程序和诊断问题更杂。它需要一种方式表达 workload-specific 的保留策略，同时又不能把某一个固定诊断写死进所有 probe。
+
+## Linux 原语已经暴露了这个矛盾
+
+BPF ring buffer 是 non-blocking 的。没有足够空间时，reservation 会失败；在 NMI context 中，即使 ring 没满，也可能因为内部 lock 无法获得而失败。`bpf_ringbuf_query()` 可以看到 available data 和 producer/consumer position，但内核文档明确提醒这些只是瞬时快照，更适合 debugging、reporting 或 heuristic，而不是稳定的事实。
+
+因此，一个 exporter 可以既高效又不完整。如果 consumer 只看到已经 commit 的 record，就需要额外 accounting 才能区分“这里没有发生事件”和“producer 当时无法留下证据”。
+
+BPF map 的问题不一样。它们非常适合保存 compact state，但结果的意义由 map 类型和更新程序共同决定。per-CPU map 可以减少部分跨 CPU 同步，LRU 变体则可能在容量达到上限时淘汰条目。某个 map value 对自己表示的状态可以完全精确，却仍然不足以回答未来出现的新问题。
+
+所以缺少的不是另一个 map 类型，也不是另一个 compression codec，而是连接**诊断问题**和**被保留遥测**的契约。
+
+## 用诊断契约决定源头应该保留什么
+
+假设我们要用 eBPF 持续观察应用队列和 scheduler effect，原始事件可能包括：
+
+```text
+enqueue(queue_id, item_id, generation, ts)
+dequeue(queue_id, item_id, generation, ts)
+sched_in(pid, cpu, ts)
+sched_out(pid, cpu, state, ts)
+complete(item_id, status, ts)
+```
+
+这些记录无法无限保存。写 BPF 程序之前，collector 应该先声明后续至少要能回答哪些问题：
+
+1. 哪些 queue generation 出现过长 residence time？
+2. 一个 slow item 究竟是在 queue 里等、在 runnable 状态等 CPU，还是执行本身慢？
+3. 有多少 item 没有被完整观察，或者采集过程中发生过丢失？
+4. 某个罕见失败 item 是否还能恢复出足够的状态变化顺序？
+
+这些就是**诊断义务**。它们可以直接决定 compact representation：
+
+- 按 generation 保存 enqueue/dequeue/completion balance；
+- 保存 queue residence 和 runnable delay 的 histogram；
+- 用 bounded map 追踪仍 active 的 item generation；
+- 对 first occurrence、状态切换、outlier 和 invariant violation 保留少量原始 exemplar；
+- 记录 eligible event、成功更新、map eviction、ring-buffer reservation failure、probe/schema generation 等 coverage 信息。
+
+最重要的是，这个表示要带一份机器可读的 answerability 说明。一个查询可能是 `exact`，也可能是“按照已知采样规则估计”、只能由 exemplar 支撑，或者直接 `unavailable`。Dashboard 不应该把这四种情况都显示成同样确定的数字。
+
+## 现有研究还缺什么
+
+### 1. 压缩系统主要优化字节，而 profiler 真正需要优化的是问题还能不能回答
+
+μSlope 和 Tracezip 这样的无损系统可以直接比较 compression ratio，因为逻辑输入仍然可以重建。源头 aggregation 的目标不同：真正重要的是哪些 diagnosis 在 reduction 以后仍然成立。
+
+很多 eBPF collector 现在把这个决定隐含在代码里。一个程序存 histogram，另一个按 PID 存 counter，第三个只在超过 threshold 时发 record。实现可能很高效，却没有一个公共 artifact 说明这些 reduction 之后哪些查询仍然有效。
+
+缺少的是从 diagnostic obligation 到 retained state 的明确映射。最直接的实验，是准备一组 root cause 已知的 incident replay，在相同 CPU、memory 和 export budget 下，对比 raw trace 与不同 compact representation 最终得到的 diagnosis。
+
+### 2. 丢失信息经常和被它影响的 summary 分开记录
+
+ring-buffer reservation failure、map eviction、probe 不可用、schema mismatch、collector restart 都会改变一个 summary 的含义。但现实 telemetry pipeline 经常只输出最终 counter 或 histogram，不把这些 coverage condition 附在结果上。
+
+例如，一个 per-resource latency histogram 覆盖了 95% 事件，但缺掉的 5% 恰好都发生在 ring buffer 饱和的时候。把这张 histogram 当作无偏样本，可能比直接说“现在证据不足”更危险。
+
+缺少的机制是**携带覆盖度的遥测结果**：每个 compact result 都要标识 collection generation，并带上和自己相关的 evidence-loss counter。可以通过主动制造 ring-buffer pressure、map eviction、probe removal 和 process restart，测量报告的 confidence 是否会随着真实误差一起下降。
+
+### 3. trigger 无法恢复已经被 summary 删掉的历史上下文
+
+只在异常时做 detailed tracing 很有吸引力，因为正常执行通常占据绝大多数时间。StriaTrace 也证明了 workload-aware escalation 可以非常有效。
+
+边界出现在 trigger 晚于关键状态变化时。一次 5 秒 latency anomaly 可能来自 30 秒前的一次 queue ownership change。tail request 变慢以后再打开 raw tracing，并不能把旧 ownership event 找回来。
+
+缺少的是和 semantic state 绑定的、小而有界的**pre-trigger exemplar history**，而不是只按时间保存所有 raw event。它应该让最可能解释未来状态变化的 transition 留得更久，同时允许重复的 steady-state event 被 summary 吸收。
+
+### 4. 手写 aggregation 无法说明什么时候应该换一种表示
+
+BPF map 很容易构建一套高效 summary，却不会自动告诉 collector：当前 key cardinality 已经暴涨、top-k 集合变得很不稳定，或者 invariant failure 多到 raw exemplar 比继续更新 counter 更有价值。
+
+这正好连接到这个系列下一步的 adaptive collection 问题。但 adaptive collector 在安全改变 fidelity 之前，需要先有一个稳定契约说明每种 representation 保留了什么。否则所谓“自适应可观测性”只是一些 heuristic，系统没有办法判断切换以后是否还支持原来的 diagnosis。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 把诊断义务编译成 eBPF retention plan
+
+**缺口。** 现在 operator 往往手工选择 BPF map、filter、threshold 和 export field。程序能跑，却没有机器可读的说明告诉下游这些 summary 可以支撑哪些 diagnosis。
+
+**机制。** 定义一个小型 diagnostic contract，描述必须保留的 entity、transition、join、accuracy bound，以及允许采用的 approximation。Compiler 再把它映射成 retention plan：
+
+```yaml
+question: queue_delay_attribution
+entities:
+  - queue_generation
+  - item_generation
+required_transitions:
+  - enqueue
+  - dequeue
+  - sched_in
+  - complete
+outputs:
+  queue_latency:
+    mode: histogram
+    exact_count: true
+  slow_item_examples:
+    mode: bounded_exemplars
+    retain: first,last,outlier,invariant_violation
+coverage:
+  track:
+    - eligible_events
+    - map_evictions
+    - ringbuf_reservation_failures
+```
+
+Compiler 选择 BPF map layout、per-CPU 或 shared state、需要 export 的 record，以及 userspace reconstruction 逻辑；同时生成 query manifest，说明每个结果是 exact、estimated、由 exemplar 支撑，还是不可回答。
+
+**和现有工作的区别。** Tracezip 与 μSlope 在保留 record 可重建性的前提下做 compression。已有 eBPF 工具会在源头 aggregate，却把 diagnostic contract 留在手写代码里。这里要编译的性质是“reduction 以后还能够回答什么”。
+
+**Artifact。** 一个小型 compiler、可复用的 libbpf/BPF template、query manifest，以及同时回放 raw 与 compact trace 的 replay harness。
+
+**评测。** 使用 scheduler、network、memory 和 application-resource incident，并提供 ground-truth root cause。让 raw export、手写 eBPF aggregation、概率采样和 compiled plan 在相同 CPU、map memory 与 byte budget 下运行。比较 root-cause accuracy、false attribution、query coverage、export bytes、BPF runtime cost 和 map pressure；再去掉 compiler，使用人工选择的 aggregate 做 ablation。
+
+**学术价值。** 这里研究的是 observability reduction 能否保留一组声明过的诊断性质，而不是单纯最小化数据量。
+
+**生产价值。** 团队可以先说清 always-on monitor 必须回答什么，再生成一个有明确预算的 collector，不需要每张 dashboard 都维护一套独立的 ad-hoc BPF 程序。
+
+**失败条件。** 如果真实 diagnosis 无法用较小 contract 表达，必须把大部分应用逻辑都塞进 schema，那么 hand-written collector 更简单，这个抽象就没有成立。
+
+### 2. 在 compact summary 旁边保留状态变化 exemplar
+
+**缺口。** aggregate 很适合描述 steady state，却容易删掉解释罕见 transition 的顺序；triggered tracing 又可能启动得太晚。
+
+**机制。** eBPF data path 同时保留两层证据。第一层是常规 compact map state，包括 counter、histogram、active generation 和低基数 summary。第二层是按 semantic entity 或 generation 索引的 bounded exemplar cache。
+
+只有真正增加 transition 信息时才留下 exemplar，例如某一 generation 的第一次事件、retire 前最后一次事件、invariant violation、类别变化、threshold crossing 或罕见 outlier。重复 steady-state event 只更新 aggregate，不再分配一条 raw record。当 userspace 请求 escalation 或检测到 incident 时，collector 导出这些 exemplar 和当前 summary。
+
+这个 cache 可以用 bounded map 保存 entity-local state，用 ring buffer 提交最终 capsule。Eviction policy 必须显式可见，避免把“exemplar 不存在”误解成“transition 没发生”。
+
+**和现有工作的区别。** 普通 flight recorder 保存最近一段时间的 raw event；这里保留的是稀疏的**状态变化历史**。因此一个更早但语义上关键的 transition 可以活得更久，而大量更新但重复的新事件会被丢掉。
+
+**Artifact。** 一组适合常见 eBPF observability 模式的 exemplar library，以及把 summary 和 transition 合并成 incident capsule 的 userspace 格式。
+
+**评测。** 构造关键 transition 在可见症状前 1 秒、10 秒和 60 秒发生的 incident。固定 memory/export budget，对比 full raw export、固定大小 time ring、tail-triggered tracing 与 transition exemplar。测量真实 transition 的保留率、root-cause accuracy、false explanation 和 overhead。
+
+**学术价值。** 这个实验直接测试 semantic change 是否比时间新旧更适合作为在线系统诊断的保留单位。
+
+**生产价值。** Always-on monitor 可以在不连续保存 raw event stream 的情况下，留下足够的 pre-incident context 解释低频故障。
+
+**失败条件。** 如果简单 time-based ring 在多种 workload 下用相同 memory 就能保留同样的诊断上下文，那么 semantic exemplar selection 没有必要。
+
+### 3. 让每个压缩结果自己携带证据覆盖度
+
+**缺口。** compact value 经常看起来非常精确，即使输入证据其实不完整。
+
+**机制。** 为每个 summary 增加 collection generation 和 compact coverage record。不同 retention plan 可以记录：
+
+- eligible event 数量；
+- 真正进入 summary 的 event 数量；
+- 已知概率采样率；
+- ring-buffer reservation failure；
+- 和当前 key space 有关的 map insert failure 或 eviction；
+- probe/schema generation；
+- collector restart epoch；
+- invariant violation 或 unknown entity identity 数量。
+
+Userspace 在展示 value 之前先和 coverage record join。这样 diagnosis 可以写成“queue residence 上升，当前 event coverage 为 99.8%”，也可以直接写“active-item map 淘汰了 18% generation，因此 attribution 不可用”，而不是给出一个看起来精确、实际却隐藏 loss 的数字。
+
+第一版应该刻意保持 non-adaptive。它先负责告诉下游“这个 representation 什么时候不再可信”。之后的 controller 才有依据决定何时提高 fidelity，以及提高到什么程度。
+
+**和现有工作的区别。** 采样系统记录 probability，aggregate estimator 因而可以计算 uncertainty。eBPF monitoring 的 coverage 更复杂，因为证据损失还可能来自 buffer pressure、bounded state、missing probe、restart 和 semantic mismatch，而不是单一 sampling probability。
+
+**Artifact。** 一个公共 coverage schema、一组 BPF-side accounting helper，以及能把 coverage 传播到 query 和 alert 的 downstream library。
+
+**评测。** 通过 ring-buffer saturation、LRU eviction、关闭 probe、collector restart 和 schema change 主动注入不同类型的 loss。比较 reported coverage 与真实 query error 的 calibration，并测试 coverage-aware diagnosis 是否比完全相同但没有 coverage metadata 的 collector 更少给出错误 root cause。
+
+**学术价值。** 它把 observability completeness 变成 compact representation 自己携带、可以测量的系统性质。
+
+**生产价值。** Operator 能区分“metric 正常”和“collector 没有足够证据下结论”。对于罕见 incident，这个区别往往比多一位小数更重要。
+
+**失败条件。** 如果 coverage metadata 不能预测 diagnosis error，或者 downstream 已经可以可靠推断同样的信息，那么 hot path 上增加这些 accounting 不值得。
+
+## Benchmark 应该测诊断保留率，而不是只测 compression ratio
+
+一个有意义的 benchmark 需要 full raw ground truth，并给所有方案相同资源预算。Workload 还要故意包含适合不同 representation 的情况。
+
+每个 incident 都在预算路径之外保存一份完整 reference trace。候选 collector 则限制 BPF CPU time、map memory、每秒 export byte 和 userspace processing budget。随后执行需要不同证据的 diagnosis query：
+
+| Incident | 必须保留的证据 | 容易生成的 summary | 容易丢失的信息 |
+| --- | --- | --- | --- |
+| queue buildup | enqueue/dequeue generation | residence histogram | 罕见 ownership transition |
+| scheduler delay | runnable/scheduled interval | per-process delay total | 哪个 queue item 被阻塞 |
+| memory regression | allocation/page generation | bytes per stack | COW/reclaim transition |
+| network retry storm | connection/request generation | retry counter | 第一个失败 dependency |
+| stale semantic probe | probe generation 与 invariant | event rate | 语义已经改变的证据 |
+
+Benchmark 至少要报告：
+
+- root-cause accuracy 与 false attribution；
+- 仍然可以回答的 diagnosis query 比例；
+- stated coverage 和实际 error 的 calibration；
+- raw-event bytes 和 exported bytes；
+- BPF execution overhead 与 map memory；
+- 找到足够诊断证据所需的时间。
+
+一个 collector 即使做到 1000:1 compression，只要它删掉了区分 queue delay 和 scheduler delay 的那条信息，就不比能保留关键 transition 的 20:1 方案更好。反过来，如果复杂 exemplar 对 diagnosis 没有比一张 histogram 带来任何提升，系统只是多花了复杂度。
+
+## 哪些结果会改变这个判断？
+
+本文依赖两个假设。第一，完整导出 raw eBPF event 的成本确实高到会限制 always-on deployment；第二，未来 diagnosis 虽然不能完全预测，但存在一组稳定核心问题，可以提前声明。
+
+有两类结果会削弱这两个假设。
+
+第一，如果无损方案可以用和 semantic aggregation 接近的 CPU、memory 和 bandwidth 成本编码并导出完整相关事件，那么保留 raw evidence 更简单。Tracezip 与 μSlope 已经说明这必须是认真对比的 baseline，而不是假想敌。
+
+第二，如果真实 incident 经常需要 diagnostic contract 无法提前预测的字段和关系，那么源头 semantic reduction 可能过于脆弱。更稳妥的设计会保留更大比例、采样概率已知的 raw sample，或者更连续的 flight-recorder state。
+
+真正有区分度的实验，是在多个系统领域做 equal-budget incident replay。如果 hand-written aggregate、概率采样或无损压缩在 root-cause accuracy 和 query coverage 上都能达到同样结果，就没有必要再增加 compiler 和 exemplar layer。
+
+如果 diagnostic contract 可以稳定用更低 export cost 保住同样的 diagnosis，那么 eBPF observability 的目标就不应该只是“少发一些事件”，而应该是：**删掉重复信息，同时让被删掉的部分本身仍然可见、可判断。**
+
+## 参考资料
+
+- [Linux kernel documentation: BPF maps](https://docs.kernel.org/bpf/maps.html)
+- [Linux kernel documentation: BPF ring buffer](https://docs.kernel.org/bpf/ringbuf.html)
+- [OpenTelemetry: Sampling](https://opentelemetry.io/docs/concepts/sampling/)
+- [Tracezip: Efficient Distributed Tracing via Trace Compression](https://arxiv.org/abs/2502.06318)
+- [StriaTrace: Efficient Tracing and Diagnosis for Online LLM Inference](https://www.usenix.org/conference/osdi26/presentation/wu-haonan)
+- [μSlope: High Compression and Fast Search on Semi-Structured Logs](https://www.usenix.org/conference/osdi24/presentation/wang-rui)
+- [eBPF 能理解应用自己定义的资源吗？](https://eunomia.dev/zh/research/ebpf-application-resource-semantics/)
+- [异步系统里，eBPF Profiler 还要追踪什么？](https://eunomia.dev/zh/research/async-ebpf-causal-profiler/)
+- [性能分析器的采样什么时候会产生偏差？](https://eunomia.dev/zh/research/profiler-sampling-bias/)
+- [AI Agent 轨迹到底该保留什么：固定证据预算下的可观测性设计](https://eunomia.dev/zh/research/agent-trace-evidence-budget/)

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can eBPF Compress Telemetry Without Losing the Diagnosis?](https://eunomia.dev/research/ebpf-diagnostic-telemetry-compression/)
+
+Always-on eBPF telemetry can become too expensive to export continuously, while counters and histograms can erase the context needed for later diagnosis. This report develops diagnostic contracts, state-transition exemplars, coverage-carrying summaries, and an equal-budget benchmark that scores diagnosis retention instead of compression ratio alone.
+
 ### [Can eBPF Understand Application-Defined Resources?](https://eunomia.dev/research/ebpf-application-resource-semantics/)
 
 Internal pools, queues, caches, and credits can determine performance while remaining invisible as OS resources. This report develops a versioned resource-semantics manifest compiled into eBPF attachments, runtime confidence loss for stale contracts, and a mutation benchmark that tests semantic correctness across software upgrades.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 能压缩遥测数据而不丢失诊断依据吗？](https://eunomia.dev/zh/research/ebpf-diagnostic-telemetry-compression/)
+
+持续运行的 eBPF 遥测可能产生过多数据，而 counter 和 histogram 又会删掉后续诊断需要的上下文。本文提出 diagnostic contract、状态变化 exemplar、携带 coverage 的 summary，并用相同预算 benchmark 比较不同表示保留 root cause 的能力，而不是只比较 compression ratio。
+
 ### [eBPF 能理解应用自己定义的资源吗？](https://eunomia.dev/zh/research/ebpf-application-resource-semantics/)
 
 应用内部的 pool、queue、cache 和 credit 可以直接决定性能，却不一定是操作系统资源。本文提出可版本化的 resource-semantics manifest，把语义编译成 eBPF attach plan，并用运行时 confidence loss 与 mutation benchmark 检查软件升级后这些语义是否仍然可信。


### PR DESCRIPTION
## Evidence

- No newer Google weekly export beginning 2026-08-17 was found in the configured Drive folder on 2026-08-22. The newest verified finalized windows remain GSC rows through 2026-08-15 and GA4 through 2026-08-16.
- The valid equal-duration GSC comparison remains 393 clicks / 66,510 impressions for 2026-08-10..15 versus 478 / 69,053 for 2026-08-03..08. The missing 2026-08-09 row still blocks a complete 7-day comparison, and verified history still cannot support the required 28-day comparison.
- The repository-generated public-safe brief reports homepage/robots/sitemap healthy, 686 sitemap entries, and no collection gap. A fresh public homepage fetch did not establish a new technical SEO defect.
- The published newest-ten Daily Report mix is 7 eBPF / 0 pure Agent / 3 adjacent, so an eBPF-centered report is permitted and remains 7/0/3 after publication.

## Scope

- Add exactly one bilingual Daily Report: `Can eBPF Compress Telemetry Without Losing the Diagnosis?` / `eBPF 能压缩遥测数据而不丢失诊断依据吗？`.
- Compare Linux BPF maps/ringbuf with OpenTelemetry sampling, Tracezip, StriaTrace, and μSlope.
- Develop diagnostic-contract compilation, state-transition exemplars, coverage-carrying summaries, and an equal-budget diagnosis-retention benchmark.
- Update the EN/ZH Daily Report indexes and directly coupled SEO operating records.
- Complete the six-report eBPF Observability and Profiling series and promote eBPF Networking and Security for the next normal run.
- No unrelated technical SEO implementation change.
- No `seo-skills` pointer update; the repository still requires compatibility migration first.

## Validation

- Fresh branch from main `72df2c0a4410fd8190600ab56b05780c02b5260c`.
- Pre-PR scope review: 10 files, limited to one bilingual report, its two indexes, today's daily record, and directly coupled operating metadata.
- Both report variants contain the required gap section, developed research directions with artifact/evaluation/failure conditions, and a falsifier boundary.
- Expected repository CI and generated-output checks must pass before merge. A complete final diff/generated-output self-review will be repeated after CI.

## Deployment and acceptance

After squash merge, wait for `Deploy Static App` on the exact squash commit. Then verify both production routes:

- `https://eunomia.dev/research/ebpf-diagnostic-telemetry-compression/`
- `https://eunomia.dev/zh/research/ebpf-diagnostic-telemetry-compression/`

Acceptance requires visible EN/ZH content, Daily Report navigation, locale-correct canonical and reciprocal hreflang/x-default, Article JSON-LD, intended internal links, the required gap/ideas sections, and the conclusion boundary. Close out with one compact comment on the merged PR.