### PR TITLE
Daily: explain multi-tenant eBPF network policy composition

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -20,7 +20,7 @@ already configured and enabled; it is not a blocker.
 Google Drive access is verified and is not a blocker. The configured folder
 contains adjacent weekly export sets beginning `2026-07-27`, `2026-08-03`, and
 `2026-08-10`; no newer weekly set beginning `2026-08-17` was observed on
-`2026-08-22`. The newest verified Search Console date rows remain through
+`2026-08-23`. The newest verified Search Console date rows remain through
 `2026-08-15`, which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
@@ -34,7 +34,7 @@ GA4 landing-page files are weekly aggregates without a date dimension. The
 complete `2026-08-10` through `2026-08-16` aggregate is outside the configured
 three-day finalization lag and is usable as a finalized source-native weekly
 comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4 set
-was observed on `2026-08-22`. The landing-page exports do not provide complete
+was observed on `2026-08-23`. The landing-page exports do not provide complete
 acquisition, conversion, or outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -73,26 +73,52 @@ A daily report must still provide:
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-This series becomes active after the `2026-08-22` report completes the normal
-six-report boundary for eBPF Observability and Profiling. The first preferred
-question is transactional policy update: how programs, maps, links, generation
-state, and userspace control planes can change without exposing a mixed policy
-during rollout, crash recovery, or rollback.
+This series became active after the `2026-08-22` report completed the normal
+six-report boundary for eBPF Observability and Profiling.
+
+The roadmap initially preferred transactional policy updates across programs,
+maps, links, and userspace control planes. Fresh novelty review on `2026-08-23`
+rejected that candidate for this run because
+`/research/stateful-ebpf-transactional-upgrade/` already develops a prepare /
+migrate / commit / retire generation protocol across programs, links, maps,
+pinned state, controller recovery, and rollback. Repeating the same update
+transaction with a networking example would not materially advance the archive.
+
+The `2026-08-23` report therefore starts the active series with a distinct
+security-policy question: how additive Kubernetes `NetworkPolicy`, tiered
+`ClusterNetworkPolicy`, and Cilium L3-L7 policy can compose for multiple owners
+without losing authority, delegation, or source-policy provenance after the
+result is compiled into an eBPF datapath. It develops an authority-aware
+composition IR, generation-stable verdict witnesses, and a counterexample-driven
+multi-tenant policy benchmark.
+
+### Published progress
+
+1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
+   policy-language semantics from BPF hook composition and update transactions.
+   It asks how several legitimate policy owners can produce one effective
+   network verdict while keeping the deciding owner, tier, delegation path, and
+   source rule inspectable across policy generations. The report is
+   eBPF-centered because the proposed provenance contract is evaluated against
+   the realized BPF policy datapath, not only against Kubernetes objects.
 
 ### Preferred next questions
 
-1. transactional policy updates across programs, maps, links, and control planes;
-2. multi-tenant network-policy composition and conflict resolution;
-3. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
-   userspace eBPF;
-4. information-flow enforcement across process, file, socket, and encrypted
+1. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
+   userspace eBPF, with a networking/security question that does not repeat the
+   earlier io_uring control-surface report;
+2. information-flow enforcement across process, file, socket, and encrypted
    application boundaries;
-5. verifier and runtime interfaces for richer stateful policies;
-6. portable policy execution between kernel, userspace, NIC, and DPU targets.
+3. verifier and runtime interfaces for richer stateful policies;
+4. portable policy execution between kernel, userspace, NIC, and DPU targets;
+5. revisit transactional network-policy rollout only when new evidence supports
+   a mechanism materially different from the published stateful-upgrade
+   generation protocol.
 
-An eBPF-centered report remains arithmetically possible in the current rolling
-window because the `2026-08-22` eBPF report also ages an eBPF report out. Evidence
-and novelty still decide whether a candidate is publishable.
+Before and after the August 23 publication, the newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
+report ages the `2026-08-10` eBPF-centered transactional-upgrade report out of the
+rolling ten.
 
 ## Completed series — eBPF Observability and Profiling
 

--- a/.github/seo-data/daily/2026-08-23.md
+++ b/.github/seo-data/daily/2026-08-23.md
@@ -1,0 +1,137 @@
+# Daily SEO and research operation — 2026-08-23
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Operation date: `2026-08-23`
+- Fresh branch: `daily/2026-08-23-ebpf-network-policy-composition`
+- Delivery state at publication commit: pending pull request, CI, squash merge, exact-commit production deployment, bilingual production verification, and one merged-PR closeout comment.
+
+## Source coverage and freshness
+
+| Source | Status | Verified coverage or observation |
+| --- | --- | --- |
+| Google Drive weekly exports | available, unchanged | Configured folder still contains weekly sets beginning `2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer set beginning `2026-08-17` was observed on `2026-08-23`. |
+| Google Search Console export | partial for required comparison | Newest verified date rows remain finalized through `2026-08-15`; the `2026-08-09` row is absent. |
+| Google Analytics 4 export | finalized weekly aggregate | `2026-08-10..16` remains the newest available finalized source-native weekly landing-page aggregate. |
+| Cloudflare | disabled | Not configured in `site.md`; absence is not interpreted as zero. |
+| Public-safe daily collector | current | Generated `2026-08-23 07:53 UTC`; website, GitHub, and DEV collection succeeded without recorded coverage gaps. |
+| Live public site | available | Current collection reports homepage, robots, and sitemap `200`, canonical `https://eunomia.dev/`, and 690 sitemap entries. A browser fetch also returned the public homepage, although that browser index may lag current publication state. |
+| Public primary technical sources | reviewed | Kubernetes NetworkPolicy, Network Policy API v0.2.0/NPEP-122, and Cilium 1.20.1 policy/eBPF documentation were reviewed for the report. |
+
+Raw Google rows, Drive identifiers, queries, user-level analytics, credentials, and private source identifiers are not stored in this repository record.
+
+## Analytics comparison
+
+No new weekly export exists, so the newest valid source-native comparisons remain the same as the previous operation. They were rechecked against the unchanged configured Drive folder rather than inferred as current-period zeroes.
+
+### GSC
+
+A complete latest-7-days versus previous-7-days comparison remains unavailable because `2026-08-09` is missing from the exported date series. The valid equal-duration six-day comparison is:
+
+| Window | Clicks | Impressions | Weighted CTR | Weighted average position |
+| --- | ---: | ---: | ---: | ---: |
+| `2026-08-10..15` | 393 | 66,510 | ~0.591% | ~9.91 |
+| `2026-08-03..08` | 478 | 69,053 | ~0.692% | ~9.42 |
+
+Across the comparable windows, clicks are down about 17.8%, impressions about 3.7%, CTR about 0.101 percentage point, and weighted average position is about 0.49 worse. The available history is still insufficient for the required latest-complete-28-days versus prior-28-days comparison.
+
+The earlier `2026-08-05` impression spike still lacks date-by-page or date-by-query evidence, so no page or query attribution is made.
+
+### GA4
+
+The newest finalized source-native weekly aggregate remains:
+
+| Window | Organic landing-page sessions | Session-weighted engagement rate |
+| --- | ---: | ---: |
+| `2026-08-10..16` | 970 | ~44.95% |
+| `2026-08-03..09` | 991 | ~44.90% |
+
+Sessions are down about 2.1% while engagement is essentially flat. `(not set)` is 134 sessions in the newer aggregate versus 116 in the prior one; excluding `(not set)`, sessions are 836 versus 875. The landing-page export does not establish conversion or acquisition causes by itself.
+
+## Current public-safe signals
+
+The repository-generated `2026-08-23` public-safe brief reports:
+
+- homepage `200` in 155 ms;
+- robots and sitemap `200`;
+- 690 sitemap entries;
+- canonical `https://eunomia.dev/`;
+- 98 active non-fork GitHub repositories;
+- 9,801 GitHub stars, 1,282 forks, and 273 open issue/PR records across the collected portfolio;
+- 60 observed DEV articles, 43 reactions, and 4 comments;
+- no recorded public-safe collector coverage gap.
+
+These source-native metrics are not mixed with GSC clicks, GA4 sessions, or other differently defined metrics.
+
+## Technical SEO/GEO audit
+
+The current evidence does not establish a concrete crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect requiring a site implementation change today. Sitemap count increased from 686 to 690 after recent publications, which is consistent with the bilingual pages added since the previous collection and is not treated as an error.
+
+Search traffic remains softer in the comparable GSC window, but the available exports do not identify a page-level technical cause. No search-facing code or metadata change is made merely to satisfy cadence.
+
+The `seo-skills` submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream has newer commits, but repository operating records require contract migration before a pointer-only update, so the pointer is intentionally unchanged.
+
+## Daily Report topic selection
+
+Before topic selection, the actually published newest ten reports are **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. An eBPF-centered publication remains compliant because the incoming report ages the eBPF-centered `2026-08-10` transactional-upgrade report out of the newest ten, keeping the window at **7 / 0 / 3**.
+
+Active series: **eBPF Networking and Security**.
+
+### Rejected first candidate
+
+The roadmap's first preferred candidate, transactional policy updates across programs, maps, links, and control planes, was rejected on the novelty gate for this run. `/research/stateful-ebpf-transactional-upgrade/` already develops an application-level prepare / migrate / commit / retire generation protocol over programs, links, maps, pinned state, controller recovery, and rollback. A second report centered on transactional rollout would substantially duplicate that thesis without new evidence establishing a different mechanism.
+
+### Selected question
+
+Selected report: **How Should eBPF Compose Multi-Tenant Network Policies?** / **多租户网络策略应该怎样在 eBPF 数据面里组合？**
+
+Classification: **eBPF-centered; eBPF Networking and Security**.
+
+The report advances the active series by moving from update atomicity to policy semantics and authority. Primary evidence establishes that:
+
+- ordinary Kubernetes `NetworkPolicy` combines applicable allow rules additively;
+- current `ClusterNetworkPolicy` adds Admin/Baseline tiers, priority, and explicit `Accept`, `Deny`, and `Pass` semantics;
+- the Network Policy API tenancy example still marks its same-tenant selector use case as currently not implementable and tracks the model in NPEP-122;
+- Cilium 1.20.1 supports several Kubernetes/Cilium policy formats simultaneously and warns that the combined allowed set can become confusing and cause unintended allows;
+- Cilium's eBPF policy map is optimized around compact per-endpoint identity/port/protocol enforcement, while source-policy reconstruction is exposed through separate control-plane/debug paths.
+
+Central claim: multi-owner policy enforcement needs an authority-aware composition representation plus generation-stable verdict provenance. The report develops three testable directions: a composition IR, compact datapath verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
+
+## Files in scope
+
+- `docs/research/ebpf-network-policy-composition.md`
+- `docs/research/ebpf-network-policy-composition.zh.md`
+- `docs/research/index.md`
+- `docs/research/index.zh.md`
+- `.github/seo-data/daily/2026-08-23.md`
+- directly coupled current operating/series records updated on the same branch when required by validation.
+
+No unrelated project, tutorial, homepage, pricing, or promotion change is in scope.
+
+## Validation and delivery plan
+
+Before merge, verify:
+
+- exactly one new Daily Report topic exists in English and Chinese;
+- both descriptions, titles, first paragraphs, internal links, and source references satisfy repository SEO/GEO rules;
+- both reports contain the required concrete gap section, developed ideas with artifact/evaluation/failure conditions, and a reader-facing conclusion boundary;
+- no public provenance/process banner or inferred human author metadata is added;
+- the full intended PR diff and generated output are reviewed after CI;
+- all expected CI checks reach success before squash merge.
+
+After squash merge, the exact merge commit must successfully run the production `Deploy Static App` workflow. Production acceptance requires both routes below plus the EN/ZH Daily Report indexes to render with locale-correct canonical URLs, reciprocal hreflang plus `x-default`, Article JSON-LD, Daily Report navigation, intended internal links, and the required report sections:
+
+- `https://eunomia.dev/research/ebpf-network-policy-composition/`
+- `https://eunomia.dev/zh/research/ebpf-network-policy-composition/`
+
+The final merge, CI, deployment, and public verification facts will be recorded once as the compact closeout comment on the merged main PR, following `DAILY_TASK.md`; no second closeout PR is created.
+
+## Follow-up
+
+- Keep the active series on eBPF Networking and Security after this first report.
+- Prefer the next distinct roadmapped question only after a fresh evidence and novelty review; zero-copy programmable I/O or information-flow enforcement are stronger candidates than repeating transactional upgrade semantics.
+- Recalculate the rolling newest-ten mix from the actual published index on the next run.
+- Recheck the configured Drive folder for a weekly set beginning `2026-08-17`; do not infer missing data as zero.
+- Continue monitoring GSC softness before making a search-facing implementation change without page-level evidence.

