### PR TITLE
chore: add a reusable development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm@sha256:0d29e5fdc64f8397cd502223e0c4679f1e60877ca0fd2db4f2e2e0028e4271af
+
+ARG GH_CLI_VERSION=2.98.0
+
+USER root
+
+RUN set -eux; \
+    architecture="$(dpkg --print-architecture)"; \
+    case "$architecture" in \
+      amd64) gh_sha256="3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de" ;; \
+      arm64) gh_sha256="cf689084f3a3618f7eae4a2420d335d74626d65f5e594b9828d125d69f800d86" ;; \
+      *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;; \
+    esac; \
+    archive="gh_${GH_CLI_VERSION}_linux_${architecture}.tar.gz"; \
+    curl --fail --location --show-error \
+      --output "/tmp/${archive}" \
+      "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/${archive}"; \
+    echo "${gh_sha256}  /tmp/${archive}" | sha256sum --check --strict; \
+    tar --extract --gzip --file "/tmp/${archive}" --directory /tmp; \
+    install --mode 0755 \
+      "/tmp/gh_${GH_CLI_VERSION}_linux_${architecture}/bin/gh" \
+      /usr/local/bin/gh; \
+    rm --recursive --force "/tmp/${archive}" \
+      "/tmp/gh_${GH_CLI_VERSION}_linux_${architecture}"; \
+    npm install --global @openai/codex@0.147.0; \
+    gh --version; \
+    codex --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "eunomia.dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "remoteUser": "node"
+}


### PR DESCRIPTION
## Summary

- add a minimal root Dev Container for the eunomia.dev repository
- pin the multi-architecture Node 22 base image by digest
- install checksum-verified GitHub CLI 2.98.0 and Codex CLI 0.147.0
- keep credentials, agent state, workspace mounts, and scheduler configuration out of the image

## Validation

- parsed `.devcontainer/devcontainer.json` with Python's JSON parser
- ran `git diff --check`
- independently reviewed the final patch for multi-architecture and supply-chain issues

The container image still needs an end-to-end amd64/arm64 Envbuilder build before merge.