### PR TITLE
Daily: define zero-copy buffer ownership across eBPF paths

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -20,7 +20,7 @@ already configured and enabled; it is not a blocker.
 Google Drive access is verified and is not a blocker. The configured folder
 contains adjacent weekly export sets beginning `2026-07-27`, `2026-08-03`, and
 `2026-08-10`; no newer weekly set beginning `2026-08-17` was observed on
-`2026-08-23`. The newest verified Search Console date rows remain through
+`2026-08-24`. The newest verified Search Console date rows remain through
 `2026-08-15`, which are finalized under the configured three-day lag.
 
 A complete latest-7-days versus previous-7-days Search Console comparison remains
@@ -34,7 +34,7 @@ GA4 landing-page files are weekly aggregates without a date dimension. The
 complete `2026-08-10` through `2026-08-16` aggregate is outside the configured
 three-day finalization lag and is usable as a finalized source-native weekly
 comparison against `2026-08-03` through `2026-08-09`. No newer weekly GA4 set
-was observed on `2026-08-23`. The landing-page exports do not provide complete
+was observed on `2026-08-24`. The landing-page exports do not provide complete
 acquisition, conversion, or outbound behavior coverage by themselves.
 
 These constraints never justify skipping the daily operation. Each run must use

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -84,13 +84,21 @@ migrate / commit / retire generation protocol across programs, links, maps,
 pinned state, controller recovery, and rollback. Repeating the same update
 transaction with a networking example would not materially advance the archive.
 
-The `2026-08-23` report therefore starts the active series with a distinct
-security-policy question: how additive Kubernetes `NetworkPolicy`, tiered
-`ClusterNetworkPolicy`, and Cilium L3-L7 policy can compose for multiple owners
-without losing authority, delegation, or source-policy provenance after the
-result is compiled into an eBPF datapath. It develops an authority-aware
-composition IR, generation-stable verdict witnesses, and a counterexample-driven
-multi-tenant policy benchmark.
+The `2026-08-23` report starts the active series with a distinct security-policy
+question: how additive Kubernetes `NetworkPolicy`, tiered `ClusterNetworkPolicy`,
+and Cilium L3-L7 policy can compose for multiple owners without losing authority,
+delegation, or source-policy provenance after the result is compiled into an
+eBPF datapath. It develops an authority-aware composition IR, generation-stable
+verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
+
+The `2026-08-24` report advances a second, materially different boundary. AF_XDP,
+io_uring ZC Rx, page_pool, and DPDK all recycle packet memory through native
+ownership protocols, while BPF policy decisions, NIC steering, and userspace
+processing can cross those boundaries. The report develops a generation-scoped
+buffer capability, policy-linked handoff witnesses, and a cross-path zero-copy
+fault benchmark. It is distinct from the earlier io_uring programmability report:
+the missing property here is buffer lease ownership and provenance across APIs,
+not BPF execution control inside the ring.
 
 ### Published progress
 
@@ -101,24 +109,32 @@ multi-tenant policy benchmark.
    source rule inspectable across policy generations. The report is
    eBPF-centered because the proposed provenance contract is evaluated against
    the realized BPF policy datapath, not only against Kubernetes objects.