--- a/.github/seo-data/daily/2026-08-23.md
+++ b/.github/seo-data/daily/2026-08-23.md
@@ -1,4 +1,4 @@
-# Daily SEO and research operation — 2026-08-23
+# SEO operations — 2026-08-23
 
 ## Scope
 
@@ -6,42 +6,43 @@
 - Site timezone: `America/Los_Angeles`
 - Operation date: `2026-08-23`
 - Fresh branch: `daily/2026-08-23-ebpf-network-policy-composition`
-- Delivery state at publication commit: pending pull request, CI, squash merge, exact-commit production deployment, bilingual production verification, and one merged-PR closeout comment.
+- Scope: analyze enabled SEO evidence, audit current technical SEO/GEO state, and publish exactly one bilingual Daily Report under the active eBPF Networking and Security series.
+- No unrelated homepage, tutorial, product, pricing, or speculative technical SEO change is included.
 
-## Source coverage and freshness
+## Data window
+
+The configured Google Drive folder was rechecked on `2026-08-23`. It still contains weekly export sets beginning `2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer weekly set beginning `2026-08-17` was observed.
+
+Search Console date rows are verified through `2026-08-15`, which is finalized under the configured three-day lag. The `2026-08-09` row remains absent, so a complete latest-seven-days versus previous-seven-days comparison is unavailable. Verified history is also still too short for the required 28-day comparison.
+
+The GA4 organic landing-page export for `2026-08-10..16` is outside the configured finalization lag and remains the newest finalized source-native weekly aggregate. Cloudflare is disabled by repository configuration and is not interpreted as zero.
+
+## Evidence collected
 
 | Source | Status | Verified coverage or observation |
 | --- | --- | --- |
-| Google Drive weekly exports | available, unchanged | Configured folder still contains weekly sets beginning `2026-07-27`, `2026-08-03`, and `2026-08-10`; no newer set beginning `2026-08-17` was observed on `2026-08-23`. |
-| Google Search Console export | partial for required comparison | Newest verified date rows remain finalized through `2026-08-15`; the `2026-08-09` row is absent. |
-| Google Analytics 4 export | finalized weekly aggregate | `2026-08-10..16` remains the newest available finalized source-native weekly landing-page aggregate. |
-| Cloudflare | disabled | Not configured in `site.md`; absence is not interpreted as zero. |
+| Google Drive weekly exports | available, unchanged | No weekly set beginning `2026-08-17`; latest files remain the `2026-08-10..16` set. |
+| Google Search Console export | partial for required full-window comparison | Finalized date rows through `2026-08-15`; `2026-08-09` absent. |
+| Google Analytics 4 export | finalized weekly aggregate | `2026-08-10..16` is the newest available finalized weekly organic landing-page aggregate. |
+| Cloudflare | disabled | Not configured in `site.md`; no edge-native claim is made. |
 | Public-safe daily collector | current | Generated `2026-08-23 07:53 UTC`; website, GitHub, and DEV collection succeeded without recorded coverage gaps. |
-| Live public site | available | Current collection reports homepage, robots, and sitemap `200`, canonical `https://eunomia.dev/`, and 690 sitemap entries. A browser fetch also returned the public homepage, although that browser index may lag current publication state. |
-| Public primary technical sources | reviewed | Kubernetes NetworkPolicy, Network Policy API v0.2.0/NPEP-122, and Cilium 1.20.1 policy/eBPF documentation were reviewed for the report. |
+| Live/public site evidence | available | Homepage, robots, and sitemap are `200`; canonical is `https://eunomia.dev/`; sitemap contains 690 entries. |
+| Primary technical sources | reviewed | Kubernetes NetworkPolicy, Network Policy API v0.2.0 and NPEP-122, and Cilium 1.20.1 policy/eBPF documentation. |
 
 Raw Google rows, Drive identifiers, queries, user-level analytics, credentials, and private source identifiers are not stored in this repository record.
 
-## Analytics comparison
+### GSC comparison
 
-No new weekly export exists, so the newest valid source-native comparisons remain the same as the previous operation. They were rechecked against the unchanged configured Drive folder rather than inferred as current-period zeroes.
-
-### GSC
-
-A complete latest-7-days versus previous-7-days comparison remains unavailable because `2026-08-09` is missing from the exported date series. The valid equal-duration six-day comparison is:
+The valid equal-duration six-day comparison is:
 
 | Window | Clicks | Impressions | Weighted CTR | Weighted average position |
 | --- | ---: | ---: | ---: | ---: |
 | `2026-08-10..15` | 393 | 66,510 | ~0.591% | ~9.91 |
 | `2026-08-03..08` | 478 | 69,053 | ~0.692% | ~9.42 |
 
-Across the comparable windows, clicks are down about 17.8%, impressions about 3.7%, CTR about 0.101 percentage point, and weighted average position is about 0.49 worse. The available history is still insufficient for the required latest-complete-28-days versus prior-28-days comparison.
+Across these comparable windows, clicks are down about 17.8%, impressions about 3.7%, CTR about 0.101 percentage point, and weighted average position is about 0.49 worse. The earlier `2026-08-05` impression spike still lacks date-by-page or date-by-query evidence, so no page or query attribution is made.
 
-The earlier `2026-08-05` impression spike still lacks date-by-page or date-by-query evidence, so no page or query attribution is made.
-
-### GA4
-
-The newest finalized source-native weekly aggregate remains:
+### GA4 comparison
 
 | Window | Organic landing-page sessions | Session-weighted engagement rate |
 | --- | ---: | ---: |
@@ -50,88 +51,71 @@ The newest finalized source-native weekly aggregate remains:
 
 Sessions are down about 2.1% while engagement is essentially flat. `(not set)` is 134 sessions in the newer aggregate versus 116 in the prior one; excluding `(not set)`, sessions are 836 versus 875. The landing-page export does not establish conversion or acquisition causes by itself.
 
-## Current public-safe signals
+### Current public-safe signals
 
-The repository-generated `2026-08-23` public-safe brief reports:
+The repository-generated `2026-08-23` brief reports homepage `200` in 155 ms, robots and sitemap `200`, 690 sitemap entries, canonical `https://eunomia.dev/`, 98 active non-fork GitHub repositories, 9,801 stars, 1,282 forks, 273 open issue/PR records, 60 observed DEV articles, 43 reactions, 4 comments, and no recorded public-safe collector coverage gap. These source-native metrics are not blended with GSC clicks or GA4 sessions.
 
-- homepage `200` in 155 ms;
-- robots and sitemap `200`;
-- 690 sitemap entries;
-- canonical `https://eunomia.dev/`;
-- 98 active non-fork GitHub repositories;
-- 9,801 GitHub stars, 1,282 forks, and 273 open issue/PR records across the collected portfolio;
-- 60 observed DEV articles, 43 reactions, and 4 comments;
-- no recorded public-safe collector coverage gap.
+## Work performed
 
-These source-native metrics are not mixed with GSC clicks, GA4 sessions, or other differently defined metrics.
+### Technical SEO/GEO audit
 
-## Technical SEO/GEO audit
+The current evidence does not establish a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect requiring a separate implementation change today. Sitemap count increased from 686 to 690 after recent publications, consistent with newly generated bilingual routes rather than a demonstrated error.
 
-The current evidence does not establish a concrete crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect requiring a site implementation change today. Sitemap count increased from 686 to 690 after recent publications, which is consistent with the bilingual pages added since the previous collection and is not treated as an error.
-
-Search traffic remains softer in the comparable GSC window, but the available exports do not identify a page-level technical cause. No search-facing code or metadata change is made merely to satisfy cadence.
+Search traffic remains softer in the comparable GSC window, but the available exports do not identify a page-level technical cause. No search-facing code or metadata change was invented to satisfy cadence.
 
 The `seo-skills` submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream has newer commits, but repository operating records require contract migration before a pointer-only update, so the pointer is intentionally unchanged.
 
-## Daily Report topic selection
+### Daily Report selection and implementation
 
 Before topic selection, the actually published newest ten reports are **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. An eBPF-centered publication remains compliant because the incoming report ages the eBPF-centered `2026-08-10` transactional-upgrade report out of the newest ten, keeping the window at **7 / 0 / 3**.
 
 Active series: **eBPF Networking and Security**.
 
-### Rejected first candidate
-
-The roadmap's first preferred candidate, transactional policy updates across programs, maps, links, and control planes, was rejected on the novelty gate for this run. `/research/stateful-ebpf-transactional-upgrade/` already develops an application-level prepare / migrate / commit / retire generation protocol over programs, links, maps, pinned state, controller recovery, and rollback. A second report centered on transactional rollout would substantially duplicate that thesis without new evidence establishing a different mechanism.
-
-### Selected question
+The roadmap's first preferred candidate, transactional policy updates across programs, maps, links, and control planes, was rejected on the novelty gate. `/research/stateful-ebpf-transactional-upgrade/` already develops an application-level prepare / migrate / commit / retire generation protocol over programs, links, maps, pinned state, controller recovery, and rollback. Reframing that thesis around networking would not materially advance the archive.
 
 Selected report: **How Should eBPF Compose Multi-Tenant Network Policies?** / **多租户网络策略应该怎样在 eBPF 数据面里组合？**
 
 Classification: **eBPF-centered; eBPF Networking and Security**.
 
-The report advances the active series by moving from update atomicity to policy semantics and authority. Primary evidence establishes that:
+Primary evidence establishes that ordinary Kubernetes `NetworkPolicy` combines applicable allow rules additively; current `ClusterNetworkPolicy` adds Admin/Baseline tiers, priority, and explicit `Accept`, `Deny`, and `Pass`; the Network Policy API tenancy example still marks its same-tenant selector use case as currently not implementable and tracks the model in NPEP-122; Cilium 1.20.1 supports several Kubernetes/Cilium policy formats simultaneously and warns that the combined allowed set can become confusing and cause unintended allows; and Cilium's eBPF policy map is optimized around compact per-endpoint identity/port/protocol enforcement while source-policy reconstruction is exposed through separate control-plane/debug paths.
 