+2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` separates
+   allocator-specific lifetime rules from a cross-path ownership contract. It
+   asks how packet-buffer leases can preserve owner, DMA reachability, recycle
+   generation, and BPF policy provenance across AF_XDP, io_uring ZC Rx, DPDK,
+   userspace eBPF, and NIC handoffs. It is eBPF-centered because policy identity
+   and BPF/user-runtime transitions are part of the correctness contract rather
+   than optional instrumentation.
 
 ### Preferred next questions
 
-1. zero-copy and programmable I/O paths across XDP, AF_XDP, io_uring, DPDK, and
-   userspace eBPF, with a networking/security question that does not repeat the
-   earlier io_uring control-surface report;
-2. information-flow enforcement across process, file, socket, and encrypted
-   application boundaries;
-3. verifier and runtime interfaces for richer stateful policies;
-4. portable policy execution between kernel, userspace, NIC, and DPU targets;
-5. revisit transactional network-policy rollout only when new evidence supports
+1. information-flow enforcement across process, file, socket, and encrypted
+   application boundaries, narrowed enough to avoid duplicating existing
+   ActPlane-style effect-label mechanisms;
+2. verifier and runtime interfaces for richer stateful policies;
+3. portable policy execution between kernel, userspace, NIC, and DPU targets;
+4. revisit transactional network-policy rollout only when new evidence supports
    a mechanism materially different from the published stateful-upgrade
-   generation protocol.
+   generation protocol;
+5. revisit zero-copy ownership only when implementation evidence or the proposed
+   cross-path benchmark exposes a distinct mechanism beyond the lease/provenance
+   contract developed on `2026-08-24`.
 
-Before and after the August 23 publication, the newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
-report ages the `2026-08-10` eBPF-centered transactional-upgrade report out of the
-rolling ten.
+Before the August 24 publication, the newest ten contain **7 eBPF-centered / 0
+pure Agent / 3 adjacent systems**. The incoming eBPF-centered report ages the
+`2026-08-12` eBPF-centered async-profiler report out of the rolling ten, so the
+window remains **7 / 0 / 3** after publication.
 
 ## Completed series — eBPF Observability and Profiling
 

--- a/.github/seo-data/daily/2026-08-24.md
+++ b/.github/seo-data/daily/2026-08-24.md
@@ -1,0 +1,116 @@
+# SEO operations — 2026-08-24
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Operation date: `2026-08-24`
+- Fresh branch: `daily/2026-08-24-ebpf-zero-copy-buffer-ownership`
+- Scope: analyze enabled SEO evidence, audit current technical SEO/GEO state, and publish exactly one bilingual Daily Report under the active eBPF Networking and Security series.
+- No unrelated homepage, tutorial, product, pricing, or speculative technical SEO change is included.
+
+## Data window
+
+The configured Google Drive folder was rechecked on `2026-08-24`. It still contains weekly export sets beginning `2026-07-27`, `2026-08-03`, and `2026-08-10`; an explicit search found no newer weekly set beginning `2026-08-17`.
+
+Search Console date rows are verified through `2026-08-15`, which is finalized under the configured three-day lag. The `2026-08-09` row remains absent, so a complete latest-seven-days versus previous-seven-days comparison is unavailable. Verified history is also still too short for the required 28-day comparison.
+
+The GA4 organic landing-page export for `2026-08-10..16` remains the newest finalized source-native weekly aggregate. Cloudflare is disabled by repository configuration and is not interpreted as zero.
+
+## Evidence collected
+
+| Source | Status | Verified coverage or observation |
+| --- | --- | --- |
+| Google Drive weekly exports | available, unchanged | No weekly set beginning `2026-08-17`; latest files remain the `2026-08-10..16` set. |
+| Google Search Console export | partial for required full-window comparison | Finalized date rows through `2026-08-15`; `2026-08-09` absent. |
+| Google Analytics 4 export | finalized weekly aggregate | `2026-08-10..16` is the newest available finalized weekly organic landing-page aggregate. |
+| Cloudflare | disabled | Not configured in `site.md`; no edge-native claim is made. |
+| Live/public site evidence | available | Public homepage is reachable; the current production export has an allow-all `robots.txt`, the canonical sitemap URL, and sitemap entries with EN/ZH plus `x-default` alternates. |
+| Public GitHub evidence | available | The Eunomia organization repository portfolio is accessible; project activity is used as public technical context rather than blended with search/acquisition metrics. |
+| Primary technical sources | reviewed | Current Linux AF_XDP, io_uring zero-copy Rx, and page_pool documentation plus current DPDK packet-buffer lifetime semantics. |
+
+Raw Google rows, Drive identifiers, queries, user-level analytics, credentials, account identifiers, and private source identifiers are not stored in this repository record.
+
+### GSC comparison
+
+The valid equal-duration six-day comparison remains:
+
+| Window | Clicks | Impressions | Weighted CTR | Weighted average position |
+| --- | ---: | ---: | ---: | ---: |
+| `2026-08-10..15` | 393 | 66,510 | ~0.591% | ~9.91 |
+| `2026-08-03..08` | 478 | 69,053 | ~0.692% | ~9.42 |
+
+Across these comparable windows, clicks are down about 17.8%, impressions about 3.7%, CTR about 0.101 percentage point, and weighted average position is about 0.49 worse. The earlier `2026-08-05` impression spike still lacks date-by-page or date-by-query evidence, so no page or query attribution is made.
+
+### GA4 comparison
+
+| Window | Organic landing-page sessions | Session-weighted engagement rate |
+| --- | ---: | ---: |
+| `2026-08-10..16` | 970 | ~44.95% |
+| `2026-08-03..09` | 991 | ~44.90% |
+
+Sessions are down about 2.1% while engagement is essentially flat. `(not set)` is 134 sessions in the newer aggregate versus 116 in the prior one; excluding `(not set)`, sessions are 836 versus 875. The landing-page export does not establish conversion or acquisition causes by itself.
+
+## Work performed
+
+### Technical SEO/GEO audit
+
+The current repository and public-site evidence does not establish a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, rendering, accessibility, performance, or deployment defect requiring a separate implementation change today. Search traffic remains softer in the comparable GSC window, but the available exports do not identify a page-level technical cause. No search-facing code or metadata change was invented to satisfy cadence.
+
+The `seo-skills` submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` is newer at `f42128a3f05c73cf10c786a2711c488bb3a14839`, but repository operating records require contract migration before a pointer-only update, so the pointer is intentionally unchanged.
+
+### Daily Report selection and implementation
+
+Before topic selection, the actually published newest ten reports are **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. Today's selected report is eBPF-centered. Publishing it ages the `2026-08-12` eBPF-centered async-profiler report out of the newest ten, so the rolling window remains **7 / 0 / 3**.
+
+Active series: **eBPF Networking and Security**.
+
+Two candidate directions were considered. Cross-boundary information-flow enforcement remains promising, but current Eunomia/ActPlane work already develops policy labels over process, file, and network effects, so a broad version has a higher novelty-overlap risk. The selected zero-copy candidate advances the active roadmap with a more distinct systems boundary.
+
+Selected report: **Who Owns a Packet Buffer in a Zero-Copy eBPF Datapath?** / **零拷贝 eBPF 数据路径里，谁拥有数据包缓冲区？**
+
+Classification: **eBPF-centered; eBPF Networking and Security**.
+
+Primary evidence shows that AF_XDP transfers UMEM-frame ownership through FILL and COMPLETION rings and permits shared UMEM with explicit synchronization requirements; io_uring ZC Rx delivers TCP payload directly into registered userspace memory, returns consumed buffers through a refill ring, and currently relies on out-of-band NIC steering configuration; page_pool tracks in-flight pages, DMA state, synchronization, and recycling inside kernel networking; and DPDK uses a different userspace packet-buffer lifetime model based on mbufs, mempools, reference counts, and external-buffer callbacks.
+
+The report develops three testable directions: a generation-scoped buffer capability for cross-path handoffs, compact policy-linked handoff witnesses that avoid payload capture by default, and a cross-path zero-copy fault benchmark that compares unmodified native APIs, metadata-only witnesses, and active capability checking.
+
+Files changed in the main delivery are limited to the bilingual report, EN/ZH Daily Report indexes, today's operating record, and directly coupled `status.md`, `plan.md`, `content-series.md`, `block.md`, and `site.md` state.
+
+## Validation and self-review
+
+Pre-PR review checked that:
+
+- exactly one new Daily Report topic exists in English and Chinese;
+- both variants contain the required concrete gap section;
+- both variants contain three developed directions with mechanism, delta, artifact, evaluation, academic/production value, and failure condition;
+- both variants contain a reader-facing conclusion/falsifier section;
+- titles, descriptions, openings, internal links, and source references follow the repository's SEO/GEO and writing rules;
+- the report does not restate the earlier io_uring BPF control-surface thesis; its central mechanism is cross-path buffer lease ownership and policy provenance;
+- no process-oriented banner, generation badge, inferred human author, raw analytics row, private Drive identifier, credential, or personal information is published;
+- the branch contains only the intended daily scope.
+
+Repository CI must reach success on the final head. After all expected checks are green, the complete final PR diff, changed-file list, generated output, check results, scope, public-data safety, and mergeability will be reviewed again before squash merge. Any issue found in that final review will be fixed on the same branch and the check/review cycle repeated.
+
+## Delivery
+
+- Pull request: `#172` (`https://github.com/eunomia-bpf/eunomia.dev/pull/172`)
+- Pull request type: real, non-draft, targeting `main`
+- Branch: `daily/2026-08-24-ebpf-zero-copy-buffer-ownership`
+- Main delivery state: awaiting successful expected CI and final self-review before squash merge
+- Production workflow after merge: `Deploy Static App` on the exact squash commit
+- Production acceptance routes:
+  - `https://eunomia.dev/research/ebpf-zero-copy-buffer-ownership/`
+  - `https://eunomia.dev/zh/research/ebpf-zero-copy-buffer-ownership/`
+
+Production acceptance requires visible EN/ZH content, Daily Report navigation, locale-correct canonical URLs, reciprocal hreflang plus `x-default`, Article JSON-LD, intended internal links, the required gap/ideas sections, and the conclusion boundary. The final merge, CI, deployment, and verification facts will be recorded once as the compact closeout comment on merged PR `#172`; no second closeout PR is created.
+
+## Decisions and follow-ups
+
+- Keep **eBPF Networking and Security** active after this second report.
+- Prefer a distinct next question such as cross-boundary information-flow enforcement, richer verifier/runtime interfaces for stateful security policy, or portable policy execution after fresh evidence and novelty review.
+- Recalculate the rolling newest-ten mix from the actual published index on the next run.
+- Recheck the configured Drive folder for a weekly set beginning `2026-08-17`; do not infer missing data as zero.
+- Keep full GSC 7-day and 28-day comparisons unavailable until source history supports them.
+- Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
+- Continue monitoring GSC softness before making a search-facing implementation change without page-level evidence.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -72,20 +72,21 @@ priorities that can guide a later daily run belong below.
 ## Current priorities
 
 1. Preserve the rolling ten-report mix mechanically from the actually published
-   archive. Before and after the `2026-08-23` eBPF multi-tenant network-policy
-   composition report, the newest ten are **7 eBPF-centered / 0 pure Agent / 3
-   adjacent systems** because the `2026-08-10` eBPF report ages out when today's
-   eBPF report enters.
+   archive. Before the `2026-08-24` zero-copy buffer-ownership report, the newest
+   ten are **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming
+   report is eBPF-centered and ages the `2026-08-12` eBPF-centered async-profiler
+   report out of the window, so the mix remains **7 / 0 / 3** after publication.
 2. Keep **eBPF Networking and Security** as the active series. The `2026-08-23`
-   report starts it with policy composition, authority provenance, and
-   explanation across Kubernetes and Cilium policy formats. The previously
-   preferred transactional-policy-update candidate was rejected for this run
-   because the existing stateful-upgrade report already covers a multi-object
-   prepare / migrate / commit / retire generation protocol. Prefer a distinct
-   next question such as zero-copy programmable I/O or cross-boundary
-   information-flow enforcement after fresh evidence and novelty review.
+   report established policy composition, authority provenance, and explanation
+   across Kubernetes and Cilium policy formats. The `2026-08-24` report advances
+   a distinct zero-copy question: buffer lease ownership, DMA reachability,
+   recycling, and policy provenance across AF_XDP, io_uring ZC Rx, DPDK, and
+   userspace eBPF paths. Prefer a next question such as cross-boundary
+   information-flow enforcement, richer verifier/runtime interfaces for stateful
+   security policy, or portable policy execution after fresh evidence and
+   novelty review.
 3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   On `2026-08-23`, no newer weekly set than `2026-08-10` through `2026-08-16`
+   On `2026-08-24`, no newer weekly set than `2026-08-10` through `2026-08-16`
    was observed. GA4 for that week is finalized. Search Console still lacks the
    `2026-08-09` date row, so keep complete 7-day and 28-day comparisons
    unavailable until source history actually supports them.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -53,7 +53,7 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
 `2026-08-16`; no newer weekly set beginning `2026-08-17` was observed in the
-configured Drive folder on `2026-08-22`. Search Console rows through
+configured Drive folder on `2026-08-24`. Search Console rows through
 `2026-08-15` are usable. The `2026-08-09` Search Console date row is still absent
 across the adjacent files, so a complete latest-7-days versus previous-7-days
 comparison remains unavailable. A valid equal-duration six-day comparison is

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -52,8 +52,8 @@ property IDs, account identifiers, credentials, or private URLs in Git.
 
 Search Console and GA4 exports provide weekly sets for `2026-07-27` through
 `2026-08-02`, `2026-08-03` through `2026-08-09`, and `2026-08-10` through
-`2026-08-16`; no newer weekly set beginning `2026-08-17` was observed in the
-configured Drive folder on `2026-08-24`. Search Console rows through
+`2026-08-16`; an explicit search of the configured Drive folder on `2026-08-24`
+found no newer weekly set beginning `2026-08-17`. Search Console rows through
 `2026-08-15` are usable. The `2026-08-09` Search Console date row is still absent
 across the adjacent files, so a complete latest-7-days versus previous-7-days
 comparison remains unavailable. A valid equal-duration six-day comparison is

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,56 +7,54 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Last verified data window: Search Console rows through `2026-08-15`; GA4 weekly organic landing-page files through `2026-08-16`
-- Latest daily record: `2026-08-23`
-- Last completed Daily Report pull request before the current run: `#168`
-- Last verified Daily Report squash commit: `d47759a492e36aa2895dbd6366045d92c36efffd`
-- Last verified production publication from a Daily Report run: static export commit `2066687c14dbde187baf0854200fd565447d3789`
-- Current daily branch: `daily/2026-08-23-ebpf-network-policy-composition`
+- Latest daily record: `2026-08-24`
+- Last completed Daily Report pull request before the current run: `#169`
+- Last verified Daily Report squash commit: `226ced7b443f81726d290f33cf86d614a76fec9f`
+- Last verified production publication from a Daily Report run: static export commit `29d044d1f7a41e3e20a3573ea2c6ba0dcd54b273`
+- Current daily branch: `daily/2026-08-24-ebpf-zero-copy-buffer-ownership`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#168` is closed out. It squash-merged as
-`d47759a492e36aa2895dbd6366045d92c36efffd`; production published static export
-commit `2066687c14dbde187baf0854200fd565447d3789`, whose commit message binds that
+PR `#169` is closed out. It squash-merged as
+`226ced7b443f81726d290f33cf86d614a76fec9f`; production published static export
+commit `29d044d1f7a41e3e20a3573ea2c6ba0dcd54b273`, whose commit message binds that
 export to the exact squash commit. The merged-PR closeout comment records green
 pre-merge checks, exact production publication, bilingual report/index metadata,
-and the remaining external crawler-cache limitation.
+and the remaining Google-history limitations.
 
 ## Current Daily Report mix
 
-Immediately before the `2026-08-23` report, the actually published newest ten
+Immediately before the `2026-08-24` report, the actually published newest ten
 reports are:
 
 - eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
 - adjacent systems: **3 of 10**
 
-Today's `/research/ebpf-network-policy-composition/` report is **eBPF-centered**.
-It asks how several policy owners and policy languages can be compiled into an
-eBPF network datapath without losing authority, precedence, delegation, or
-explanation provenance. Publishing it ages the `2026-08-10` eBPF-centered
-transactional-upgrade report out of the newest ten, so the rolling window remains
-**7 eBPF / 0 pure Agent / 3 adjacent**.
+Today's `/research/ebpf-zero-copy-buffer-ownership/` report is **eBPF-centered**.
+It asks how AF_XDP, io_uring ZC Rx, DPDK, and userspace eBPF paths can preserve
+buffer lease ownership, DMA reachability, recycling state, and policy provenance
+across kernel/userspace/NIC handoffs. Publishing it ages the `2026-08-12`
+eBPF-centered async-profiler report out of the newest ten, so the rolling window
+remains **7 eBPF / 0 pure Agent / 3 adjacent**.
 
-The active series is **eBPF Networking and Security**. The roadmap's first
-transactional-policy candidate was rejected for this run because the existing
-stateful eBPF transactional-upgrade report already develops the multi-object
-generation protocol. The selected multi-tenant network-policy composition
-question is materially distinct: policy semantics and authority are the central
-mechanisms, not update atomicity.
+The active series is **eBPF Networking and Security**. The `2026-08-23` report
+established policy composition and authority provenance across Kubernetes and
+Cilium policy formats. The `2026-08-24` report advances a distinct boundary:
+zero-copy packet-memory ownership and provenance across native I/O APIs. The
+central mechanism is a generation-scoped buffer capability plus policy-linked
+handoff witness, not another io_uring BPF execution-control abstraction.
 
 ## Current signals
 
-- Repository-generated public-safe operating brief: refreshed `2026-08-23 07:53 UTC`
-- Homepage: HTTP 200 in **155 ms**
-- `robots.txt`: HTTP 200; sitemap: HTTP 200
-- Sitemap entries observed: **690**
-- Canonical homepage: `https://eunomia.dev/`
-- Public GitHub portfolio snapshot: 98 active non-fork repositories, **9,801** stars, 1,282 forks, and 273 open issue/PR records
-- DEV publication surface: 60 articles, 43 public reactions, and 4 comments
+- Google Drive configured evidence: rechecked `2026-08-24`; no weekly set beginning `2026-08-17` was observed
+- Public homepage: reachable
+- Current production `robots.txt`: allows crawling and advertises `https://eunomia.dev/sitemap.xml`
+- Current production sitemap: absolute canonical URLs with English, Chinese, and `x-default` language alternates are present
+- Public GitHub repository evidence: available
 - Public web and primary-source evidence: available
 - Google Analytics 4: finalized weekly organic landing-page exports through `2026-08-16`
 - Google Search Console: weekly export set through the week ending `2026-08-16`; finalized date rows currently end on `2026-08-15`
-- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-23`
+- Newer weekly Google set beginning `2026-08-17`: not observed in the configured Drive folder on `2026-08-24`
 - Cloudflare: disabled by repository configuration
 
 For the valid equal-duration Search Console comparison, `2026-08-10` through
@@ -86,26 +84,27 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and static audit artifacts. Production
 deploys through `Deploy Static App`.
 
-The August 23 public-safe collector reports healthy homepage, robots, sitemap,
-and canonical checks. The available Google evidence and repository output do not
-establish a crawl, canonical, hreflang, structured-data, redirect, broken-link,
-rendering, accessibility, performance, or deployment defect requiring a separate
-technical SEO patch today.
+The August 24 evidence shows a reachable homepage, a valid production robots file,
+and sitemap language alternates. The available Google evidence and repository
+output do not establish a crawl, canonical, hreflang, structured-data, redirect,
+broken-link, rendering, accessibility, performance, or deployment defect requiring
+a separate technical SEO patch today.
 
-Today's report uses current Kubernetes NetworkPolicy, Network Policy API v0.2.0,
-NPEP-122 tenancy work, and Cilium 1.20.1 policy/eBPF documentation. It develops
-an authority-aware composition IR, generation-stable datapath verdict witnesses,
-and a counterexample-driven multi-tenant policy benchmark.
+Today's report uses current Linux AF_XDP, io_uring zero-copy Rx, and page_pool
+documentation plus DPDK packet-buffer lifetime semantics. It develops a
+generation-scoped zero-copy buffer capability, policy-linked handoff witnesses,
+and a cross-path fault benchmark.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream contains newer commits, but
-the consuming repository still requires contract migration before a pointer-only
-update, so this daily run intentionally leaves the pointer unchanged.
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` is currently
+`f42128a3f05c73cf10c786a2711c488bb3a14839`, but the consuming repository still
+requires contract migration before a pointer-only update, so this daily run
+intentionally leaves the pointer unchanged.
 
 ## Current focus
 
-1. Complete the `2026-08-23` eBPF multi-tenant network-policy composition Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. Keep **eBPF Networking and Security** active after this first report; prefer the next distinct roadmapped question only after fresh evidence and novelty review.
+1. Complete the `2026-08-24` zero-copy buffer-ownership Daily Report through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Keep **eBPF Networking and Security** active after this second report; prefer a distinct next question such as information-flow enforcement, richer stateful-policy verifier/runtime interfaces, or portable policy execution after fresh evidence and novelty review.
 3. Keep the complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never treat the missing `2026-08-09` row as zero.
 4. Obtain date-by-page or date-by-query evidence before attributing the `2026-08-05` impression spike.
 5. Monitor another finalized Search Console period before changing search-facing titles, copy, or navigation without page-level evidence.