-- ordinary Kubernetes `NetworkPolicy` combines applicable allow rules additively;
-- current `ClusterNetworkPolicy` adds Admin/Baseline tiers, priority, and explicit `Accept`, `Deny`, and `Pass` semantics;
-- the Network Policy API tenancy example still marks its same-tenant selector use case as currently not implementable and tracks the model in NPEP-122;
-- Cilium 1.20.1 supports several Kubernetes/Cilium policy formats simultaneously and warns that the combined allowed set can become confusing and cause unintended allows;
-- Cilium's eBPF policy map is optimized around compact per-endpoint identity/port/protocol enforcement, while source-policy reconstruction is exposed through separate control-plane/debug paths.
+The report develops three testable directions: an authority-aware composition IR, compact generation-stable datapath verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
 
-Central claim: multi-owner policy enforcement needs an authority-aware composition representation plus generation-stable verdict provenance. The report develops three testable directions: a composition IR, compact datapath verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
+Files changed in the main delivery are limited to the bilingual report, EN/ZH Daily Report indexes, today's operating record, and directly coupled `status.md`, `plan.md`, `content-series.md`, and `block.md` state.
 
-## Files in scope
+## Validation and self-review
 
-- `docs/research/ebpf-network-policy-composition.md`
-- `docs/research/ebpf-network-policy-composition.zh.md`
-- `docs/research/index.md`
-- `docs/research/index.zh.md`
-- `.github/seo-data/daily/2026-08-23.md`
-- directly coupled current operating/series records updated on the same branch when required by validation.
-
-No unrelated project, tutorial, homepage, pricing, or promotion change is in scope.
-
-## Validation and delivery plan
-
-Before merge, verify:
+Pre-PR review checked that:
 
 - exactly one new Daily Report topic exists in English and Chinese;
-- both descriptions, titles, first paragraphs, internal links, and source references satisfy repository SEO/GEO rules;
-- both reports contain the required concrete gap section, developed ideas with artifact/evaluation/failure conditions, and a reader-facing conclusion boundary;
-- no public provenance/process banner or inferred human author metadata is added;
-- the full intended PR diff and generated output are reviewed after CI;
-- all expected CI checks reach success before squash merge.
+- both variants contain the required concrete gap section;
+- both variants contain three developed directions with mechanism, artifact, evaluation, academic/production value, and failure condition;
+- both variants contain a reader-facing conclusion/falsifier section;
+- titles, descriptions, openings, internal links, and source references follow the repository's SEO/GEO and writing rules;
+- no process-oriented banner, generation badge, inferred human author, raw analytics row, private Drive identifier, credential, or personal information is published;
+- the branch contains only the intended daily scope.
 
-After squash merge, the exact merge commit must successfully run the production `Deploy Static App` workflow. Production acceptance requires both routes below plus the EN/ZH Daily Report indexes to render with locale-correct canonical URLs, reciprocal hreflang plus `x-default`, Article JSON-LD, Daily Report navigation, intended internal links, and the required report sections:
+Repository CI must still reach success on the final head. After all expected checks are green, the complete final PR diff, changed-file list, generated output, check results, scope, public-data safety, and mergeability will be reviewed again before squash merge. Any issue found in that final review will be fixed on the same branch and the full check/review cycle repeated.
 
-- `https://eunomia.dev/research/ebpf-network-policy-composition/`
-- `https://eunomia.dev/zh/research/ebpf-network-policy-composition/`
+## Delivery
 
-The final merge, CI, deployment, and public verification facts will be recorded once as the compact closeout comment on the merged main PR, following `DAILY_TASK.md`; no second closeout PR is created.
+- Pull request: `#169` (`https://github.com/eunomia-bpf/eunomia.dev/pull/169`)
+- Pull request type: real, non-draft, targeting `main`
+- Branch: `daily/2026-08-23-ebpf-network-policy-composition`
+- Main delivery state: awaiting successful expected CI and final self-review before squash merge
+- Production workflow after merge: `Deploy Static App` on the exact squash commit
+- Production acceptance routes:
+  - `https://eunomia.dev/research/ebpf-network-policy-composition/`
+  - `https://eunomia.dev/zh/research/ebpf-network-policy-composition/`
 
-## Follow-up
+Production acceptance requires visible EN/ZH content, Daily Report navigation, locale-correct canonical URLs, reciprocal hreflang plus `x-default`, Article JSON-LD, intended internal links, the required gap/ideas sections, and the conclusion boundary. The final merge, CI, deployment, and verification facts will be recorded once as the compact closeout comment on merged PR `#169`; no second closeout PR is created.
 
-- Keep the active series on eBPF Networking and Security after this first report.
-- Prefer the next distinct roadmapped question only after a fresh evidence and novelty review; zero-copy programmable I/O or information-flow enforcement are stronger candidates than repeating transactional upgrade semantics.
+## Decisions and follow-ups
+
+- Keep **eBPF Networking and Security** active after this first report.
+- Prefer the next distinct roadmapped question only after fresh evidence and novelty review; zero-copy programmable I/O or information-flow enforcement are stronger candidates than repeating transactional upgrade semantics.
 - Recalculate the rolling newest-ten mix from the actual published index on the next run.
 - Recheck the configured Drive folder for a weekly set beginning `2026-08-17`; do not infer missing data as zero.
+- Keep full GSC 7-day and 28-day comparisons unavailable until source history supports them.
+- Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
 - Continue monitoring GSC softness before making a search-facing implementation change without page-level evidence.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -72,19 +72,20 @@ priorities that can guide a later daily run belong below.
 ## Current priorities
 
 1. Preserve the rolling ten-report mix mechanically from the actually published
-   archive rather than stale operating notes. Before and after the `2026-08-22`
-   eBPF diagnostic telemetry compression report, the newest ten are **7
-   eBPF-centered / 0 pure Agent / 3 adjacent systems** because an eBPF report
-   ages out when today's eBPF report enters.
-2. Complete **eBPF Observability and Profiling** at six substantial reports with
-   the `2026-08-22` diagnostic-preserving semantic compression report. On the
-   next normal run, make **eBPF Networking and Security** the active series and
-   prefer transactional policy updates across programs, maps, links, and control
-   planes after fresh evidence and novelty review. Keep the observability-series
-   question about online confidence and adaptive collection queued for a later
-   revisit rather than stretching the completed series.
+   archive. Before and after the `2026-08-23` eBPF multi-tenant network-policy
+   composition report, the newest ten are **7 eBPF-centered / 0 pure Agent / 3
+   adjacent systems** because the `2026-08-10` eBPF report ages out when today's
+   eBPF report enters.
+2. Keep **eBPF Networking and Security** as the active series. The `2026-08-23`
+   report starts it with policy composition, authority provenance, and
+   explanation across Kubernetes and Cilium policy formats. The previously
+   preferred transactional-policy-update candidate was rejected for this run
+   because the existing stateful-upgrade report already covers a multi-object
+   prepare / migrate / commit / retire generation protocol. Prefer a distinct
+   next question such as zero-copy programmable I/O or cross-boundary
+   information-flow enforcement after fresh evidence and novelty review.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-22`, no newer weekly set than `2026-08-10` through `2026-08-16`
+   On `2026-08-23`, no newer weekly set than `2026-08-10` through `2026-08-16`
    was observed. GA4 for that week is finalized. Search Console still lacks the
    `2026-08-09` date row, so keep complete 7-day and 28-day comparisons
    unavailable until source history actually supports them.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,59 +7,56 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`
-- Latest daily record: `2026-08-22`
-- Last completed Daily Report pull request before the current run: `#167`
-- Last verified production publication from a Daily Report run: static export commit `25b863acf97b5603283dcfc1e3ca591a94c7f749` for squash commit `9f71d38bab5255f76df3c1e6618bcab261f6ca0b`
-- Current daily branch: `daily/2026-08-22-ebpf-diagnostic-compression`
+- Latest daily record: `2026-08-23`
+- Last completed Daily Report pull request before the current run: `#168`
+- Last verified Daily Report squash commit: `d47759a492e36aa2895dbd6366045d92c36efffd`
+- Last verified production publication from a Daily Report run: static export commit `2066687c14dbde187baf0854200fd565447d3789`
+- Current daily branch: `daily/2026-08-23-ebpf-network-policy-composition`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#167` is closed out. It squash-merged as
-`9f71d38bab5255f76df3c1e6618bcab261f6ca0b`; production published static export
-commit `25b863acf97b5603283dcfc1e3ca591a94c7f749`, whose commit message binds the
-export to that exact squash commit. The deployed English and Chinese
-application-resource semantics pages contain locale-correct canonical URLs,
-reciprocal `en`/`zh` alternates plus `x-default`, Article JSON-LD, Daily Report
-navigation and internal links, the required gap and ideas sections, and a
-reader-facing conclusion boundary. One compact closeout comment on PR `#167`
-records those facts.
+PR `#168` is closed out. It squash-merged as
+`d47759a492e36aa2895dbd6366045d92c36efffd`; production published static export
+commit `2066687c14dbde187baf0854200fd565447d3789`, whose commit message binds that
+export to the exact squash commit. The merged-PR closeout comment records green
+pre-merge checks, exact production publication, bilingual report/index metadata,
+and the remaining external crawler-cache limitation.
 
 ## Current Daily Report mix
 
-Immediately before the `2026-08-22` report, the actually published newest ten
+Immediately before the `2026-08-23` report, the actually published newest ten
 reports are:
 
 - eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
 - adjacent systems: **3 of 10**
 
-Today's `/research/ebpf-diagnostic-telemetry-compression/` report is
-**eBPF-centered**. Its central mechanism performs source-side semantic reduction
-inside an eBPF observability path using BPF maps, ring-buffer exemplars, and
-coverage accounting. eBPF is therefore required by the technical question rather
-than mentioned as a transport option. Publishing it ages another eBPF-centered
-report out of the newest ten, so the rolling window remains **7 eBPF / 0 pure
-Agent / 3 adjacent**.
+Today's `/research/ebpf-network-policy-composition/` report is **eBPF-centered**.
+It asks how several policy owners and policy languages can be compiled into an
+eBPF network datapath without losing authority, precedence, delegation, or
+explanation provenance. Publishing it ages the `2026-08-10` eBPF-centered
+transactional-upgrade report out of the newest ten, so the rolling window remains
+**7 eBPF / 0 pure Agent / 3 adjacent**.
 