--- a/docs/research/ebpf-zero-copy-buffer-ownership.md
+++ b/docs/research/ebpf-zero-copy-buffer-ownership.md
@@ -1,0 +1,240 @@
+---
+date: 2026-08-24
+title: "Who Owns a Packet Buffer in a Zero-Copy eBPF Datapath?"
+description: "AF_XDP, io_uring ZC Rx, and DPDK recycle buffers differently. This report develops ownership capabilities and policy provenance for zero-copy eBPF paths."
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - XDP
+  - Zero Copy
+research_question: "How should a zero-copy eBPF networking path represent buffer ownership, DMA reachability, recycling, and policy provenance across kernel, userspace, and NIC handoffs?"
+source_cutoff: 2026-08-24
+status: daily-report
+---
+
+# Who Owns a Packet Buffer in a Zero-Copy eBPF Datapath?
+
+A packet enters an XDP program, gets redirected into AF_XDP, is inspected by a userspace dataplane, and later goes back to a NIC. The application sees the same UMEM address several times. The bytes may never be copied. That is the performance win.
+
+It also creates a less obvious systems question: **at each moment, who is allowed to touch that buffer, which device may DMA into it, when may it be recycled, and which policy decision still applies to the bytes now occupying that address?**
+
+<!-- more -->
+
+Linux already has strong local answers for parts of this problem. [AF_XDP](https://docs.kernel.org/networking/af_xdp.html) uses explicit FILL and COMPLETION rings to transfer ownership of UMEM frames between userspace and the kernel. [io_uring zero-copy Rx](https://docs.kernel.org/networking/iou-zcrx.html) receives TCP payload directly into registered userspace memory and uses a refill ring to return consumed buffers. The kernel [page_pool](https://docs.kernel.org/networking/page_pool.html) tracks in-flight packet pages, DMA mapping, synchronization, and recycling. DPDK has its own packet-buffer model built around `rte_mbuf`, mempools, reference counts, and external-buffer lifetime callbacks.
+
+Each mechanism is reasonable inside its own path. The problem appears when a high-performance dataplane crosses several paths and expects one security or provenance story to survive them.
+
+Consider AF_XDP first. An XDP program can redirect an ingress frame through an `XSKMAP` into userspace. The AF_XDP documentation is unusually explicit about ownership: the FILL ring transfers a UMEM frame from userspace to the kernel; the COMPLETION ring transfers a processed TX frame back to userspace. Shared UMEM is possible across sockets and queues, but its producer/consumer rules need explicit synchronization. The documentation also warns that placing one frame into conflicting ownership paths can corrupt packets because the NIC may receive or transmit through the same memory concurrently.
+
+Now compare io_uring ZC Rx. It deliberately keeps TCP header processing in the kernel while delivering payload into userspace memory without the kernel-to-user copy. The NIC must support header/data split, RSS, and flow steering. The current kernel interface does not configure that NIC state; the user sets it up out of band. Consumed buffers are returned through the refill ring and become available to the kernel again.
+
+DPDK moves the boundary farther into userspace. Its current programmer documentation describes a userspace packet-processing framework whose `mbuf` objects come from memory pools. Its external-buffer API uses a separate reference count and a free callback so the buffer can be released only after all attached mbufs detach. That is another valid lifetime protocol, but it is not the AF_XDP protocol and it is not the io_uring ZC Rx protocol.
+
+The common mental model is that zero copy is mainly a data-movement optimization. If every subsystem already has a ring, reference count, or page lifetime rule, then correctness should be a local implementation detail.
+
+That model is incomplete for programmable networking. A BPF program may make a security decision before an AF_XDP handoff. NIC steering may then move a flow to a queue configured outside the BPF control plane. A userspace runtime may apply another policy. The same physical or virtual address can later hold an unrelated packet after recycling. Local lifetime rules prevent many use-after-free bugs, but they do not automatically preserve **policy generation, provenance, or authority across the handoff**.
+
+This report argues for treating a zero-copy buffer handoff as a typed capability transition, not only as a queue operation. The capability should be generation-scoped, cheap enough for fast paths, and rich enough to answer three questions after an incident: who owned the buffer, which policy authorized the transition, and whether the address had already been recycled into a different logical packet.
+
+This is distinct from the earlier [io_uring eBPF programmability report](https://eunomia.dev/research/io-uring-bpf-programmability/), which asked what control surface BPF should have inside an io_uring execution loop. It is also distinct from the [heterogeneous eBPF placement report](https://eunomia.dev/research/heterogeneous-ebpf-execution-placement/), which asked where a BPF program should execute. Here the execution location may already be chosen. The missing property is a common lifetime and provenance contract for the memory crossing those locations.
+
+## Zero copy already means explicit ownership transfer
+
+The first useful observation is that zero copy does not remove ownership. It makes ownership more important because the same memory is reused aggressively.
+
+### AF_XDP makes the transfer visible in rings
+
+An AF_XDP socket connects an XDP program to a UMEM region supplied by userspace. RX and TX descriptors refer to offsets in that UMEM. The kernel documentation says the FILL and COMPLETION rings transfer ownership of frames between userspace and the kernel.
+
+That wording matters. A FILL entry is not just a free-list hint. Once userspace publishes the address, the kernel may use that frame for ingress. A COMPLETION entry gives the frame back to userspace after the kernel has finished processing the corresponding TX descriptor. The documentation also notes that completion does not prove successful transmission, only that the frame can be reused.
+
+Shared UMEM makes the ownership topology more interesting. Several sockets can reference the same memory, including sockets on different queues or devices. The rings are single-producer/single-consumer, so applications need their own synchronization. AF_XDP therefore already exposes a small distributed ownership protocol among an XDP program, kernel socket machinery, userspace workers, and the NIC.
+
+The protocol is path-local, however. It does not say that a frame was admitted under policy generation 84, redirected by rule 19, then inspected by userspace policy generation 52 before reuse.
+
+### io_uring ZC Rx splits control and data paths
+
+io_uring ZC Rx exposes a different boundary. Packet headers stay in the normal kernel TCP stack while payload is placed directly in registered userspace memory. The application later returns consumed areas to the kernel through the refill ring.
+
+The NIC setup is currently out of band. Users configure header/data split, RSS, and flow steering before registering the io_uring queue. This makes a useful counterexample to a pure BPF-centric model: the packet's actual path can depend on hardware queue state that is not itself represented in the BPF policy objects.
+
+A policy debugger that sees only the XDP or socket decision can therefore miss a queue-steering change that moved traffic into or out of the zero-copy path. The bytes are correct and the buffer lifetime may be correct, while the explanation of *why this flow followed this path* is incomplete.
+
+### page_pool protects a kernel-local recycling contract
+
+The kernel page_pool allocator is optimized for pages and fragments used by skb and XDP frames. Its documentation describes in-flight accounting, reference handling, DMA mapping, device synchronization, and direct recycling in safe contexts such as NAPI.
+
+This is useful evidence that high-performance packet memory already needs more than `malloc` and `free`. The allocator tracks whether a page can be recycled and when DMA synchronization must happen. But page_pool intentionally solves a kernel networking allocator problem. It does not define a portable logical packet identity across AF_XDP, io_uring, a userspace BPF runtime, or DPDK.
+
+### DPDK uses a different userspace lifetime model
+
+DPDK's `rte_mbuf` model puts packet metadata in userspace and uses mempools for reuse. External buffers have their own shared information, reference count, and free callback. The callback runs when attached mbufs no longer reference the buffer.
+
+That protocol can express sharing that would be awkward with a single owner bit. It also illustrates the abstraction mismatch: AF_XDP communicates ownership through rings, page_pool through kernel references and recycle APIs, io_uring ZC Rx through completion/refill state, and DPDK through mbuf ownership and reference counts.
+
+Trying to replace all of them with one allocator would be the wrong goal. The more useful abstraction is a **common handoff contract above the allocator**, with adapters that preserve the native fast path.
+
+## The hard bug is stale meaning, not only stale memory
+
+Suppose UMEM frame `0x4000` first carries a packet from tenant A. An XDP program running policy generation 84 redirects it to an AF_XDP socket. Userspace consumes the packet, the frame returns through a completion or refill path, and later the same address carries a packet from tenant B under policy generation 85.
+
+A trace that stores only `addr=0x4000` cannot safely join the two events. The address is a storage location, not a stable packet identity.
+
+This is the same kind of mistake that appears when a PID is treated as a process identity across reuse, or when a map entry is interpreted without its configuration generation. Zero-copy networking amplifies it because address reuse is intentional and frequent.
+
+The minimal logical identity needs at least a generation or lease epoch:
+
+```text
+buffer_ref = {
+  region_id,
+  offset,
+  lease_generation
+}
+```
+
+A handoff can then carry the policy and execution context that was true for that lease:
+
+```text
+handoff = {
+  buffer_ref,
+  from_owner,
+  to_owner,
+  queue_or_device,
+  dma_domain,
+  policy_generation,
+  decision_id,
+  transition_seq
+}
+```
+
+This metadata should not travel in every packet header. It can live in a bounded side table, a userspace manifest, sampled transition events, or a compact token encoded in metadata that a particular path already carries. The research question is how little state is sufficient to prove the important invariants.
+
+## Where current work is still weak
+
+### 1. Path-local ownership protocols do not compose into one cross-boundary contract
+
+AF_XDP, io_uring ZC Rx, page_pool, and DPDK each define when their own buffer can be reused. They do not share one notion of owner, lease generation, DMA reachability, or handoff authority.
+
+The missing capability is not a universal memory allocator. It is a machine-readable transition model that can say, for example, "userspace relinquished this AF_XDP frame to kernel RX", "the NIC may DMA into this lease", and "this lease was later recycled and must no longer inherit the earlier packet's policy witness."
+
+A decisive experiment would connect two or more native zero-copy paths, inject ownership mistakes at their boundary, and compare a common contract against the unmodified path-local APIs. If all injected faults are already rejected at the native boundary with equally useful diagnostics, the extra abstraction is unnecessary.
+
+### 2. Buffer addresses are reused faster than policy provenance
+
+Fast paths want to recycle addresses. Incident analysis wants stable identities. Those goals conflict if observability joins events by address alone.
+
+The missing property is a generation-scoped buffer identity that survives long enough to relate a BPF decision to the exact logical packet lease, then expires when the memory is recycled. A stable physical address should be allowed to produce many distinct logical identities over time.
+
+The test is straightforward: recycle a small UMEM aggressively while changing policy generations and interleaving tenants. An analyzer should never attribute a generation-84 decision to generation-85 bytes merely because the address matches.
+
+### 3. Hardware steering can change the zero-copy boundary outside the BPF control plane
+
+io_uring ZC Rx currently requires out-of-band NIC configuration for header/data split, RSS, and flow steering. AF_XDP can also share UMEM across queues and devices. DPDK may bypass the normal kernel networking path entirely.
+
+The missing capability is a compact description of the *realized path* that can be joined with BPF policy state: NIC queue, steering generation, memory region, and the handoff that moved the packet into userspace. Without it, a security policy may be correct at one hook while the operator's model of which traffic reaches that hook is stale.
+
+A discriminating evaluation would mutate steering rules while keeping BPF policy constant. If the system's explanation cannot tell that traffic moved to a different queue or userspace path, the policy observability boundary is incomplete.
+
+### 4. Zero-copy failures are hard to diagnose without copying the payload
+
+The obvious debugging response is to capture packets. That can destroy the performance property being debugged, expose sensitive payloads, and still fail to explain buffer ownership.
+
+The missing mechanism is metadata-first evidence: ownership transitions, lease generations, queue identities, policy witnesses, and drop/recycle reasons without retaining packet contents by default.
+
+The test should compare full packet capture, ordinary counters, and metadata-only witnesses under the same fault set. A useful witness design should diagnose double reuse, stale policy attribution, and wrong-path steering with much less data than payload capture.
+
+## Promising directions with academic and production value
+
+### 1. A generation-scoped buffer capability for zero-copy handoffs
+
+**Gap.** Native APIs expose path-specific lifetime rules but no portable representation of ownership and policy provenance across them.
+
+**Mechanism.** Give every active zero-copy buffer lease a compact capability:
+
+```text
+cap = {
+  region_id,
+  offset,
+  generation,
+  owner,
+  access_mode,
+  dma_target,
+  policy_generation
+}
+```
+
+Transitions are explicit operations such as `USER_TO_RX`, `RX_TO_USER`, `USER_TO_TX`, `TX_COMPLETE`, `USER_TO_IOURING_REFILL`, and adapter-specific DPDK attach/detach transitions. The capability is invalidated on recycle and recreated with a new generation. The native ring or mbuf remains the fast-path source of truth; the capability layer mirrors only the state needed for cross-path checking and provenance.
+
+For eBPF, a verifier-friendly representation could keep immutable region descriptors in maps and use bounded per-CPU or per-queue state for active generations. Userspace eBPF runtimes such as [bpftime](https://github.com/eunomia-bpf/bpftime) could consume the same schema at their attach boundary rather than inventing a different packet-lifetime vocabulary.
+
+**Delta.** Existing APIs protect their own object lifetime. The new property is a typed capability whose generation and authority survive a transition between APIs without requiring them to use the same allocator.
+
+**Artifact.** A small UAPI-neutral schema, AF_XDP and io_uring adapters, an optional DPDK adapter, a BPF-side checker for selected transitions, and a userspace validator that can reconstruct the lease state machine.
+
+**Evaluation.** Run line-rate forwarding with AF_XDP zero-copy, io_uring ZC Rx, and DPDK variants. Measure packets per second, CPU cycles per packet, cache misses, memory overhead, and tail latency. Inject double-fill, premature recycle, use after completion, stale policy generation, worker crash, and NIC reset faults. Measure prevention rate and diagnostic precision.
+
+**Academic value.** This asks whether linear or capability-like ownership can be made practical across kernel, userspace, and device packet-memory protocols without putting a general-purpose type system on the fast path.
+
+**Production value.** A runtime can fail closed on invalid handoffs and explain the exact lease transition rather than reporting generic packet corruption.
+
+**Failure condition.** If the capability shadow state costs enough cache traffic to erase the zero-copy benefit, or if native APIs already catch the cross-path failures with equivalent provenance, the mechanism should be rejected.
+
+### 2. Preserve a compact handoff witness with each policy generation
+
+**Gap.** A security decision and the buffer lifetime often live in separate evidence streams. Recycled addresses make timestamp-only joining unsafe.
+
+**Mechanism.** Assign each relevant BPF policy decision a compact `decision_id` scoped to a policy generation. At zero-copy handoffs, emit or retain a witness containing the buffer lease generation, decision ID, source and destination owner classes, device/queue, and transition sequence. Userspace keeps the reverse mapping from `decision_id` to policy object or rule.
+
+The witness does not contain packet payload by default. It can be emitted only for denies, anomalous transitions, policy-generation changes, and a sampled fraction of ordinary allows. The goal is not tracing every packet. The goal is to make later evidence unambiguous when a buffer address has been reused hundreds of times.
+
+**Delta.** Existing packet traces can show addresses, queue events, or policy verdicts. The new property is an explicit join key between the *logical buffer lease* and the *policy generation that authorized the handoff*.
+
+**Artifact.** A witness format, BPF map/event helpers, an AF_XDP userspace library wrapper, and a command that reconstructs one packet lease without reading payload contents.
+
+**Evaluation.** Drive a tiny UMEM at high reuse rates while rotating policies and queue steering. Compare address-only correlation, timestamp-based correlation, and generation-scoped witnesses. Score false joins, missed joins, evidence volume, and root-cause accuracy. Include adversarial timing where two generations reuse the same frame within one scheduler tick.
+
+**Academic value.** This creates a measurable provenance problem at the boundary between systems security and high-performance I/O rather than treating provenance as an unlimited logging problem.
+
+**Production value.** Operators can answer "which policy admitted these bytes before this userspace handoff?" without full packet capture or preserving old control-plane state forever.
+
+**Failure condition.** If generation-scoped witnesses do not materially reduce false attribution compared with cheaper queue-local counters and timestamps, they are unnecessary metadata.
+
+### 3. Build a cross-path zero-copy fault benchmark before standardizing the contract
+
+**Gap.** It is easy to design a beautiful ownership schema without proving that real mixed datapaths need it.
+
+**Mechanism.** Build a benchmark that composes native paths rather than testing them in isolation. Scenarios should include XDP to AF_XDP, AF_XDP forwarding across shared UMEM, TCP payload delivery through io_uring ZC Rx, DPDK external buffers, and an optional userspace eBPF policy stage. Each scenario declares the expected ownership and policy-generation sequence, then a fault injector violates one boundary at a time.
+
+Faults should include:
+
+- the same AF_XDP frame published to conflicting ownership paths;
+- a recycled address reused under a new tenant or policy generation;
+- a queue-steering change that moves a flow outside the expected BPF path;
+- userspace exit while buffers are outstanding;
+- delayed completion followed by premature reuse;
+- NIC reset or queue reconfiguration during a policy update;
+- a DPDK external buffer detached while another logical packet reference remains.
+
+The benchmark should compare three designs: unmodified native APIs, metadata-only witness collection, and active capability checking.
+
+**Delta.** Existing API selftests verify individual mechanisms. The proposed benchmark makes *composition failure* the unit of evaluation and gives the contract proposal a way to fail.
+
+**Artifact.** Reproducible traffic generators, fault injectors, a reference ownership trace, and graders for safety, provenance correctness, diagnosis time, and performance overhead.
+
+**Evaluation.** Besides throughput and latency, report fault-detection recall, false positives, false policy joins after buffer reuse, recovery correctness, and bytes of evidence per million packets. Run across at least two NIC/driver combinations because zero-copy and DMA behavior is hardware-sensitive.
+
+**Academic value.** The benchmark can distinguish a real cross-boundary abstraction problem from a collection of implementation bugs.
+
+**Production value.** Networking runtimes get regression tests for failures that otherwise appear only under load, queue reconfiguration, or rapid buffer reuse.
+
+**Failure condition.** If realistic compositions do not produce failures beyond what each native API already detects, the right result is to improve local diagnostics instead of standardizing a new contract.
+
+## What would change this conclusion?
+
+The strongest alternative is that zero-copy ownership should stay intentionally path-specific. AF_XDP rings, io_uring refill state, page_pool references, and DPDK mbuf reference counts are optimized around different execution models. A common capability layer could add cache pressure, duplicate state, and new failure modes while providing little more than a tracing convention.
+
+That alternative wins if experiments show three things together: native APIs already reject the important cross-path misuse cases; address and timestamp correlation is reliable enough under realistic reuse; and hardware steering changes can be reconstructed cheaply from existing control-plane state.
+
+The conclusion changes in the other direction if mixed datapaths repeatedly produce failures that are individually legal inside each subsystem but collectively violate buffer ownership or policy provenance. In that case, the missing abstraction is not another zero-copy transport. It is a small contract that says what one buffer lease means as bytes move through BPF, kernel networking, userspace, and the NIC.

--- a/docs/research/ebpf-zero-copy-buffer-ownership.zh.md
+++ b/docs/research/ebpf-zero-copy-buffer-ownership.zh.md
@@ -1,0 +1,240 @@
+---
+date: 2026-08-24
+title: "零拷贝 eBPF 数据路径里，谁拥有数据包缓冲区？"
+description: "AF_XDP、io_uring ZC Rx 与 DPDK 都依赖缓冲区复用，但所有权和回收协议不同。本文提出跨内核、用户态与网卡的缓冲区能力、策略 provenance 与故障注入评测。"
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - XDP
+  - Zero Copy
+research_question: "零拷贝 eBPF 网络路径应该怎样表示缓冲区所有权、DMA 可达性、回收状态和策略 provenance，使这些语义能跨内核、用户态与网卡 handoff 保持一致？"
+source_cutoff: 2026-08-24
+status: daily-report
+---
+
+# 零拷贝 eBPF 数据路径里，谁拥有数据包缓冲区？
+
+一个包先进入 XDP 程序，被重定向到 AF_XDP，在用户态 dataplane 里检查，然后再送回网卡。应用可能反复看到同一个 UMEM 地址，数据本身一次都没有复制。这正是 zero copy 想得到的性能收益。
+
+但它也带来一个更容易被忽略的问题：**每个时刻到底是谁有权访问这个 buffer，哪个设备可以向它 DMA，什么时候可以回收，以及这个地址里当前这批字节还应该关联哪一代策略决定？**
+
+<!-- more -->
+
+Linux 对这个问题的局部答案其实已经很明确。[AF_XDP](https://docs.kernel.org/networking/af_xdp.html) 用 FILL 和 COMPLETION ring 在用户态与内核之间移交 UMEM frame 的所有权。[io_uring zero-copy Rx](https://docs.kernel.org/networking/iou-zcrx.html) 让 TCP payload 直接进入注册的用户态内存，再通过 refill ring 把已经消费的 buffer 交还内核。内核 [page_pool](https://docs.kernel.org/networking/page_pool.html) 负责 packet page 的 in-flight 计数、DMA mapping、同步和回收。DPDK 则用 `rte_mbuf`、mempool、reference count 和 external-buffer callback 管理用户态 packet buffer 生命周期。
+
+这些机制在各自路径内部都很合理。真正困难的是，一个高性能 datapath 同时跨过几种路径时，能不能让同一套安全语义和 provenance 跟着 buffer 一起走。
+
+先看 AF_XDP。XDP 程序可以通过 `XSKMAP` 把 ingress frame 重定向到用户态。AF_XDP 文档对 ownership 的描述非常直接：FILL ring 把 UMEM frame 从用户态交给内核，COMPLETION ring 把已经完成 TX 处理的 frame 从内核交回用户态。UMEM 可以跨 socket、queue 甚至 device 共享，但单生产者/单消费者 ring 需要应用自己保证同步。文档还明确提醒，如果同一个 frame 同时被放进互相冲突的 ownership path，NIC 可能并发收发同一块内存，从而造成 packet corruption。
+
+再看 io_uring ZC Rx。它没有绕过整个 TCP stack。packet header 仍然在内核里正常处理，payload 才直接放到用户态内存。NIC 需要 header/data split、RSS 和 flow steering。当前 kernel API 并不负责配置这些 NIC 状态，用户需要在 io_uring 注册之前从带外完成。应用消费完数据后，再通过 refill ring 把对应的内存区域交还给内核。
+
+DPDK 把边界继续推到用户态。它的 packet buffer 由 `rte_mbuf` 和 mempool 管理。external buffer 有独立的 reference count 和 free callback，只有最后一个关联 mbuf 脱离后，buffer 才能真正释放。这同样是一套有效的 lifetime protocol，但它不是 AF_XDP 的 ring protocol，也不是 io_uring ZC Rx 的 refill protocol。
+
+常见的理解是，zero copy 主要是在优化 data movement。既然每个子系统已经有 ring、reference count 或 page lifecycle，那么 correctness 应该只是各自实现内部的问题。
+
+对 programmable networking 来说，这个理解还不够。一个 BPF 程序可能在 AF_XDP handoff 之前做完安全决定；之后 NIC steering 又可能把 flow 切到另一个 queue，而这个 queue 配置并不属于 BPF control plane；用户态 runtime 还可能再执行一层策略。buffer 被回收之后，同一个物理或虚拟地址很快就会承载另一个完全无关的 packet。局部 lifetime rule 能避免很多 use-after-free，但它不会自动保留 **policy generation、provenance 和 authority**。
+
+本文的观点是：zero-copy buffer handoff 应该被看成一种 typed capability transition，而不只是 ring operation。这个 capability 必须有 generation，fast path 开销要足够小，同时要能在事故发生后回答三个问题：当时谁拥有 buffer，哪条策略授权了这次 handoff，以及这个地址是不是已经被回收到另一个逻辑 packet 上。
+
+这个问题和之前的 [io_uring eBPF 可编程性报告](https://eunomia.dev/zh/research/io-uring-bpf-programmability/) 不一样。那篇讨论的是 BPF 在 io_uring execution loop 里应该拥有什么 control surface。它也不同于 [异构 eBPF 执行位置报告](https://eunomia.dev/zh/research/heterogeneous-ebpf-execution-placement/)，后者讨论程序应该运行在内核、用户态还是设备侧。这里假设执行位置已经选好，缺的是跨这些位置移动的内存怎样保持统一的 lifetime 与 provenance contract。
+
+## Zero copy 并没有消除所有权，它把所有权变得更重要
+
+zero copy 的核心是高频复用同一块内存。因此 ownership 不会消失，反而更需要被准确表达。
+
+### AF_XDP 把所有权移交显式放进 ring
+
+AF_XDP socket 把 XDP 程序连接到用户态提供的 UMEM。RX 和 TX descriptor 通过 UMEM offset 指向数据。内核文档明确把 FILL 和 COMPLETION ring 描述为在用户态与内核之间转移 frame ownership 的机制。
+
+这个措辞很重要。FILL entry 不是普通 free-list hint。用户态一旦发布一个地址，内核就可能把它用于 ingress。COMPLETION entry 表示内核已经处理完相应 TX descriptor，frame 可以重新由用户态使用。文档还特别说明，completion 只证明 ownership 已经回来，并不等价于 packet 一定成功发送。
+
+shared UMEM 让 ownership topology 更复杂。多个 socket 可以引用同一块内存，包括不同 queue 和不同 device 上的 socket。ring 是 single-producer/single-consumer，因此应用必须自己同步。实际上，AF_XDP 已经形成了一个由 XDP program、kernel socket path、userspace worker 和 NIC 共同参与的小型 ownership protocol。
+
+问题在于，这个 protocol 只描述 AF_XDP 自己的路径。它不会告诉我们某个 frame 是在 policy generation 84 下由 rule 19 放行，之后又在 userspace policy generation 52 下处理，最后才被回收。
+
+### io_uring ZC Rx 把控制路径和数据路径拆开
+
+io_uring ZC Rx 暴露的是另一种边界。header 继续走内核 TCP stack，payload 直接进入注册的 userspace memory。应用处理后通过 refill ring 把内存交回内核。
+
+NIC setup 目前需要带外完成。用户要配置 header/data split、RSS 和 flow steering，之后才能注册对应的 io_uring queue。这是一个很好的反例：packet 实际走哪条路径，可能取决于 BPF policy object 完全看不到的 hardware queue state。
+
+因此，一个只看到 XDP 或 socket verdict 的 debugger 可能会漏掉关键变化：flow steering 已经把流量切进或切出 zero-copy queue。buffer 生命周期完全正确，数据也没有损坏，但系统对“为什么这个 flow 走了这条路径”的解释仍然是错的。
+
+### page_pool 保护的是内核局部的 recycling contract
+
+kernel page_pool 专门优化 skb 和 XDP frame 使用的 page 或 page fragment。文档描述了 in-flight accounting、reference handling、DMA mapping、device synchronization，以及在 NAPI 等安全 context 里直接 recycle 的规则。
+
+这说明高性能 packet memory 本来就需要比 `malloc/free` 更强的生命周期语义。allocator 必须知道 page 能不能回收，什么时候需要 DMA sync。不过 page_pool 的目标就是解决 kernel networking allocator 的问题，它并不试图定义跨 AF_XDP、io_uring、用户态 BPF runtime 或 DPDK 的逻辑 packet identity。
+
+### DPDK 使用另一套用户态 lifetime model
+
+DPDK 的 `rte_mbuf` 把 packet metadata 放在用户态，并用 mempool 做复用。external buffer 有自己的 shared info、reference count 与 free callback；当最后一个 mbuf 不再引用它时，callback 才会执行。
+
+这套模型很适合表达共享引用，也同时暴露了 abstraction mismatch：AF_XDP 用 ring 表示 ownership，page_pool 用 kernel reference 和 recycle API，io_uring ZC Rx 用 completion/refill state，DPDK 用 mbuf ownership 和 reference count。
+
+目标不应该是强迫它们全部换成一个 allocator。更有价值的是在 allocator 之上定义一个 **共同的 handoff contract**，每条 native path 用 adapter 保留自己的 fast path。
+
+## 真正危险的是 stale meaning，而不只是 stale memory
+
+假设 UMEM frame `0x4000` 第一次装的是 tenant A 的 packet。运行 policy generation 84 的 XDP 程序把它送到 AF_XDP。用户态消费后，frame 经过 completion 或 refill path 回收。很快，同一个地址又装上 tenant B 的 packet，而此时 policy 已经是 generation 85。
+
+如果 trace 只记录 `addr=0x4000`，后续 join 就不可靠。地址只是 storage location，不是稳定的 packet identity。
+
+这和 PID reuse 后仍把 PID 当作 process identity、或者在没有 configuration generation 的情况下解释 map entry 是同一类错误。zero-copy networking 让这个问题更明显，因为地址复用本来就是设计目标。
+
+最小的逻辑 identity 至少要包含一次 lease generation：
+
+```text
+buffer_ref = {
+  region_id,
+  offset,
+  lease_generation
+}
+```
+
+每次 handoff 再带上当时有效的 policy 与 execution context：
+
+```text
+handoff = {
+  buffer_ref,
+  from_owner,
+  to_owner,
+  queue_or_device,
+  dma_domain,
+  policy_generation,
+  decision_id,
+  transition_seq
+}
+```
+
+这些 metadata 不应该塞进每个 packet header。它们可以存在 bounded side table、userspace manifest、采样 transition event，或者某条 native path 本来就能携带的 compact token 里。真正需要研究的是：为了证明重要 invariant，最少需要保存多少状态。
+
+## 现有工作还弱在哪里
+
+### 1. 各路径自己的 ownership protocol 还不能组合成一个跨边界 contract
+
+AF_XDP、io_uring ZC Rx、page_pool 和 DPDK 都定义了自己什么时候可以复用 buffer，但它们并没有共享一套 owner、lease generation、DMA reachability 与 handoff authority 语义。
+
+缺的不是 universal memory allocator，而是一套机器可读的 transition model。它应该能表达“用户态已经把这个 AF_XDP frame 交给 kernel RX”“NIC 当前有权向这个 lease DMA”“这个 lease 已经回收，不能再继承上一批 packet 的 policy witness”。
+
+决定性的实验是把两种以上 native zero-copy path 串起来，在它们的边界注入 ownership error，再比较 common contract 和原始 path-local API。如果所有 fault 都已经能被 native boundary 拒绝，而且诊断信息同样完整，那就没有必要引入额外抽象。
+
+### 2. Buffer 地址的复用速度比 policy provenance 消失得更快
+
+fast path 希望地址尽快复用，incident analysis 希望 identity 稳定。如果 observability 只按地址 join，这两个目标会直接冲突。
+
+缺的是 generation-scoped buffer identity。它只需要活到能够把 BPF decision 和准确的 logical packet lease 关联起来，然后在 recycle 时失效。同一个物理地址应该可以随时间产生很多不同逻辑 identity。
+
+测试方式很直接：用很小的 UMEM 强制高频 recycle，同时切换 policy generation 并交错多个 tenant。analyzer 绝不能因为地址相同，就把 generation 84 的 verdict 归到 generation 85 的数据上。
+
+### 3. Hardware steering 可以在 BPF control plane 之外改变 zero-copy 边界
+
+io_uring ZC Rx 当前依赖带外 NIC 配置完成 header/data split、RSS 和 flow steering。AF_XDP 可以跨 queue 和 device 共享 UMEM，DPDK 甚至可能绕过普通 kernel networking path。
+
+缺的是一个可以与 BPF policy state join 的 **realized path description**：NIC queue、steering generation、memory region，以及 packet 进入 userspace 的具体 handoff。否则某个 hook 上的 security policy 可能完全正确，但 operator 对“哪些流量实际上会经过这个 hook”的理解已经过期。
+
+区分能力最强的评测是只修改 steering rule，不修改 BPF policy。如果系统解释不出 flow 已经被切到不同 queue 或 userspace path，那说明 policy observability boundary 还不完整。
+
+### 4. 如果不能复制 payload，zero-copy failure 很难诊断
+
+最直接的 debug 方法是抓包，但这可能破坏正在调试的性能性质、暴露敏感 payload，而且依然无法解释 buffer ownership。
+
+缺的是 metadata-first evidence：ownership transition、lease generation、queue identity、policy witness 和 drop/recycle reason，默认不保留 packet content。
+
+评测应该在同一组 fault 上比较 full packet capture、普通 counter 和 metadata-only witness。好的 witness 设计应该能用远小于 payload capture 的数据量诊断 double reuse、stale policy attribution 和 wrong-path steering。
+
+## 具有学术价值和生产价值的方向
+
+### 1. 给 zero-copy handoff 一个 generation-scoped buffer capability
+
+**Gap。** Native API 有各自的 lifetime rule，但缺少跨 API 的 ownership 与 policy provenance 表示。
+
+**Mechanism。** 为每个活跃 zero-copy buffer lease 分配一个 compact capability：
+
+```text
+cap = {
+  region_id,
+  offset,
+  generation,
+  owner,
+  access_mode,
+  dma_target,
+  policy_generation
+}
+```
+
+transition 显式表示为 `USER_TO_RX`、`RX_TO_USER`、`USER_TO_TX`、`TX_COMPLETE`、`USER_TO_IOURING_REFILL`，以及 DPDK adapter 的 attach/detach transition。buffer recycle 时旧 capability 失效，新 lease 使用新 generation。native ring 或 mbuf 仍然是 fast path 的事实来源，capability layer 只 mirror 跨路径检查和 provenance 需要的最小状态。
+
+在 eBPF 一侧，可以把 immutable region descriptor 放到 map，用 bounded per-CPU 或 per-queue state 记录活跃 generation。像 [bpftime](https://github.com/eunomia-bpf/bpftime) 这样的用户态 eBPF runtime 也可以在 attach boundary 使用同一 schema，而不是再定义一套 packet lifetime 词汇。
+
+**Delta。** 现有 API 保护的是自己的 object lifetime。新的性质是一个 typed capability，它的 generation 与 authority 可以跨 API handoff 保留，同时不要求所有路径使用相同 allocator。
+
+**Artifact。** 一个小型、尽量 UAPI-neutral 的 schema，AF_XDP 和 io_uring adapter，可选 DPDK adapter，针对关键 transition 的 BPF checker，以及能够重建 lease state machine 的 userspace validator。
+
+**Evaluation。** 分别运行 AF_XDP zero-copy、io_uring ZC Rx 和 DPDK line-rate forwarding。测 packets/s、cycles/packet、cache miss、内存开销与 tail latency。注入 double-fill、premature recycle、completion 后错误复用、stale policy generation、worker crash 与 NIC reset，比较 prevention rate 和 diagnostic precision。
+
+**Academic value。** 这个问题可以检验 linear type 或 capability 式 ownership 能否跨 kernel、userspace 和 device packet-memory protocol 落地，而不需要把通用 type system 放进 fast path。
+
+**Production value。** runtime 可以对非法 handoff fail closed，并报告具体 lease transition，而不是只给出模糊的 packet corruption。
+
+**Failure condition。** 如果 shadow capability state 引入的 cache traffic 足以抵消 zero-copy 收益，或者 native API 已经能捕获同样的跨路径 fault 并给出等价 provenance，这个机制就不值得采用。
+
+### 2. 把 compact handoff witness 和 policy generation 绑定
+
+**Gap。** Security decision 与 buffer lifetime 往往存在不同 evidence stream。地址反复回收后，单纯用 timestamp join 并不安全。
+
+**Mechanism。** 给每个相关 BPF policy decision 分配一个属于某个 policy generation 的 compact `decision_id`。zero-copy handoff 时保存或输出一个 witness，包含 buffer lease generation、decision ID、源 owner 与目标 owner 类型、device/queue 和 transition sequence。userspace 保存 `decision_id` 到 policy object 或 rule 的 reverse mapping。
+
+witness 默认不包含 packet payload。它可以只在 deny、异常 transition、policy generation 切换，以及少量普通 allow sample 时输出。目标不是 trace 每一个 packet，而是在 buffer 地址已经被复用几百次之后，关键 evidence 仍然不会产生歧义。
+
+**Delta。** 现有 packet trace 可以记录地址、queue event 或 policy verdict。新的性质是 logical buffer lease 与授权 handoff 的 policy generation 之间存在显式 join key。
+
+**Artifact。** witness format、BPF map/event helper、AF_XDP userspace library wrapper，以及一个无需读取 payload 就能重建单次 packet lease 的命令行工具。
+
+**Evaluation。** 用很小的 UMEM 制造极高 reuse rate，同时轮换 policy 和 queue steering。比较 address-only correlation、timestamp correlation 和 generation-scoped witness。统计 false join、missed join、evidence volume 与 root-cause accuracy，并加入同一个 scheduler tick 内复用相同 frame 的 adversarial timing。
+
+**Academic value。** 这把 provenance 变成一个可以测量的 high-performance I/O 与 systems security 边界问题，而不是默认无限制日志就能解决。
+
+**Production value。** operator 可以回答“这些 bytes 在进入 userspace 之前到底被哪一代 policy 放行”，而不需要 full packet capture，也不必永久保存旧 control-plane state。
+
+**Failure condition。** 如果 generation-scoped witness 相比更便宜的 queue-local counter 与 timestamp 并没有明显降低 false attribution，它就只是多余 metadata。
+
+### 3. 在标准化 contract 之前，先做一个跨路径 zero-copy fault benchmark
+
+**Gap。** 设计一套漂亮的 ownership schema 很容易，但必须先证明真实 mixed datapath 确实需要它。
+
+**Mechanism。** benchmark 不单独测每个 API，而是组合 native path。场景包括 XDP 到 AF_XDP、shared UMEM 上的 AF_XDP forwarding、io_uring ZC Rx 的 TCP payload、DPDK external buffer，以及可选的 userspace eBPF policy stage。每个场景先声明正确的 ownership 与 policy-generation sequence，再由 fault injector 一次破坏一个边界。
+
+至少加入这些 fault：
+
+- 同一个 AF_XDP frame 被发布到互相冲突的 ownership path；
+- recycle 地址在新的 tenant 或 policy generation 下重新使用；
+- queue steering 更新使 flow 离开预期 BPF path；
+- userspace 在仍持有 outstanding buffer 时退出；
+- completion 延迟时提前复用 frame；
+- policy update 过程中发生 NIC reset 或 queue reconfiguration；
+- DPDK external buffer 在仍有逻辑 packet reference 时被 detach。
+
+benchmark 比较三个设计：完全未修改的 native API、metadata-only witness，以及 active capability checking。
+
+**Delta。** 现有 API selftest 主要验证单个机制。这里把 **composition failure** 作为评测单位，让 proposed contract 有明确失败条件。
+
+**Artifact。** 可复现 traffic generator、fault injector、reference ownership trace，以及针对 safety、provenance correctness、diagnosis time 和 performance overhead 的 grader。
+
+**Evaluation。** 除了 throughput 和 latency，还要报告 fault-detection recall、false positive、buffer reuse 后的 false policy join、recovery correctness，以及每百万 packet 需要多少 evidence bytes。至少跨两组 NIC/driver 测试，因为 zero-copy 与 DMA 行为依赖硬件。
+
+**Academic value。** benchmark 能把真正的 cross-boundary abstraction gap 和一组普通 implementation bug 区分开。
+
+**Production value。** networking runtime 可以获得覆盖高负载、queue reconfiguration 与高频 buffer reuse 故障的 regression test，而这些问题平时很难稳定复现。
+
+**Failure condition。** 如果真实组合场景没有出现 native API 自己无法检测的新 fault，正确结论应该是改进局部 diagnostics，而不是推动新的通用 contract。
+
+## 什么会改变这个结论？
+
+最强的反对意见是：zero-copy ownership 本来就应该保持 path-specific。AF_XDP ring、io_uring refill state、page_pool reference 和 DPDK mbuf reference count 面向的 execution model 不同。common capability layer 可能增加 cache pressure、重复状态和新的 bug，却只换来一套更复杂的 tracing convention。
+
+如果实验同时证明三件事，这个反对意见就成立：native API 已经能拒绝重要的 cross-path misuse；在真实 reuse rate 下，address 加 timestamp 已经足够可靠；hardware steering 的变化也可以低成本从现有 control-plane state 重建。
+
+反过来，如果 mixed datapath 反复出现这种 failure：每个 subsystem 单独看都合法，但组合起来已经违反 buffer ownership 或 policy provenance，那么缺的就不是另一种 zero-copy transport。真正需要的是一套足够小的 contract，用来说明一份 buffer lease 在 BPF、kernel networking、userspace 与 NIC 之间移动时到底代表什么。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Who Owns a Packet Buffer in a Zero-Copy eBPF Datapath?](https://eunomia.dev/research/ebpf-zero-copy-buffer-ownership/)
+
+AF_XDP, io_uring ZC Rx, and DPDK already use different native lifetime protocols. This report develops a generation-scoped buffer capability, policy-linked handoff witnesses, and a cross-path fault benchmark for zero-copy eBPF datapaths.
+
 ### [How Should eBPF Compose Multi-Tenant Network Policies?](https://eunomia.dev/research/ebpf-network-policy-composition/)
 
 Multi-tenant clusters can combine additive Kubernetes NetworkPolicy, tiered ClusterNetworkPolicy, and Cilium L3-L7 policy in one eBPF datapath. This report develops an authority-aware composition IR, generation-stable verdict witnesses, and a counterexample benchmark for explaining which policy owner and rule determined an effective verdict.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [零拷贝 eBPF 数据路径里，谁拥有数据包缓冲区？](https://eunomia.dev/zh/research/ebpf-zero-copy-buffer-ownership/)
+
+AF_XDP、io_uring ZC Rx 和 DPDK 都会高频复用 packet buffer，却使用不同的 ownership 与回收协议。本文提出 generation-scoped buffer capability、绑定 policy generation 的 handoff witness，以及专门检测跨路径 ownership 与 provenance 错误的 zero-copy fault benchmark。
+
 ### [多租户网络策略应该怎样在 eBPF 数据面里组合？](https://eunomia.dev/zh/research/ebpf-network-policy-composition/)
 
 多租户集群可能同时运行 additive 的 Kubernetes NetworkPolicy、带 tier 的 ClusterNetworkPolicy 和 Cilium L3-L7 policy。本文提出带 authority 的 composition IR、跨 generation 稳定的 verdict witness，以及专门检查多 owner 策略组合和 explanation correctness 的 counterexample benchmark。


### PR DESCRIPTION
## Summary

- publish one bilingual Daily Report on zero-copy buffer ownership and policy provenance across AF_XDP, io_uring ZC Rx, DPDK, and userspace eBPF paths
- update the EN/ZH Daily Report indexes
- refresh the August 24 public-safe SEO operating record and directly coupled status, plan, blocker, site, and series state
- keep the active eBPF Networking and Security series and rolling topic mix compliant

## Evidence

The report is grounded in current Linux AF_XDP, io_uring ZC Rx, and page_pool documentation plus current DPDK packet-buffer lifetime semantics. It is intentionally distinct from the earlier io_uring BPF control-surface report: the central question here is cross-path buffer lease ownership, DMA reachability, recycling, and policy provenance.

## SEO operations

The configured Google Drive folder has no newer weekly export beginning 2026-08-17. Search Console remains finalized through 2026-08-15 with the 2026-08-09 row missing; GA4 2026-08-10..16 remains the newest finalized weekly aggregate. Current repository/live-site evidence does not establish a technical SEO defect, so no speculative site change is included.

The newest-ten report mix is 7 eBPF-centered / 0 pure Agent / 3 adjacent systems before and after this eBPF-centered publication. The incoming report ages the 2026-08-12 eBPF-centered async-profiler report out of that window.

## Validation

`Validate SEO Operations` is green on the final head. `Deploy Static App` is the remaining expected PR check; after it succeeds the full final diff/generated-output self-review will be completed before squash merge, followed by exact-merge deployment and bilingual public verification as required by `DAILY_TASK.md`.