-The report is the sixth substantial entry in **eBPF Observability and Profiling**.
-After successful publication, that series reaches the repository's normal
-4–6-report boundary. The next normal run should promote **eBPF Networking and
-Security** to the active series, with transactional policy updates across
-programs, maps, links, and control planes as the first preferred question after
-fresh evidence review.
+The active series is **eBPF Networking and Security**. The roadmap's first
+transactional-policy candidate was rejected for this run because the existing
+stateful eBPF transactional-upgrade report already develops the multi-object
+generation protocol. The selected multi-tenant network-policy composition
+question is materially distinct: policy semantics and authority are the central
+mechanisms, not update atomicity.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-22 07:51 UTC`
-- Homepage: HTTP 200 in **153 ms**
+- Repository-generated public-safe operating brief: refreshed `2026-08-23 07:53 UTC`
+- Homepage: HTTP 200 in **155 ms**
 - `robots.txt`: HTTP 200; sitemap: HTTP 200
-- Sitemap entries observed: **686**
+- Sitemap entries observed: **690**
 - Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 98 active non-fork repositories, **9,789** stars, 1,281 forks, and 271 open issue/PR records
+- Public GitHub portfolio snapshot: 98 active non-fork repositories, **9,801** stars, 1,282 forks, and 273 open issue/PR records
 - DEV publication surface: 60 articles, 43 public reactions, and 4 comments
 - Public web and primary-source evidence: available
 - Google Analytics 4: finalized weekly organic landing-page exports through `2026-08-16`
 - Google Search Console: weekly export set through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
-- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-22`
+- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-23`
 - Cloudflare: disabled by repository configuration
 
 For the valid equal-duration Search Console comparison, `2026-08-10` through
@@ -68,13 +65,13 @@ For the valid equal-duration Search Console comparison, `2026-08-10` through
 comparable `2026-08-03` through `2026-08-08` slice reports **478 clicks / 69,053
 impressions**, **0.692%** CTR, and position about **9.42**. Clicks are about
 **17.8% lower**, impressions about **3.7% lower**, CTR about **0.101 percentage
-points lower**, and average position about **0.49 positions worse**. The older
-slice includes the unusual `2026-08-05` impression spike, so the movement remains
-monitored rather than attributed to one page, query, or report.
+points lower**, and average position about **0.49 positions worse**.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison remains
 unavailable because the `2026-08-09` date row is absent. The required 28-day
 comparison is also unavailable because verified export history is too short.
+The `2026-08-05` impression spike still lacks date-by-page or date-by-query
+evidence and is not attributed.
 
 The finalized GA4 organic landing-page export for `2026-08-10` through
 `2026-08-16` contains **970 sessions** at about **44.95%** session-weighted
@@ -89,34 +86,29 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and static audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The August 22 public-safe brief reports healthy homepage, robots, sitemap, and
-canonical checks. A fresh public homepage fetch also returns the expected
-navigation, canonical site identity, project links, and Daily Report entry. The
-available Google evidence and repository output do not establish a new crawl,
-canonical, hreflang, structured-data, redirect, broken-link, rendering,
-accessibility, performance, or deployment defect. The appropriate public change
-today is the mandatory bilingual Daily Report and its directly coupled
-index/series updates, not a speculative technical SEO patch.
+The August 23 public-safe collector reports healthy homepage, robots, sitemap,
+and canonical checks. The available Google evidence and repository output do not
+establish a crawl, canonical, hreflang, structured-data, redirect, broken-link,
+rendering, accessibility, performance, or deployment defect requiring a separate
+technical SEO patch today.
 
-Today's report compares Linux BPF map and ring-buffer semantics with
-OpenTelemetry sampling, Tracezip, OSDI 2026 StriaTrace, and OSDI 2024 μSlope. It
-develops a diagnostic-contract compiler for retention plans, bounded
-state-transition exemplars, coverage-carrying compact summaries, and an
-equal-budget diagnosis-retention benchmark. This is intentionally narrower and
-lower-level than the existing Agent trace evidence-budget report.
+Today's report uses current Kubernetes NetworkPolicy, Network Policy API v0.2.0,
+NPEP-122 tenancy work, and Cilium 1.20.1 policy/eBPF documentation. It develops
+an authority-aware composition IR, generation-stable datapath verdict witnesses,
+and a counterexample-driven multi-tenant policy benchmark.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. The consuming repository still
-requires contract migration before a pointer-only update, so the submodule is not
-mixed into this daily delivery.
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream contains newer commits, but
+the consuming repository still requires contract migration before a pointer-only
+update, so this daily run intentionally leaves the pointer unchanged.
 
 ## Current focus
 
-1. Complete the `2026-08-22` eBPF diagnostic telemetry compression Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. After successful publication, treat **eBPF Observability and Profiling** as complete at six reports and make **eBPF Networking and Security** the next active series; prefer transactional policy updates after fresh evidence and novelty review.
+1. Complete the `2026-08-23` eBPF multi-tenant network-policy composition Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Keep **eBPF Networking and Security** active after this first report; prefer the next distinct roadmapped question only after fresh evidence and novelty review.
 3. Keep the complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
-5. Monitor Search Console click/CTR movement across another finalized weekly period before changing search-facing titles, copy, or navigation.
+5. Monitor another finalized Search Console period before changing search-facing titles, copy, or navigation without page-level evidence.
 6. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
 7. Migrate the consuming SEO contract before updating the skill submodule pointer.
 8. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.

--- a/docs/research/ebpf-network-policy-composition.md
+++ b/docs/research/ebpf-network-policy-composition.md
@@ -1,0 +1,263 @@
+---
+date: 2026-08-23
+title: "How Should eBPF Compose Multi-Tenant Network Policies?"
+description: "Multi-tenant clusters combine admin, namespace, and Cilium policy layers. This report develops explainable eBPF policy composition with conflict witnesses."
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - Kubernetes
+research_question: "How can an eBPF network-policy datapath preserve correct multi-tenant precedence while explaining which policy owner and rule determined each effective verdict?"
+source_cutoff: 2026-08-23
+status: daily-report
+---
+
+# How Should eBPF Compose Multi-Tenant Network Policies?
+
+A platform administrator denies cross-tenant traffic. A namespace owner adds a Kubernetes `NetworkPolicy` that allows one service. A security team adds a Cilium L7 rule for the same workload. All three policies may be valid, and all three may eventually influence the eBPF datapath that decides whether a packet is accepted.
+
+The difficult question is no longer whether eBPF can enforce a rule. It is whether the system can preserve **who had authority to decide, which rule won, and why a different rule did not** after several policy languages have been compiled into compact datapath state.
+
+<!-- more -->
+
+Kubernetes deliberately gives its original `NetworkPolicy` simple composition semantics. If several policies select the same pod, their allowed ingress or egress traffic is combined additively. There is no ordering between those policies. The current [Kubernetes NetworkPolicy documentation](https://kubernetes.io/docs/concepts/services-networking/network-policies/) describes the effective allow set as the union of applicable rules.
+
+The newer [Network Policy API](https://network-policy-api.sigs.k8s.io/) adds a different kind of composition. `ClusterNetworkPolicy` v0.2.0 introduces `Admin` and `Baseline` tiers, priorities, and `Accept`, `Deny`, and `Pass` actions. Admin rules can impose cluster-wide decisions that ordinary workload policies cannot override, while `Pass` can deliberately delegate a decision to a lower layer. The latest released `ClusterNetworkPolicy` API is v0.2.0 according to the project's [getting-started guide](https://network-policy-api.sigs.k8s.io/getting-started/).
+
+Cilium then adds another practical dimension. [Cilium 1.20.1](https://docs.cilium.io/en/stable/network/kubernetes/policy/) can enforce Kubernetes `NetworkPolicy`, Kubernetes `ClusterNetworkPolicy`, `CiliumNetworkPolicy`, and `CiliumClusterwideNetworkPolicy` together. Its documentation explicitly warns that using several policy formats at once can make the complete allowed set difficult to understand and can lead to unintended allows if operators do not reason about the combination carefully.
+
+That warning exposes a systems gap. The control plane may know policy objects, owners, tiers, selectors, and source labels. The eBPF datapath needs a compact answer such as an allowed identity, port, and protocol tuple. Cilium documents a per-endpoint [Policy BPF map](https://docs.cilium.io/en/latest/network/ebpf/maps/) whose default capacity is 16,000 allowed identity, port, and protocol pairs. That representation is efficient for enforcement, but the operator's original question is richer than the lookup key: **which authority caused this tuple to exist, which higher-priority rule was considered, and what policy object should be changed if the verdict is wrong?**
+
+This report argues that multi-tenant eBPF policy needs an explicit **composition contract** between policy intent and datapath state. The contract should normalize policies from different owners into one decision model, detect meaningful conflicts before installation, and preserve a compact verdict witness so a datapath decision can be traced back to the policy authority that determined it.
+
+This is distinct from the earlier [eBPF hook-composition report](https://eunomia.dev/research/ebpf-hook-composition-contract/), which asked how several BPF programs sharing one hook should combine mutations and outcomes. It is also distinct from the [stateful eBPF transactional-upgrade report](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/), which asked how programs, maps, links, and controller state can switch generations safely. Here the BPF programs may stay unchanged. The missing property is the semantics of several **security-policy owners and policy languages** being compiled into one effective network decision.
+
+## Three policy layers already use different composition rules
+
+A composition mechanism should start from the semantics that exist rather than invent a universal deny-overrides-allow rule.
+
+### Kubernetes NetworkPolicy is intentionally additive
+
+The original Kubernetes API is allow-oriented. Once a pod is isolated in one direction, traffic is permitted when at least one applicable rule allows it, and the effective allowed set is the union across policies. This model is useful because namespace owners can add policies without depending on evaluation order.
+
+It also means that the word "conflict" has to be used carefully. Two ordinary `NetworkPolicy` objects do not conflict in the API's formal semantics simply because one is narrower than another. If either allows a flow, the union allows it. An operator can still experience an *intent conflict* when one team believes a narrower rule restricts a broader rule, but the API does not interpret it that way.
+
+That distinction matters for tooling. A useful analyzer should not report "policy conflict" merely because two selectors overlap. It should report that a policy is shadowed, broadens the effective allow set, has no effect, or changes a flow in a way that violates a declared organizational constraint.
+
+### ClusterNetworkPolicy adds authority and delegation
+
+The Network Policy API exists because cluster administrators need controls that the original namespaced model cannot express cleanly. Its [API reference](https://network-policy-api.sigs.k8s.io/reference/spec/) gives higher precedence to lower numeric priorities within an administrator layer, while the [ClusterNetworkPolicy model](https://network-policy-api.sigs.k8s.io/api-overview/) separates administrator and baseline responsibilities.
+
+Cilium's current implementation documents the practical evaluation order as `Admin` tier, `NetworkPolicy` tier, then `Baseline` tier. An Admin decision cannot be overridden by `NetworkPolicy`, while Baseline acts as a lower-priority guardrail. `Pass` is especially interesting because it makes delegation part of the policy language instead of treating every unmatched rule as an implicit fall-through.
+
+Now an explanation such as "this packet was denied" is insufficient. The operator may need to know that an Admin-tier rule made the final decision before a namespace policy could participate, or that an Admin-tier `Pass` deliberately delegated the flow and a workload policy then allowed it.
+
+### Cilium compiles several formats into an eBPF datapath
+
+Cilium provides the concrete eBPF setting for this problem. It can ingest several Kubernetes and Cilium policy formats, calculate endpoint policy, assign security identities, and program BPF state for enforcement. Its [troubleshooting guide](https://docs.cilium.io/en/stable/security/policy/troubleshooting/) shows how an operator can pair endpoint information with policy labels and `cilium-dbg policy get` to reconstruct which source policies apply to an endpoint.
+
+That is useful control-plane introspection, but it is a reconstruction workflow. The packet verdict itself is compact. Hubble can report a `policy-verdict` with source and destination identities, direction, port, and allow/drop state, as shown in Cilium's [policy-creation guide](https://docs.cilium.io/en/latest/security/policy-creation/). The evidence required to answer "which rule owned this decision?" still lives across policy repositories, endpoint state, selector caches, and the datapath representation.
+
+The gap is therefore not that Cilium has no observability. The gap is that **policy provenance is not a portable property of the compiled verdict**.
+
+## Multi-tenancy makes missing provenance more than a debugging inconvenience
+
+A single team can often resolve ambiguous policy behavior by inspecting all objects it owns. Multi-tenancy changes the authority model.
+
+Imagine a shared cluster with three roles:
+
+1. the platform team owns Admin-tier isolation and emergency blocks;
+2. tenant teams own namespace-level service connectivity;
+3. a security team owns cluster-wide L7 controls through Cilium policy.
+
+Suppose tenant `blue` expects traffic from `blue/frontend` to `blue/api` on TCP 443. The platform policy first checks whether source and destination belong to the same tenant. The tenant policy allows the service pair. The security policy restricts the HTTP method on that connection.
+
+If the connection fails, the correct remediation depends on the deciding layer. Changing the namespace `NetworkPolicy` cannot override an Admin deny. Changing an Admin rule to fix an L7 denial expands authority unnecessarily. A policy engine that only reports the final drop forces the operator to reconstruct the hierarchy manually.
+
+The Network Policy API's own current examples show that tenancy semantics are still evolving. Its [tenant-isolation example](https://network-policy-api.sigs.k8s.io/reference/examples/) marks the same-tenant selector needed by the sample as "currently not implementable" and points to [NPEP-122](https://network-policy-api.sigs.k8s.io/npeps/npep-122/). That proposal describes ambiguity around how tenancy itself should be represented, including strict versus overridable isolation. This is not evidence that multi-tenancy cannot be enforced today. It is evidence that **tenant identity and delegation are first-class semantics that a generic policy compiler cannot safely infer from selector overlap alone**.
+
+## The effective policy needs a representation before it becomes BPF map entries
+
+A practical design can separate policy-language semantics from datapath layout with an intermediate representation. Call one normalized rule:
+
+```text
+rule = {
+  source_object,
+  source_generation,
+  owner,
+  authority_tier,
+  priority,
+  action,
+  subject_selector,
+  peer_selector,
+  direction,
+  protocol,
+  port,
+  l7_constraints
+}
+```
+
+The important fields are not all needed on every packet. They are needed while computing the effective decision.
+
+For a candidate flow, the compiler evaluates rules according to the semantics of the originating API. Ordinary Kubernetes `NetworkPolicy` contributes to an additive allow set. `ClusterNetworkPolicy` contributes tier, priority, and explicit `Accept`, `Deny`, or `Pass`. Cilium L7 constraints add another enforcement stage. The compiler then produces two related outputs:
+
+- **datapath state**, optimized for fast identity/port/protocol and L7 enforcement;
+- **decision provenance**, optimized for explaining why that state exists.
+
+The provenance does not need to copy complete YAML into a BPF map. A compact witness can use a generation ID, normalized rule ID, action, and authority tier. Userspace retains the reverse mapping from normalized rule IDs to source objects and owners.
+
+For an allowed L3/L4 tuple, a witness might look like:
+
+```text
+policy_gen=1842
+verdict=ALLOW
+owner=tenant-blue
+rule_id=0x31a8
+layer=NetworkPolicy
+admin_path=PASS:0x9f20
+```
+
+For a deny decided by the administrator layer:
+
+```text
+policy_gen=1842
+verdict=DENY
+owner=platform-security
+rule_id=0x0d44
+layer=Admin
+```
+
+This turns a packet verdict into a join key rather than a forensic exercise.
+
+## Where current work is still weak
+
+### 1. Cross-format policy composition is implemented, but its effective intent is hard to inspect
+
+Kubernetes `NetworkPolicy` has additive semantics. `ClusterNetworkPolicy` adds tiered authority, priority, and delegation. Cilium policies add Cilium-specific L3-L7 constructs. Cilium can run these formats together and explicitly warns that the complete allowed set may become confusing.
+
+The missing capability is a common **effective-policy artifact** that says how source policies from several formats contributed to each reachable decision region. A useful artifact should distinguish formal precedence from mere overlap. It should identify broadening rules, unreachable rules, delegated decisions, and rules whose effect is conditional on another policy layer.
+
+A decisive experiment would generate policy sets using all supported formats, enumerate or symbolically sample relevant source/destination identities and ports, and compare the analyzer's effective-policy result with the actual datapath verdict for every generated flow. If a compact normalized model cannot match the implementation without embedding Cilium internals, the proposed abstraction is too generic.
+
+### 2. Tenant identity is often implied by labels rather than declared as an owned object
+
+The current Network Policy API tenancy proposal explains why "same tenant" is harder than one selector expression. A label can group namespaces, but the system still needs a definition of which label establishes tenant identity, who may change it, and whether isolation is strict or can be overridden by namespace owners.
+
+The missing element is an authority-bound tenant identity that policy composition can reference directly. Without it, two policy authors can use the same labels with different assumptions, and an analyzer can only guess which label is organizational identity versus ordinary workload metadata.
+
+The test should include tenant-label mutation and adversarial namespace creation. If changing an untrusted namespace label can make a namespace enter another tenant's policy group before an independent authority check rejects it, the composition model is incomplete.
+
+### 3. Datapath verdicts do not naturally carry the source-policy witness
+
+A BPF policy map has to make packet decisions quickly. Cilium's documented policy map is sized around allowed identity, port, and protocol pairs, not around retaining every source policy object that helped produce those pairs. Existing troubleshooting can recover source policies through endpoint labels and agent state, but that is separate from the verdict path.
+
+The missing property is a **stable witness for the deciding policy generation and rule**. It can be stored in a companion map, attached to policy-verdict events, or reconstructed from an immutable generation manifest, but the relationship must survive policy updates long enough to explain an incident.
+
+The discriminating test is to update policies rapidly while retaining verdict logs. Ask the debugger to explain verdicts from old generations after the control plane has moved on. If explanations silently resolve against the current policy instead of the policy that produced the packet decision, provenance is not strong enough.
+
+### 4. L3/L4 and L7 rules can change effective denial behavior in different places
+
+Cilium's [policy enforcement documentation](https://docs.cilium.io/en/latest/security/policy/intro/) notes that an L7 rule can cause drops even when `EnableDefaultDeny` is disabled unless the L7 policy explicitly allows the traffic. This is a good example of why one Boolean "default deny" flag cannot summarize the full policy stack.
+
+The missing capability is a composition model that exposes which enforcement stage owns the final result. The operator should be able to distinguish "Admin tier denied before workload policy", "L3/L4 policy did not admit the identity", and "L7 policy admitted the connection but rejected this request" without translating each subsystem's internal representation by hand.
+
+A useful evaluation should replay the same source/destination pair with L3, L4, and L7 changes and score whether an explanation identifies the correct deciding layer and source rule.
+
+## Promising directions with academic and production value
+
+### 1. Compile several policy languages into an authority-aware composition IR
+
+**Gap.** Current APIs expose different composition semantics, and production CNI implementations can support several formats simultaneously, but operators lack one inspectable artifact for the effective result.
+
+**Mechanism.** Build a compiler front end for Kubernetes `NetworkPolicy`, `ClusterNetworkPolicy`, `CiliumNetworkPolicy`, and `CiliumClusterwideNetworkPolicy`. Normalize selectors and actions while preserving each source language's semantics. Represent authority tier, owner, priority, explicit delegation, and enforcement layer as first-class fields. The compiler then partitions the relevant identity/port space into decision regions and emits both datapath entries and a provenance manifest.
+
+The compiler must not flatten every format into a global "deny wins" rule. Kubernetes `NetworkPolicy` remains additive; `ClusterNetworkPolicy` tier and `Pass` semantics remain explicit; Cilium L7 constraints remain staged. Conflicts are reported only when an organizational invariant or declared ownership rule is violated, or when one rule's effect is unexpectedly broadened, shadowed, or delegated.
+
+**Delta.** Existing CNI controllers already compile policies. The new property is that the compilation product is a **portable, inspectable composition IR with authority provenance**, rather than an implementation-specific internal policy tree plus BPF state.
+
+**Artifact.** An open composition schema, importers for the four policy formats, a Cilium backend, and a command that can answer "what permits or denies this flow?" from a pinned policy generation.
+
+**Evaluation.** Generate policy suites with overlapping selectors, Admin/Baseline tiers, `Pass`, namespace policies, Cilium L7 rules, and label changes. Compare the IR against Cilium's realized verdicts and the API-defined expected semantics. Measure verdict agreement, conflict-report precision, compile latency, BPF map entry count, and incremental update cost. Ablate the authority fields and show which cases become ambiguous or incorrectly flattened.
+
+**Academic value.** The general question is whether independently authored network policies can be composed through an explicit authority algebra while preserving each language's original semantics.
+
+**Production value.** Platform teams gain one artifact for pre-deployment review, policy diffing, incident explanation, and migration between policy APIs.
+
+**Failure condition.** If the IR needs implementation-specific exceptions for most real policies, or existing policy tracing already exposes the same effective semantics in a stable machine-readable form, a new intermediate representation does not justify another abstraction.
+
+### 2. Preserve a compact verdict witness through the eBPF datapath
+
+**Gap.** Fast policy maps answer the enforcement question, while source-policy ownership and rule identity remain primarily in the control plane.
+
+**Mechanism.** Assign every compiled decision region a generation-scoped witness ID. The normal BPF lookup continues to use compact identity/port/protocol keys. A companion value or companion map associates the resulting entry with the witness ID. Policy-verdict telemetry exports that ID on denies and on a configurable sample of allows. Userspace resolves it against an immutable manifest containing owner, tier, source object, rule, and delegation path.
+
+The design should keep the hot path cheap. It can avoid attaching full provenance to every packet by emitting a witness only on first-seen flows, policy-verdict events, sampled allows, or operator-requested diagnostic mode. The generation must remain part of the identity so old verdict logs cannot be explained using a newer policy manifest.
+
+**Delta.** Hubble already emits policy-verdict events, and Cilium already labels source policy rules. The new property is a **direct generation-stable join from a realized datapath decision to the deciding source-policy witness**.
+
+**Artifact.** A Cilium prototype extending policy-map metadata or adding a companion witness map, plus Hubble decoding and a retained generation manifest.
+
+**Evaluation.** Run connection matrices under policy churn and retain verdict events across several generations. Measure explanation accuracy after old policies have been deleted, additional BPF map memory, packet-path overhead, event bandwidth, and manifest-retention cost. Compare full per-packet provenance, sampled witnesses, and control-plane-only reconstruction.
+
+**Academic value.** This tests how much provenance an enforcement datapath must retain for explanations to remain correct under control-plane evolution.
+
+**Production value.** Security and SRE teams can map a denied or unexpectedly allowed flow directly to the responsible policy owner instead of correlating several live controller views after the fact.
+
+**Failure condition.** If control-plane reconstruction stays exact across policy churn and adds negligible incident latency, or if even a compact witness materially harms datapath scale, the witness should remain outside the packet path.
+
+### 3. Build a counterexample-driven multi-tenant policy benchmark
+
+**Gap.** Policy conformance can show whether one resource is implemented correctly, but it does not necessarily expose operator mistakes created by several legitimate owners composing policies together.
+
+**Mechanism.** Build a benchmark generator with explicit ground-truth tenants, authority roles, and intended connectivity invariants. It emits policy sets across Kubernetes and Cilium formats, then introduces one controlled mutation at a time: a broader namespace selector, a misplaced tier, an accidental `Pass`, a tenant-label change, an L7 restriction, a stale policy generation, or a policy-map capacity stress case.
+
+For each mutation, the benchmark records both the expected datapath verdict and the minimal explanation: which authority and rule should determine the outcome, and which alternative rule should be ignored, delegated, or treated as additive.
+
+**Delta.** Existing API conformance tests validate implementation behavior against resource semantics. This benchmark targets **composition mistakes and explanation quality across owners and formats**, including cases where every individual policy object is syntactically valid.
+
+**Artifact.** A reproducible Kubernetes test suite, policy corpus, expected flow matrix, policy-generation history, and adapters for Cilium first, with other Network Policy API implementations added as their support matures.
+
+**Evaluation.** Score datapath verdict correctness, explanation correctness, conflict detection precision and recall, time to identify the responsible owner, and resource overhead. Include a human/operator study only as a secondary measure; the primary oracle is the generated ground-truth decision graph. Compare ordinary `kubectl` inspection, Cilium's existing policy/debug tooling, the composition IR, and the datapath witness design.
+
+**Academic value.** The benchmark makes policy compositionality and explainability measurable properties instead of relying on anecdotal configuration failures.
+
+**Production value.** CNI maintainers and platform teams can regression-test upgrades, API migrations, and organization-specific guardrails against realistic multi-owner policy interactions.
+
+**Failure condition.** If real production policy sets rarely mix authorities or formats and generated conflicts do not resemble observed incidents, the benchmark overstates a corner case and should narrow to the policy combinations operators actually deploy.
+
+## A practical deployment path does not require replacing Kubernetes policy APIs
+
+The composition contract can be incremental.
+
+A first implementation can run entirely in the Cilium control plane. It imports current policy objects, emits a composition manifest alongside the existing realized policy, and compares predicted decisions with Cilium policy tracing. No packet-path change is required.
+
+A second step can add witness IDs only to policy-verdict telemetry. If that is sufficient for incident explanation, there is no reason to burden every policy-map lookup with more metadata.
+
+Only if policy churn or post-incident reconstruction proves that telemetry-only witnesses are insufficient should the datapath carry a generation-scoped witness directly.
+
+This staged path matters because eBPF is valuable here for enforcement and observability, but the hardest part is semantic. Faster packet lookup cannot repair an authority model that was flattened incorrectly before the BPF map was populated.
+
+## What would change this conclusion?
+
+The case for an explicit composition contract weakens if current `ClusterNetworkPolicy` semantics plus existing Cilium policy tracing already make multi-owner effective policy mechanically explainable across the policy combinations operators actually use. A benchmark that finds no explanation mismatch, no stale-generation errors, and no meaningful operator ambiguity would favor improving existing tooling rather than adding a new IR.
+
+The datapath witness is also conditional. If retaining a rule witness causes measurable policy-map pressure, reduces endpoint scale, or adds packet-path cost that control-plane reconstruction avoids, the witness should stay in sampled verdict telemetry or in a userspace generation manifest.
+
+Finally, tenancy may become simpler as the Network Policy API stabilizes a clearer tenant model. If tenant identity, ownership, delegation, and precedence become explicit enough that every implementation can preserve them without extra metadata, the composition layer can shrink. The goal is not to create another policy language. It is to make the path from several legitimate policy owners to one eBPF verdict **correct, inspectable, and stable across policy generations**.
+
+## References
+
+- [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [Kubernetes NetworkPolicy API reference](https://kubernetes.io/docs/reference/kubernetes-api/networking/network-policy-v1/)
+- [Network Policy API](https://network-policy-api.sigs.k8s.io/)
+- [Network Policy API v0.2.0 getting started](https://network-policy-api.sigs.k8s.io/getting-started/)
+- [Network Policy API specification](https://network-policy-api.sigs.k8s.io/reference/spec/)
+- [Network Policy API examples](https://network-policy-api.sigs.k8s.io/reference/examples/)
+- [NPEP-122: Tenancy API](https://network-policy-api.sigs.k8s.io/npeps/npep-122/)
+- [Network Policy API implementations](https://network-policy-api.sigs.k8s.io/implementations/)
+- [Cilium 1.20.1 Network Policy](https://docs.cilium.io/en/stable/network/kubernetes/policy/)
+- [Cilium eBPF Maps](https://docs.cilium.io/en/latest/network/ebpf/maps/)
+- [Cilium policy troubleshooting](https://docs.cilium.io/en/stable/security/policy/troubleshooting/)
+- [Cilium policy enforcement modes](https://docs.cilium.io/en/latest/security/policy/intro/)
+- [Cilium repository](https://github.com/cilium/cilium)

--- a/docs/research/ebpf-network-policy-composition.zh.md
+++ b/docs/research/ebpf-network-policy-composition.zh.md
@@ -1,0 +1,265 @@
+---
+date: 2026-08-23
+title: "多租户网络策略应该怎样在 eBPF 数据面里组合？"
+description: "多租户集群会叠加管理员、命名空间和 Cilium 网络策略。本文分析不同策略层的组合语义，并提出可解释的 eBPF policy composition 与 verdict witness。"
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - Kubernetes
+research_question: "当多种网络策略由不同租户和管理员共同定义时，eBPF 数据面怎样既保持正确的优先级与委托语义，又能解释最终 verdict 是由谁决定的？"
+source_cutoff: 2026-08-23
+status: daily-report
+---
+
+# 多租户网络策略应该怎样在 eBPF 数据面里组合？
+
+平台管理员禁止租户之间直接通信，某个 namespace 的维护者又通过 Kubernetes `NetworkPolicy` 放行自己的服务，安全团队同时为同一批 workload 加上一条 Cilium L7 规则。这三条策略都可能是合法的，最后也都可能影响 eBPF 数据面里一次 packet lookup 的结果。
+
+真正困难的已经不是 eBPF 能不能执行 allow 或 deny，而是：**多套策略被压成高效的 datapath state 以后，系统还能不能说明谁有权做这个决定、哪条规则真正决定了结果，以及另一条看起来相关的规则为什么没有生效。**
+
+<!-- more -->
+
+Kubernetes 原生 `NetworkPolicy` 的组合规则相对简单。按照当前 [Kubernetes NetworkPolicy 文档](https://kubernetes.io/docs/concepts/services-networking/network-policies/)，如果多个 policy 同时选中一个 Pod，它们允许的 ingress 或 egress 集合按加法合并。规则之间没有先后顺序，只要某个适用的 policy 允许该 flow，最终 allow 集合就包含它。
+
+新的 [Network Policy API](https://network-policy-api.sigs.k8s.io/) 引入了另一套语义。当前发布的 `ClusterNetworkPolicy` v0.2.0 支持 `Admin` 与 `Baseline` tier、priority，以及 `Accept`、`Deny`、`Pass`。管理员可以定义普通 workload policy 无法覆盖的高优先级决定，也可以通过 `Pass` 明确把某类流量交给下一层策略处理。项目的 [getting-started 文档](https://network-policy-api.sigs.k8s.io/getting-started/) 当前把 v0.2.0 列为最新发布版本。
+
+Cilium 又把这个问题变成了一个很具体的 eBPF 工程问题。[Cilium 1.20.1 的 Network Policy 文档](https://docs.cilium.io/en/stable/network/kubernetes/policy/)说明，它可以同时运行 Kubernetes `NetworkPolicy`、`ClusterNetworkPolicy`、`CiliumNetworkPolicy` 和 `CiliumClusterwideNetworkPolicy`。同一份文档也明确提醒：同时使用多种 policy format 时，完整的 allowed traffic 很容易变得难以理解，如果没有仔细检查，甚至可能出现意外放行。
+
+这就是本文关注的缺口。控制面保留 policy object、owner、tier、selector 和 rule label；真正执行时，eBPF 数据面希望得到尽可能紧凑的查表结果。Cilium 的 [eBPF map 文档](https://docs.cilium.io/en/latest/network/ebpf/maps/)把每个 endpoint 的 Policy map 描述为 identity、port、protocol 组合，默认上限为 16K。这样的表示非常适合快速 enforcement，却没有直接回答管理员最关心的问题：**这个 entry 为什么存在，是哪一层 authority 允许或拒绝了它，如果 verdict 错了应该改哪一份 policy？**
+
+本文的判断是，多租户 eBPF policy 需要一个位于 policy intent 与 datapath state 之间的**组合契约**。它不应该发明一套新的网络策略语言，而是把不同策略语言已有的 authority、priority、delegation 和 additive 语义保留下来，在安装 datapath state 之前识别真正有意义的冲突，并让最终 verdict 带有一个足够紧凑的来源 witness。
+
+这个问题和此前的 [eBPF hook composition](https://eunomia.dev/zh/research/ebpf-hook-composition-contract/) 不一样。那篇文章讨论的是多个 BPF program 共享同一 hook 时，mutation、shared state 和 competing outcome 怎样组合。它也不同于 [有状态 eBPF 原子升级](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/)，后者关注 programs、maps、links 和 userspace controller 怎样安全切换 generation。本文假设 BPF 程序本身可以完全不变，真正需要组合的是**不同安全策略拥有者和不同 policy language 的语义**。
+
+## 三层网络策略已经在使用不同的组合规则
+
+设计组合机制之前，首先要承认已有 API 并不是同一种逻辑。把所有 policy 都压成“deny 优先”反而会破坏原来的语义。
+
+### Kubernetes NetworkPolicy 本来就是 additive
+
+原生 Kubernetes API 主要描述 allow。一旦 Pod 在某个方向进入 isolation，最终允许哪些连接取决于所有适用 policy 的 allow union。这个模型的好处是 namespace owner 可以独立增加 policy，而不需要知道某条对象会先还是后执行。
+
+因此，这里使用“冲突”一词需要很谨慎。两个普通 `NetworkPolicy` 的 selector 重叠，不代表 API 语义上存在冲突。如果一条宽规则和一条窄规则都适用，最终 allow set 仍然是二者的并集。
+
+但是，人可以产生意图冲突。例如一个团队以为窄规则会限制宽规则，而 Kubernetes 实际上继续允许宽规则覆盖的流量。一个好的分析器不应该因为 selector overlap 就报警，而应该明确告诉用户：某条 policy 扩大了 effective allow set、某条规则没有实际影响、某个约束被另一层 authority 覆盖，或者某个决定被显式委托给了下一层。
+
+### ClusterNetworkPolicy 把 authority 和 delegation 放进 API
+
+Network Policy API 的目标之一，就是补足 namespace 级 `NetworkPolicy` 无法表达的 cluster administrator 控制。当前 [API reference](https://network-policy-api.sigs.k8s.io/reference/spec/)包含 priority 语义，而 [ClusterNetworkPolicy 模型](https://network-policy-api.sigs.k8s.io/api-overview/)区分管理员策略和 baseline guardrail。
+
+Cilium 当前实现把实际顺序写得更直接：`Admin` tier、`NetworkPolicy` tier、`Baseline` tier。Admin 的决定不能被普通 `NetworkPolicy` 覆盖，Baseline 则是更低层的 guardrail。`Pass` 更值得注意，因为它把“把决定交给下一层”明确写成 policy action，而不是靠 rule miss 隐式 fall through。
+
+所以一个 `DENIED` 已经不够解释结果。管理员可能需要知道，是 Admin rule 在 workload policy 参与之前就做出了决定，还是 Admin 先 `Pass`，之后 namespace policy 才真正允许了连接。
+
+### Cilium 把多种 policy format 编译进 eBPF 数据面
+
+Cilium 是这个问题最直接的生产例子。它从 Kubernetes 和 Cilium CRD 接收 policy，计算 endpoint policy，维护 security identity，最后把 enforcement state 编程进 BPF map。它的 [policy troubleshooting 文档](https://docs.cilium.io/en/stable/security/policy/troubleshooting/)说明，operator 可以把 endpoint 信息、rule label 和 `cilium-dbg policy get` 组合起来，恢复某个 endpoint 当前受到哪些 source policy 影响。
+
+这是一条可用的调试路径，但本质上仍然是控制面重建。Hubble 的 [policy-verdict](https://docs.cilium.io/en/latest/security/policy-creation/) 可以直接告诉我们 source/destination identity、方向、port 和 allow/drop，却没有把“哪一层 policy owner 真正决定了这个 verdict”天然变成 datapath verdict 的稳定属性。
+
+所以缺的并不是 Cilium 没有 observability，而是**source-policy provenance 还不是编译后 verdict 的一个可移植契约**。
+
+## 多租户让 provenance 从调试便利变成正确性问题
+
+如果一个集群只有一个团队，遇到异常时把所有 policy object 全部打开通常还能查清楚。多租户改变的是 authority model。
+
+设想一个共享集群：
+
+1. 平台团队负责 Admin tier 的 tenant isolation 和 emergency block；
+2. 各 tenant 团队负责 namespace 内的 service connectivity；
+3. 安全团队通过 Cilium policy 负责跨 namespace 或 L7 控制。
+
+tenant `blue` 希望 `blue/frontend` 可以访问 `blue/api:443`。平台策略首先判断 source 和 destination 是否属于同一个 tenant；tenant 自己的 policy 允许 service pair；安全团队又限制该连接上的 HTTP method。
+
+如果请求失败，真正该修改哪个对象取决于哪个 layer 做出了最后决定。namespace owner 改自己的 `NetworkPolicy` 无法绕过 Admin deny；为了修一个 L7 deny 去放宽 Admin rule，又会扩大不该扩大的 authority。只有最终 `DROP` 而没有来源 witness 的系统，会迫使 operator 手工恢复整条 hierarchy。
+
+Network Policy API 自己的当前示例也说明 tenancy 语义仍在演进。它的 [tenant isolation 示例](https://network-policy-api.sigs.k8s.io/reference/examples/)把需要表达“same tenant”的 selector 标成 `currently not implementable`，并指向 [NPEP-122](https://network-policy-api.sigs.k8s.io/npeps/npep-122/)。该 proposal 进一步讨论 strict isolation、可被 namespace owner override 的 isolation，以及 tenant identity 本身应该怎样定义。
+
+这并不表示 Kubernetes 今天无法做多租户隔离。它说明的是：**tenant identity 和 delegation 是需要明确建模的语义，generic policy compiler 不能只看 label overlap 就自行猜测。**
+
+## effective policy 在变成 BPF map entry 之前需要一个表示层
+
+一种实际可做的设计，是在 policy language 与 datapath layout 之间加入中间表示。每条 normalized rule 可以保留：
+
+```text
+rule = {
+  source_object,
+  source_generation,
+  owner,
+  authority_tier,
+  priority,
+  action,
+  subject_selector,
+  peer_selector,
+  direction,
+  protocol,
+  port,
+  l7_constraints
+}
+```
+
+这些字段不需要在每个 packet 上全部携带，但在计算 effective decision 时必须存在。
+
+对一个 candidate flow，compiler 先按照来源 API 自己的语义求值。普通 Kubernetes `NetworkPolicy` 进入 additive allow set；`ClusterNetworkPolicy` 保留 tier、priority 与 `Accept`、`Deny`、`Pass`；Cilium 的 L7 constraint 保留自己的 enforcement stage。之后输出两类产物：
+
+- 面向 fast path 的 **datapath state**，继续优化 identity、port、protocol 和 L7 enforcement；
+- 面向解释的 **decision provenance**，保存这个 datapath state 为什么存在。
+
+provenance 不需要把完整 YAML 放进 BPF map。datapath 只需要一个 generation、normalized rule ID、action 和 authority tier。userspace 保留 rule ID 到 source object 与 owner 的 reverse mapping。
+
+允许一个 L3/L4 tuple 时，witness 可以类似：
+
+```text
+policy_gen=1842
+verdict=ALLOW
+owner=tenant-blue
+rule_id=0x31a8
+layer=NetworkPolicy
+admin_path=PASS:0x9f20
+```
+
+如果 Admin tier 已经决定 deny，则可以是：
+
+```text
+policy_gen=1842
+verdict=DENY
+owner=platform-security
+rule_id=0x0d44
+layer=Admin
+```
+
+这样 packet verdict 提供的是一个稳定 join key，而不是要求事后做一次取证工程。
+
+## 现有研究还缺什么
+
+### 1. 多种 policy format 已经能同时执行，但 effective intent 仍然难以检查
+
+Kubernetes `NetworkPolicy` 使用 additive 语义；`ClusterNetworkPolicy` 加入 tier、priority 与 delegation；Cilium policy 又增加自己的 L3-L7 表达。Cilium 能同时运行这些格式，并且官方文档已经提醒完整 allow set 容易变得难以理解。
+
+缺少的是一个共同的 **effective-policy artifact**，明确表示来自多个 format 的 source policy 怎样共同形成每个 decision region。它要区分正式 precedence 与普通 overlap，还要识别 broadening rule、完全没有 effect 的 rule、delegated decision，以及只在另一层策略存在时才会生效的 rule。
+
+最直接的验证方式，是生成包含所有支持 format 的 policy set，再枚举或符号化采样 source/destination identity 与 port，把 analyzer 预测出来的 effective policy 和真实 datapath verdict 对比。如果一个 compact normalized model 必须塞入大量 Cilium-specific 特例才能匹配实现，这个 abstraction 就太泛化了。
+
+### 2. tenant identity 经常由 label 暗示，而不是一个有 authority 的对象
+
+当前 tenancy proposal 已经展示了问题：某个 label 可以把 namespace 分组，但系统还需要知道哪一个 label 真正定义 tenant、谁有权修改它，以及该 isolation 是 strict 还是允许 namespace owner override。
+
+缺少的是一个与 authority 绑定的 tenant identity。否则两个 policy author 可以对同一组 label 有完全不同的组织语义，analysis tool 也只能猜这个 label 是安全边界还是普通 workload metadata。
+
+测试时应加入 tenant label mutation 和恶意 namespace 创建。如果一个不可信 namespace 仅靠修改 label 就能进入另一个 tenant 的 policy group，而 composition model 没有独立 authority check，它的安全模型就是不完整的。
+
+### 3. datapath verdict 并不天然携带 source-policy witness
+
+BPF policy map 必须优先服务快速 packet decision。Cilium 当前文档中的 policy map 以 identity、port、protocol pair 为核心，而 source policy owner 与 rule identity 主要保留在控制面。现有 troubleshooting 可以从 endpoint label 和 agent state 恢复 policy，但它与发生 verdict 的那一刻并不是同一个证据对象。
+
+缺少的属性是一个**稳定的 policy generation 和 deciding rule witness**。它可以放在 companion map、policy-verdict event，或者由 immutable generation manifest 解析，但关系必须保存足够久，才能解释旧 incident。
+
+可以在持续 policy churn 下记录 verdict，再删除旧 policy object。之后要求 debugger 解释旧 generation 的 verdict。如果它默默使用当前 policy 来解释过去的 packet，provenance 就不够强。
+
+### 4. L3/L4 和 L7 可能在不同位置改变 deny 语义
+
+Cilium 的 [policy enforcement 文档](https://docs.cilium.io/en/latest/security/policy/intro/)特别指出，即使 `EnableDefaultDeny` 被关闭，L7 rule 如果没有对应 allow-all 规则，仍然可能造成 drop。这个例子说明，一个 `default deny` Boolean 无法概括完整 policy stack。
+
+缺少的是能说明最终决定在哪个 enforcement stage 发生的组合模型。operator 应该直接区分“Admin tier 在 workload policy 前 deny”“L3/L4 没有 admit identity”“连接允许建立，但 L7 policy 拒绝了当前 request”，而不是自己翻译每一层内部状态。
+
+验证可以固定 source/destination，只改变 L3、L4、L7 policy，检查 explanation 是否总能指向正确的 deciding layer 和 source rule。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 把多种 policy language 编译成带 authority 的 composition IR
+
+**缺口。** 当前 API 已经存在不同的组合语义，生产 CNI 也能同时支持多种 format，但 operator 缺少一个可检查的 effective result。
+
+**机制。** 为 Kubernetes `NetworkPolicy`、`ClusterNetworkPolicy`、`CiliumNetworkPolicy` 和 `CiliumClusterwideNetworkPolicy` 做 compiler frontend。selector 和 action 可以 normalize，但 source language 的语义不能被抹平。authority tier、owner、priority、显式 delegation 与 enforcement layer 都是 first-class field。compiler 再把 identity/port 空间切成 decision region，同时产生 datapath entry 与 provenance manifest。
+
+这个 compiler 不能把所有 format 偷换成“deny wins”。Kubernetes `NetworkPolicy` 继续 additive；`ClusterNetworkPolicy` 的 tier 和 `Pass` 明确保留；Cilium L7 仍然有自己的 stage。只有当 organizational invariant 或 ownership rule 被违反，或者规则出现意外 broadening、shadowing、delegation 时，才报告 conflict。
+
+**与现有工作的差异。** CNI controller 今天当然已经会编译 policy。新的性质不是“再做一个 compiler”，而是把编译结果变成**带 authority provenance、可检查且尽量可移植的 composition IR**，不再只剩 implementation-specific policy tree 和 BPF state。
+
+**产物。** 一个开放 schema、四种 policy format importer、Cilium backend，以及可以从某个固定 policy generation 回答“为什么这个 flow 被允许或拒绝”的命令行工具。
+
+**评测。** 生成包含 selector overlap、Admin/Baseline、`Pass`、namespace policy、Cilium L7 rule 与 label mutation 的 policy suite。对比 IR、Cilium 实际 verdict 与 API 定义的预期语义。指标包括 verdict agreement、conflict report precision、compile latency、BPF map entry 数量和 incremental update cost。去掉 authority field 做 ablation，观察哪些 case 变成 ambiguity 或错误 flattening。
+
+**学术价值。** 核心问题是：不同作者独立定义的 network policy，是否可以在保留原 policy language 语义的同时，通过显式 authority algebra 正确组合。
+
+**生产价值。** 平台团队可以用同一个 artifact 做 pre-deployment review、policy diff、incident explanation 和 policy API migration。
+
+**失败条件。** 如果真实 policy 大部分都需要 implementation-specific exception 才能进入 IR，或者现有 policy tracing 已经稳定地暴露了同样的 machine-readable effective semantics，就没有必要再维护一个中间层。
+
+### 2. 在 eBPF datapath 中保留紧凑 verdict witness
+
+**缺口。** fast policy map 负责回答能不能过包，source-policy ownership 和 rule identity 仍主要在控制面。
+
+**机制。** 每个 compiled decision region 得到一个 generation-scoped witness ID。正常 BPF lookup 继续使用 compact identity/port/protocol key；companion value 或 companion map 把 entry 关联到 witness ID。deny 和可配置比例的 allow verdict 把该 ID 发到 policy-verdict telemetry。userspace 再从 immutable manifest 解析 owner、tier、source object、rule 与 delegation path。
+
+hot path 不应该承受完整 provenance。实现可以只对 first-seen flow、deny、sampled allow 或 operator 打开的 diagnostic mode 输出 witness。generation 必须成为 identity 的一部分，避免旧 verdict 被新的 policy manifest 重新解释。
+
+**与现有工作的差异。** Hubble 已经有 policy-verdict，Cilium 也已经给 source policy rule 加 label。新的性质是建立**从真实 datapath decision 到 deciding source-policy witness 的 generation-stable join**。
+
+**产物。** 一个 Cilium prototype，扩展 policy-map metadata 或增加 companion witness map，同时加入 Hubble decoder 与 retained generation manifest。
+
+**评测。** 在连续 policy update 下跑 connection matrix，并保留多个 generation 的 verdict event。删除旧 policy 后继续做解释。测 explanation accuracy、额外 BPF map memory、packet-path overhead、event bandwidth 和 manifest retention cost。比较 full per-packet provenance、sampled witness 与纯控制面 reconstruction。
+
+**学术价值。** 可以回答 enforcement datapath 至少要保留多少 provenance，才能在控制面不断变化时继续给出正确 explanation。
+
+**生产价值。** 安全和 SRE 团队可以从一次 unexpected allow 或 deny 直接定位 responsible policy owner，而不是 incident 之后再拼多个 live controller view。
+
+**失败条件。** 如果控制面 reconstruction 在 policy churn 后仍然完全准确且定位成本很低，或者 compact witness 已经明显降低 datapath scale，就应该把 witness 留在 sampled telemetry 或 userspace manifest，而不是 packet path。
+
+### 3. 做一个 counterexample-driven 的多租户 policy benchmark
+
+**缺口。** conformance test 能检查单个 resource 是否按 API 实现，却不一定发现多个合法 owner 把 policy 组合在一起以后产生的 operator mistake。
+
+**机制。** benchmark generator 明确定义 tenant、authority role 与 connectivity invariant，然后跨 Kubernetes 与 Cilium format 生成 policy set。每次只加入一种 controlled mutation，例如过宽 namespace selector、错误 tier、意外 `Pass`、tenant label 变化、L7 restriction、stale policy generation 或 policy-map capacity pressure。
+
+每个 mutation 同时给出两个 ground truth：packet 应该 allow 还是 deny，以及最小 explanation 是什么，也就是哪一个 authority 和 rule 应该决定结果、哪一个候选 rule 应该被忽略、delegated 或按照 additive 语义处理。
+
+**与现有工作的差异。** API conformance 主要验证 resource semantics。这里测的是**跨 owner、跨 format 的 composition mistake 与 explanation quality**，而且每个单独 policy object 都可以是合法的。
+
+**产物。** 可重复运行的 Kubernetes test suite、policy corpus、expected flow matrix、policy-generation history，先支持 Cilium，再随着其他 Network Policy API implementation 成熟增加 adapter。
+
+**评测。** 统计 datapath verdict correctness、explanation correctness、conflict detection precision/recall、定位 responsible owner 所需时间和资源 overhead。human/operator study 可以作为次要指标，主要 oracle 使用 generator 给出的 ground-truth decision graph。baseline 包括普通 `kubectl` 检查、Cilium 当前 policy/debug 工具、composition IR 与 datapath witness。
+
+**学术价值。** 它把 policy compositionality 和 explainability 变成可测系统性质，而不是只依赖配置事故案例。
+
+**生产价值。** CNI maintainer 与 platform team 可以针对真实的 multi-owner interaction 做 upgrade、API migration 和 organization guardrail regression test。
+
+**失败条件。** 如果真实生产 policy 很少混用 authority 或 format，生成出来的冲突也和实际 incident 不相似，这个 benchmark 就夸大了 corner case，应该缩小到 operator 真正部署的组合。
+
+## 不需要先替换 Kubernetes policy API
+
+这个 composition contract 可以渐进实现。
+
+第一版完全可以只运行在 Cilium control plane。它读取现有 policy object，在当前 realized policy 旁边生成 composition manifest，再用已有 policy tracing 比较预测与实际结果，不改 packet path。
+
+第二步只把 witness ID 加进 policy-verdict telemetry。如果这样已经足够解释 incident，就没有理由为每个 policy-map lookup 增加 metadata。
+
+只有当 policy churn 或 post-incident reconstruction 证明 telemetry-only witness 仍然不够时，才值得让 datapath 直接携带 generation-scoped witness。
+
+这种顺序很重要。eBPF 在这里提供 enforcement 和 observability，但真正难的是 policy semantic。一个在控制面已经被错误 flatten 的 authority model，不会因为 packet lookup 更快就自动变正确。
+
+## 哪些结果会改变这个判断？
+
+如果实际 benchmark 证明，当前 `ClusterNetworkPolicy` 语义加上 Cilium 已有 policy tracing，已经能对 operator 真正使用的多种 policy 组合给出稳定、机器可读、跨 generation 正确的 explanation，那么更好的选择是完善现有 tooling，而不是引入新的 composition IR。
+
+verdict witness 也不是无条件值得加入 datapath。如果它明显提高 policy-map pressure、降低 endpoint scale，或者引入纯控制面重建可以避免的 packet-path cost，就应该只保留在 sampled policy-verdict telemetry 或 userspace generation manifest。
+
+最后，Network Policy API 未来可能会把 tenancy model 定义得更直接。如果 tenant identity、ownership、delegation 与 precedence 都变成实现必须保留的明确语义，额外 composition layer 可以继续缩小。目标并不是创造另一种 policy language，而是让多个合法 policy owner 最终汇聚到一个 eBPF verdict 的过程**正确、可检查，而且在 policy generation 变化后仍然解释得通**。
+
+## 参考资料
+
+- [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [Kubernetes NetworkPolicy API reference](https://kubernetes.io/docs/reference/kubernetes-api/networking/network-policy-v1/)
+- [Network Policy API](https://network-policy-api.sigs.k8s.io/)
+- [Network Policy API v0.2.0 getting started](https://network-policy-api.sigs.k8s.io/getting-started/)
+- [Network Policy API specification](https://network-policy-api.sigs.k8s.io/reference/spec/)
+- [Network Policy API examples](https://network-policy-api.sigs.k8s.io/reference/examples/)
+- [NPEP-122: Tenancy API](https://network-policy-api.sigs.k8s.io/npeps/npep-122/)
+- [Network Policy API implementations](https://network-policy-api.sigs.k8s.io/implementations/)
+- [Cilium 1.20.1 Network Policy](https://docs.cilium.io/en/stable/network/kubernetes/policy/)
+- [Cilium eBPF Maps](https://docs.cilium.io/en/latest/network/ebpf/maps/)
+- [Cilium policy troubleshooting](https://docs.cilium.io/en/stable/security/policy/troubleshooting/)
+- [Cilium policy enforcement modes](https://docs.cilium.io/en/latest/security/policy/intro/)
+- [Cilium repository](https://github.com/cilium/cilium)

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [How Should eBPF Compose Multi-Tenant Network Policies?](https://eunomia.dev/research/ebpf-network-policy-composition/)
+
+Multi-tenant clusters can combine additive Kubernetes NetworkPolicy, tiered ClusterNetworkPolicy, and Cilium L3-L7 policy in one eBPF datapath. This report develops an authority-aware composition IR, generation-stable verdict witnesses, and a counterexample benchmark for explaining which policy owner and rule determined an effective verdict.
+
 ### [Can eBPF Compress Telemetry Without Losing the Diagnosis?](https://eunomia.dev/research/ebpf-diagnostic-telemetry-compression/)
 
 Always-on eBPF telemetry can become too expensive to export continuously, while counters and histograms can erase the context needed for later diagnosis. This report develops diagnostic contracts, state-transition exemplars, coverage-carrying summaries, and an equal-budget benchmark that scores diagnosis retention instead of compression ratio alone.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [多租户网络策略应该怎样在 eBPF 数据面里组合？](https://eunomia.dev/zh/research/ebpf-network-policy-composition/)
+
+多租户集群可能同时运行 additive 的 Kubernetes NetworkPolicy、带 tier 的 ClusterNetworkPolicy 和 Cilium L3-L7 policy。本文提出带 authority 的 composition IR、跨 generation 稳定的 verdict witness，以及专门检查多 owner 策略组合和 explanation correctness 的 counterexample benchmark。
+
 ### [eBPF 能压缩遥测数据而不丢失诊断依据吗？](https://eunomia.dev/zh/research/ebpf-diagnostic-telemetry-compression/)
 
 持续运行的 eBPF 遥测可能产生过多数据，而 counter 和 histogram 又会删掉后续诊断需要的上下文。本文提出 diagnostic contract、状态变化 exemplar、携带 coverage 的 summary，并用相同预算 benchmark 比较不同表示保留 root cause 的能力，而不是只比较 compression ratio。


### PR DESCRIPTION
## Evidence

- The configured Drive folder was rechecked on 2026-08-23. No weekly set beginning 2026-08-17 is present; finalized source coverage therefore remains GSC date rows through 2026-08-15 and GA4 weekly organic landing-page data through 2026-08-16.
- The valid equal-duration GSC comparison remains 393 clicks / 66,510 impressions for 2026-08-10..15 versus 478 / 69,053 for 2026-08-03..08. The missing 2026-08-09 row still blocks a complete 7-day comparison and verified history still cannot support the required 28-day comparison.
- The current public-safe brief reports homepage/robots/sitemap healthy, canonical https://eunomia.dev/, 690 sitemap entries, and no collector coverage gap. No technical SEO defect is established that warrants an unrelated implementation change.
- The published newest-ten Daily Report mix is 7 eBPF / 0 pure Agent / 3 adjacent. An eBPF-centered report remains compliant because the 2026-08-10 eBPF report ages out.
- The roadmap's transactional-policy-update candidate was rejected on novelty review: the existing stateful eBPF transactional-upgrade report already develops a prepare/migrate/commit/retire generation protocol across programs, maps, links, pinned state, controller recovery, and rollback.
- Current Kubernetes NetworkPolicy, Network Policy API v0.2.0/NPEP-122, and Cilium 1.20.1 evidence supports a distinct question around multi-owner policy semantics, authority, and realized eBPF verdict provenance.

## Scope

- Add exactly one bilingual Daily Report: `How Should eBPF Compose Multi-Tenant Network Policies?` / `多租户网络策略应该怎样在 eBPF 数据面里组合？`.
- Develop an authority-aware composition IR, generation-stable verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
- Update the EN/ZH Daily Report indexes and directly coupled current SEO/series operating records.
- Keep eBPF Networking and Security active after this first report.
- No unrelated technical SEO implementation change.
- No `seo-skills` pointer update; repository records still require contract migration before a pointer-only bump.

## Validation

- Fresh branch from main `daad7a63170800c686ac25c2a7b4b5d35858e338`.
- Pre-PR scope review: 9 files, limited to one bilingual report, its two indexes, today's daily record, and directly coupled current operating metadata.
- Both report variants contain the required gap section, three developed research directions with artifacts/evaluations/failure conditions, and the reader-facing conclusion boundary.
- Expected repository CI and generated-output checks must pass before merge. A complete final diff/generated-output self-review will be repeated after CI.

## Deployment and acceptance

After squash merge, wait for `Deploy Static App` on the exact squash commit. Then verify both production routes:

- `https://eunomia.dev/research/ebpf-network-policy-composition/`
- `https://eunomia.dev/zh/research/ebpf-network-policy-composition/`

Acceptance requires visible EN/ZH content, Daily Report navigation, locale-correct canonical and reciprocal hreflang/x-default, Article JSON-LD, intended internal links, the required gap/ideas sections, and the conclusion boundary. Close out with one compact comment on the merged PR; no second closeout PR.