### PR TITLE
Daily: preserve policy identity across L7 proxy handoffs

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -5,51 +5,21 @@ already configured and enabled; it is not a blocker.
 
 ## Cloudflare analytics is not configured
 
-- Blocked action: source-native edge request, bot, cache, country, and status-code
-  analysis.
+- Blocked action: source-native edge request, bot, cache, country, and status-code analysis.
 - Evidence: Cloudflare remains disabled in `site.md`.
-- Impact: daily analysis can use Search Console, GA4, live-site, GitHub, and public
-  primary-source evidence, but cannot make Cloudflare-grounded traffic or cache
-  conclusions.
-- Minimal external action: authorize a supported read-only connector or export
-  route without committing zone IDs, credentials, private URLs, raw private data,
-  or personal information.
+- Impact: daily analysis can use Search Console, GA4, live-site, GitHub, and public primary-source evidence, but cannot make Cloudflare-grounded traffic or cache conclusions.
+- Minimal external action: authorize a supported read-only connector or export route without committing zone IDs, credentials, private URLs, raw private data, or personal information.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder was
-directly rechecked on `2026-08-27`; it contains weekly export sets through
-`2026-08-17..23` and no newer set was observed.
+Google Drive access is verified and is not a blocker. The configured folder was directly rechecked on `2026-08-28`; it contains weekly export sets through `2026-08-17..23` and no newer set was observed.
 
-For Search Console, the verified latest date export contains rows through
-`2026-08-22`; `2026-08-23` is absent. The `2026-08-22` row is outside the
-configured three-day lag and its source-native values are available. The longest
-contiguous equal-duration finalized comparison currently supported by the exports
-is six days: `2026-08-17..22` versus `2026-08-10..15` has 477 versus 393 clicks,
-59,798 versus 66,510 impressions, about 0.798% versus 0.591% CTR, and average
-position about 9.56 versus 9.91. Clicks are about 21.4% higher, impressions about
-10.1% lower, CTR about 0.207 percentage points higher, and average position
-improves by about 0.35 positions.
+For Search Console, the verified latest date export contains rows through `2026-08-22`; `2026-08-23` is absent. The longest contiguous equal-duration finalized comparison currently supported by the exports is six days: `2026-08-17..22` versus `2026-08-10..15` has 477 versus 393 clicks, 59,798 versus 66,510 impressions, about 0.798% versus 0.591% CTR, and average position about 9.56 versus 9.91. Clicks are about 21.4% higher, impressions about 10.1% lower, CTR about 0.207 percentage points higher, and average position improves by about 0.35 positions.
 
-A complete latest-7-days versus previous-7-days Search Console comparison remains
-unavailable because the latest finalized window would be `2026-08-16..22` versus
-`2026-08-09..15`, while the available date exports omit both `2026-08-16` and
-`2026-08-09`. The 28-day comparison also remains unavailable because verified
-export history is not long enough. Missing rows are never converted to zero.
+A complete latest-7-days versus previous-7-days Search Console comparison remains unavailable because the latest finalized window would be `2026-08-16..22` versus `2026-08-09..15`, while the available date exports omit both `2026-08-16` and `2026-08-09`. The 28-day comparison also remains unavailable because verified export history is not long enough. Missing rows are never converted to zero.
 
-The GA4 landing-page aggregate for `2026-08-17..23` is fully outside the
-configured three-day finalization lag and is usable as a finalized source-native
-weekly aggregate. It contains 984 organic landing-page sessions at about 49.29%
-session-weighted engagement, compared with 970 sessions at about 44.95% for
-`2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34
-percentage points higher. The weekly files have no date dimension, so they still
-cannot support within-week attribution or daily causal claims.
+The GA4 landing-page aggregate for `2026-08-17..23` is fully outside the configured three-day finalization lag and is usable as a finalized source-native weekly aggregate. It contains 984 organic landing-page sessions at about 49.29% session-weighted engagement, compared with 970 sessions at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34 percentage points higher. The weekly files have no date dimension, so they still cannot support within-week attribution or daily causal claims.
 
-These constraints never justify skipping the daily operation. Each run must use
-the available Google evidence, live-site evidence, public GitHub evidence, and
-public primary-source evidence; missing or partial coverage must never be
-converted into zero. Every run must still publish one new Daily Report under the
-current repository contract.
+These constraints never justify skipping the daily operation. Each run must use the available Google evidence, live-site evidence, public GitHub evidence, and public primary-source evidence; missing or partial coverage must never be converted into zero. Every run must still publish one new Daily Report under the current repository contract.
 
-Remove or narrow a blocker in the next daily pull request after the external
-condition is verified as resolved.
+Remove or narrow a blocker in the next daily pull request after the external condition is verified as resolved.

--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -5,21 +5,51 @@ already configured and enabled; it is not a blocker.
 
 ## Cloudflare analytics is not configured
 
-- Blocked action: source-native edge request, bot, cache, country, and status-code analysis.
+- Blocked action: source-native edge request, bot, cache, country, and status-code
+  analysis.
 - Evidence: Cloudflare remains disabled in `site.md`.
-- Impact: daily analysis can use Search Console, GA4, live-site, GitHub, and public primary-source evidence, but cannot make Cloudflare-grounded traffic or cache conclusions.
-- Minimal external action: authorize a supported read-only connector or export route without committing zone IDs, credentials, private URLs, raw private data, or personal information.
+- Impact: daily analysis can use Search Console, GA4, live-site, GitHub, and public
+  primary-source evidence, but cannot make Cloudflare-grounded traffic or cache
+  conclusions.
+- Minimal external action: authorize a supported read-only connector or export
+  route without committing zone IDs, credentials, private URLs, raw private data,
+  or personal information.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder was directly rechecked on `2026-08-28`; it contains weekly export sets through `2026-08-17..23` and no newer set was observed.
+Google Drive access is verified and is not a blocker. The configured folder was
+directly rechecked on `2026-08-28`; it contains weekly export sets through
+`2026-08-17..23` and no newer set was observed.
 
-For Search Console, the verified latest date export contains rows through `2026-08-22`; `2026-08-23` is absent. The longest contiguous equal-duration finalized comparison currently supported by the exports is six days: `2026-08-17..22` versus `2026-08-10..15` has 477 versus 393 clicks, 59,798 versus 66,510 impressions, about 0.798% versus 0.591% CTR, and average position about 9.56 versus 9.91. Clicks are about 21.4% higher, impressions about 10.1% lower, CTR about 0.207 percentage points higher, and average position improves by about 0.35 positions.
+For Search Console, the verified latest date export contains rows through
+`2026-08-22`; `2026-08-23` is absent. The `2026-08-22` row is outside the
+configured three-day lag and its source-native values are available. The longest
+contiguous equal-duration finalized comparison currently supported by the exports
+is six days: `2026-08-17..22` versus `2026-08-10..15` has 477 versus 393 clicks,
+59,798 versus 66,510 impressions, about 0.798% versus 0.591% CTR, and average
+position about 9.56 versus 9.91. Clicks are about 21.4% higher, impressions about
+10.1% lower, CTR about 0.207 percentage points higher, and average position
+improves by about 0.35 positions.
 
-A complete latest-7-days versus previous-7-days Search Console comparison remains unavailable because the latest finalized window would be `2026-08-16..22` versus `2026-08-09..15`, while the available date exports omit both `2026-08-16` and `2026-08-09`. The 28-day comparison also remains unavailable because verified export history is not long enough. Missing rows are never converted to zero.
+A complete latest-7-days versus previous-7-days Search Console comparison remains
+unavailable because the latest finalized window would be `2026-08-16..22` versus
+`2026-08-09..15`, while the available date exports omit both `2026-08-16` and
+`2026-08-09`. The 28-day comparison also remains unavailable because verified
+export history is not long enough. Missing rows are never converted to zero.
 
-The GA4 landing-page aggregate for `2026-08-17..23` is fully outside the configured three-day finalization lag and is usable as a finalized source-native weekly aggregate. It contains 984 organic landing-page sessions at about 49.29% session-weighted engagement, compared with 970 sessions at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34 percentage points higher. The weekly files have no date dimension, so they still cannot support within-week attribution or daily causal claims.
+The GA4 landing-page aggregate for `2026-08-17..23` is fully outside the
+configured three-day finalization lag and is usable as a finalized source-native
+weekly aggregate. It contains 984 organic landing-page sessions at about 49.29%
+session-weighted engagement, compared with 970 sessions at about 44.95% for
+`2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34
+percentage points higher. The weekly files have no date dimension, so they still
+cannot support within-week attribution or daily causal claims.
 
-These constraints never justify skipping the daily operation. Each run must use the available Google evidence, live-site evidence, public GitHub evidence, and public primary-source evidence; missing or partial coverage must never be converted into zero. Every run must still publish one new Daily Report under the current repository contract.
+These constraints never justify skipping the daily operation. Each run must use
+the available Google evidence, live-site evidence, public GitHub evidence, and
+public primary-source evidence; missing or partial coverage must never be
+converted into zero. Every run must still publish one new Daily Report under the
+current repository contract.
 
-Remove or narrow a blocker in the next daily pull request after the external condition is verified as resolved.
+Remove or narrow a blocker in the next daily pull request after the external
+condition is verified as resolved.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -68,271 +68,13 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
-## Active series — eBPF Networking and Security
+## Active series — GPU and Heterogeneous Runtime Systems
 
-Working question: **Where are eBPF networking and security mechanisms still
-missing deployable abstractions or correctness guarantees?**
+Working question: **What runtime, programmability, and observability abstractions
+are missing at CPU/GPU and host/device boundaries?**
 
-This series became active after the `2026-08-22` report completed the normal
-six-report boundary for eBPF Observability and Profiling.
-
-The roadmap initially preferred transactional policy updates across programs,
-maps, links, and userspace control planes. Fresh novelty review on `2026-08-23`
-rejected that candidate because `/research/stateful-ebpf-transactional-upgrade/`
-already develops a prepare / migrate / commit / retire generation protocol across
-programs, links, maps, pinned state, controller recovery, and rollback. Repeating
-the same update transaction with a networking example would not materially
-advance the archive.
-
-The `2026-08-23` report starts the active series with a distinct security-policy
-question: how additive Kubernetes `NetworkPolicy`, tiered `ClusterNetworkPolicy`,
-and Cilium L3-L7 policy can compose for multiple owners without losing authority,
-delegation, or source-policy provenance after the result is compiled into an
-eBPF datapath. It develops an authority-aware composition IR, generation-stable
-verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
-
-The `2026-08-24` report advances a second, materially different boundary. AF_XDP,
-io_uring ZC Rx, page_pool, and DPDK all recycle packet memory through native
-ownership protocols, while BPF policy decisions, NIC steering, and userspace
-processing can cross those boundaries. The report develops a generation-scoped
-buffer capability, policy-linked handoff witnesses, and a cross-path zero-copy
-fault benchmark. It is distinct from the earlier io_uring programmability report:
-the missing property is buffer lease ownership and provenance across APIs, not
-BPF execution control inside the ring.
-
-The `2026-08-25` report advances a third boundary: the Linux verifier can prove
-that each loaded BPF program executes safely while the security policy encoded in
-persistent map state still follows an invalid temporal trace. Production policy
-state can be shared across hooks, CPUs, programs, and userspace and can change
-under eviction, map pressure, revocation, restart, or stale control-plane writes.
-The report develops a small temporal policy contract, verifier-cooperative runtime
-transition guards, and an adversarial state-fault benchmark. This is distinct
-from verifier-error diagnosis, transactional upgrade, and policy composition:
-the target property is legal runtime state transition after safe bytecode has
-already been admitted.
-
-The `2026-08-26` report narrows one consequence of persistent state into an
-incident-response property. A policy or identity can be revoked while an old
-allow still survives in connection tracking, authentication caches, socket-local
-storage, or another derived datapath object. The report asks for a measurable
-upper bound on that stale authority rather than another general state-machine
-contract. It develops scoped revocation epochs, a cross-layer completion barrier,
-and a benchmark whose primary outcome is the last stale allow after a revoke.
-
-The `2026-08-27` report advances a fifth boundary by narrowing heterogeneous
-execution placement into a complete-mediation property. Linux representors and
-XDP offload expose host slow paths and device fast paths that can change under
-misses, updates, and faults. The report asks whether every reachable
-policy-relevant packet path still crosses an enforcement point for the current
-policy generation. It develops a path-coverage plan, generation-continuous
-offload/fallback, and a benchmark whose primary outcome is policy escape rather
-than offload throughput.
-
-A broad cross-boundary information-flow candidate was considered again on
-`2026-08-25` but not selected. Existing ActPlane and Eunomia material already
-covers process/file/network effect labels and layered enforcement, so a broad
-version has higher thesis-overlap risk than the narrower state-transition gap.
-A future information-flow report should therefore require a narrower mechanism
-and fresh evidence before it can become the sixth report in this series.
-
-### Published progress
-
-1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
-   policy-language semantics from BPF hook composition and update transactions.
-   It asks how several legitimate policy owners can produce one effective
-   network verdict while keeping the deciding owner, tier, delegation path, and
-   source rule inspectable across policy generations. The report is
-   eBPF-centered because the proposed provenance contract is evaluated against
-   the realized BPF policy datapath, not only against Kubernetes objects.
-2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` separates
-   allocator-specific lifetime rules from a cross-path ownership contract. It
-   asks how packet-buffer leases can preserve owner, DMA reachability, recycle
-   generation, and BPF policy provenance across AF_XDP, io_uring ZC Rx, DPDK,
-   userspace eBPF, and NIC handoffs. It is eBPF-centered because policy identity
-   and BPF/user-runtime transitions are part of the correctness contract rather
-   than optional instrumentation.
-3. `2026-08-25`: `/research/ebpf-stateful-policy-verification/` separates
-   per-program verifier safety from temporal correctness of persistent security
-   state. It asks how map-backed policy states can restrict legal transitions,
-   transition authority, generations, expiry, capacity failure, and userspace
-   writes without forcing the Linux verifier to model unbounded event history.
-   It is eBPF-centered because BPF maps, hooks, verifier boundaries, and in-kernel
-   transition enforcement are the central mechanism rather than optional probes.
-4. `2026-08-26`: `/research/ebpf-authorization-revocation/` separates policy
-   rollout from revocation effectiveness. It asks how a previously admitted
-   authorization can be made unusable within a measurable bound across conntrack,
-   auth maps, socket-local state, endpoint policy, and userspace-managed state.
-   It is eBPF-centered because the proposed epoch checks and completion barrier
-   are evaluated on persistent BPF datapath state and hot-path policy reuse.
-5. `2026-08-27`: `/research/ebpf-complete-mediation-offload/` separates backend
-   placement from global security coverage. It asks how host software, SmartNIC
-   fast paths, representor fallback, and DPU/offload execution can preserve one
-   current enforcement point for every reachable policy-relevant packet path.
-   It is eBPF-centered because BPF/XDP attachment, offload capability, policy
-   generations, and cross-backend verdict continuity are the core mechanism.
-
-### Preferred next questions
-
-1. a narrow information-flow or cross-boundary enforcement property only if fresh
-   evidence supports a mechanism materially distinct from ActPlane-style effect
-   labels and from the complete-mediation path-coverage contract;
-2. revisit transactional network-policy rollout only when new evidence supports
-   a mechanism materially different from the published stateful-upgrade
-   generation protocol;
-3. revisit zero-copy ownership only when implementation evidence or the proposed
-   cross-path benchmark exposes a distinct mechanism beyond the lease/provenance
-   contract developed on `2026-08-24`;
-4. revisit revocation only when implementation evidence distinguishes a new
-   mechanism from the scoped epoch, completion-barrier, and stale-allow benchmark
-   developed on `2026-08-26`;
-5. revisit host/NIC/DPU complete mediation only when implementation evidence
-   exposes a new mechanism beyond path coverage, generation continuity, and the
-   policy-escape benchmark developed on `2026-08-27`.
-
-Before and after the August 27 publication, the newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
-report ages another eBPF-centered report out of the rolling ten.
-
-## Completed series — eBPF Observability and Profiling
-
-Historical roadmap state: **Active series — eBPF Observability and Profiling**
-through the `2026-08-22` report. The series is completed after that publication;
-Networking and Security is the active series for the next normal run.
-
-Working question: **Which important performance and correctness questions remain
-unanswerable with today's eBPF observability stack?**
-
-The `2026-08-18` report started this series with **page-level memory attribution**:
-how to distinguish allocation from pages that were actually touched, faulted,
-reclaimed, migrated, or responsible for sampled memory cost while preserving
-provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
-
-The `2026-08-19` report was a deliberate **adjacent profiling detour** on sampling
-bias. Its central mechanism is general profiler measurement design, not eBPF, so
-it is classified as adjacent systems.
-
-The first `2026-08-20` report was a second adjacent profiling detour required by
-the rolling-window arithmetic. It asks whether a late CUDA kernel start came from
-host scheduling, runtime/command-buffer work, a dependency, or device
-availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
-host tracing can be an optional evidence source but is not essential, so this
-report is adjacent systems rather than eBPF-centered.
-
-The second `2026-08-20` report follows the same adjacent-systems boundary from a
-causality angle. It asks how host API work, runtime handoffs, CUDA Graph replay,
-and device execution can retain a trustworthy causal identity. CUPTI/CUDA
-dependency semantics are central while eBPF is one possible host observer.
-
-The `2026-08-21` report returns to an eBPF-essential question: how dynamic probes
-can observe application-defined pools, queues, caches, and credits without
-silently turning stale program semantics into confident diagnoses. It develops a
-versioned semantics manifest, runtime semantic validation, and a mutation
-benchmark for software evolution.
-
-The `2026-08-22` report closes the series with another eBPF-essential question:
-how always-on collectors can reduce high-rate telemetry before export without
-silently deleting the evidence required for diagnosis. It develops a compiled
-diagnostic contract, bounded state-transition exemplars, coverage-carrying
-summaries, and an equal-budget diagnosis-retention benchmark.
-
-### Published progress
-
-1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` separates
-   allocation intent, residency, working-set evidence, page lifecycle, and
-   sampled memory cost, then develops a lifetime-aware provenance ledger,
-   access-weighted attribution with explicit confidence, and a ground-truth
-   benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
-   migration.
-2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
-   untrustworthy. It compares randomized sampling history, current Linux perf
-   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
-   develops a sampling-schedule contract with aliasing diagnostics, independent
-   profile epochs with uncertainty and rank stability, and uncertainty-triggered
-   selective instrumentation. Because the mechanism applies to profilers in
-   general and does not require eBPF, this report is adjacent systems rather than
-   eBPF-centered.
-3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
-   command-buffer queue/submission, dependency readiness, device availability,
-   and kernel execution. It develops an explicit launch-state ledger, a
-   cross-domain launch identity that survives host handoffs and graph replay, and
-   a ground-truth launch-delay attribution benchmark. The central question is GPU
-   profiling, so it is adjacent systems.
-4. `2026-08-20`: `/research/gpu-host-device-causality/` develops
-   generation-scoped host/device causal identity, dependency-aware critical-path
-   reasoning, explicit unknown/loss states, and a ground-truth causality
-   benchmark. CUPTI/CUDA dependency semantics are essential while eBPF is one
-   possible host observer, so this report is adjacent systems.
-5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF
-   can dynamically observe application-defined resources without hard-coding
-   stale semantics. It develops a versioned resource-semantics manifest compiled
-   into eBPF attachments, runtime semantic validation with explicit confidence
-   loss, and a software-mutation benchmark. Dynamic no-rebuild instrumentation
-   and independent cross-layer validation are central, so this report is
-   eBPF-centered.
-6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` asks how an
-   always-on eBPF collector can reduce telemetry volume before export while
-   preserving later root-cause diagnosis. It develops a diagnostic-contract
-   compiler for BPF retention plans, state-transition exemplars, explicit
-   coverage accounting, and an equal-budget incident benchmark. Source-side BPF
-   aggregation and exemplar retention are central, so this report is
-   eBPF-centered.
-
-Before and after the August 22 publication, the newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
-report ages an eBPF-centered report out of the rolling ten.
-
-A related unresolved question remains: online confidence and adaptive collection
-when trace loss, missing probes, or stale schemas make the current representation
-uncertain. It is intentionally not a seventh report in this series. The August 22
-report first defines what a compact representation promises to preserve; adaptive
-fidelity can be revisited later when fresh evidence supports a distinct mechanism.
-
-## Completed series — eBPF Runtime, Extensibility, and Composition
-
-Working question: **What mechanisms are still missing if eBPF is treated as a
-programmable runtime substrate rather than only a kernel observability feature?**
-
-This series connected kernel and userspace execution, composition, state,
-upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
-execution placement. It reached the normal six-report series boundary on
-`2026-08-17` and is no longer the default topic source for scheduled publication.
-
-### Published progress
-
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
-   first-class userspace eBPF needs explicit attachment, capability, state,
-   lifetime, and attribution contracts above ISA compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
-   multi-program problem beyond dispatch and ordering to effect visibility,
-   outcome resolution, shared-state ownership, and versioned hook composition.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
-   object-level replacement from application-level upgrade and developed an
-   explicit prepare / migrate / commit / retire generation protocol for programs,
-   links, maps, pinned state, controller recovery, and rollback.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
-   execution from logical-work causality and developed typed, lifetime-aware
-   handoff edges, an edge-versus-context measurement budget, and a ground-truth
-   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
-   application-defined resources.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
-   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops`
-   execution-control path, then developed a typed capability contract, versioned
-   ring policy generations, explicit provenance, and a comparative
-   control-boundary benchmark.
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed a target
-   manifest, generation-scoped state ownership, and a ground-truth
-   placement/provenance benchmark across kernel, userspace, NIC/DPU, and
-   GPU-side targets.
-
-The Daily Report index already exposes the sequence. Report-level acquisition and
-navigation evidence is still too young to justify a dedicated public series hub.
-Revisit that decision only when evidence shows a retrieval benefit.
-
-## Queued series — GPU and Heterogeneous Runtime Systems
-
-Working question: **What runtime and observability abstractions are missing at
-CPU/GPU and host/device boundaries?**
+This roadmap becomes active after the `2026-08-28` report reaches the normal
+six-report boundary for eBPF Networking and Security.
 
 Candidate topics include GPU/CPU causal profiling, memory movement, megakernel
 observability, programmable device-side instrumentation, distributed GPU
@@ -340,10 +82,145 @@ coordination, utilization versus allocatability, host-side scheduling noise, and
 eBPF-like programmable monitors near GPU or DPU execution.
 
 Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
-runtime is central to the mechanism being evaluated.
+runtime is central to the mechanism being evaluated. A report whose core
+mechanism is CUPTI, CUDA, GPU scheduling, or another general accelerator
+abstraction without essential eBPF machinery is adjacent systems.
 
-The two August 20 reports are focused adjacent-systems contributions to this
-roadmap. They do not make this queued series active.
+The two August 20 GPU reports are useful existing anchors but do not count as
+progress in the newly active sequence. They establish two boundaries that new
+reports should not simply repeat:
+
+- `/research/gpu-kernel-launch-latency/` separates queueing/readiness delay from
+  kernel execution time;
+- `/research/gpu-host-device-causality/` develops host/device causal identity and
+  explicit unknown dependency edges.
+
+### Preferred next questions
+
+1. a device-side programmability or policy boundary where an eBPF-like runtime
+   materially changes what can be enforced or adapted without rebuilding the
+   workload;
+2. memory-placement or movement semantics where CPU and GPU observers disagree
+   about ownership, residency, or cost and a deployable cross-domain contract is
+   missing;
+3. fine-grained GPU execution observability only when the question is distinct
+   from launch-latency attribution and host/device causal tracing;
+4. distributed GPU coordination when there is a concrete runtime invariant to
+   test rather than a generic scaling survey;
+5. revisit heterogeneous placement only when fresh evidence exposes a mechanism
+   beyond the already published target-manifest and generation-scoped ownership
+   contract.
+
+After the August 28 publication, the newest ten remain **7 eBPF-centered / 0 pure
+Agent / 3 adjacent systems**. The next report may therefore be either eBPF-centered
+or adjacent, but evidence and thesis quality decide the classification.
+
+## Completed series — eBPF Networking and Security
+
+Working question: **Where are eBPF networking and security mechanisms still
+missing deployable abstractions or correctness guarantees?**
+
+This series became active after the `2026-08-22` report completed eBPF
+Observability and Profiling. It reaches the normal six-report boundary on
+`2026-08-28`.
+
+### Published progress
+
+1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
+   policy-language semantics from BPF hook composition and update transactions.
+   It asks how several legitimate policy owners can produce one effective
+   verdict while keeping the deciding owner, tier, delegation path, and source
+   rule inspectable across policy generations.
+2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` asks how packet
+   buffer leases preserve owner, DMA reachability, recycle generation, and BPF
+   policy provenance across AF_XDP, io_uring ZC Rx, DPDK, userspace eBPF, and NIC
+   handoffs.
+3. `2026-08-25`: `/research/ebpf-stateful-policy-verification/` separates
+   verifier-safe bytecode from legal temporal transitions of persistent policy
+   state shared across hooks, CPUs, maps, and userspace updates.
+4. `2026-08-26`: `/research/ebpf-authorization-revocation/` separates rollout
+   from revocation effectiveness and asks for a measurable bound on stale
+   authority across conntrack, auth maps, socket-local state, and other derived
+   datapath objects.
+5. `2026-08-27`: `/research/ebpf-complete-mediation-offload/` separates backend
+   placement from global security coverage and asks whether every reachable
+   host/SmartNIC/DPU packet path still crosses a policy-equivalent enforcement
+   point for the current generation.
+6. `2026-08-28`: `/research/ebpf-l7-proxy-policy-identity/` separates path
+   coverage from authorization identity continuity. It asks how a principal,
+   policy generation, and authorization provenance survive when eBPF redirects a
+   request into an L7 proxy that terminates the downstream connection and emits
+   or reuses a different upstream socket. It develops generation-scoped handoff
+   capabilities, policy-safe multiplexing, and an authorization-lineage
+   benchmark across kernel fast paths and proxy slow paths.
+
+The sixth report was selected only after rejecting a broad information-flow
+candidate that still overlapped ActPlane effect labels and a narrower fast/slow
+verdict-equivalence candidate that overlapped the complete-mediation report. The
+proxy identity question is distinct because the request can cross every intended
+enforcement point and still be attributed to the wrong principal after the
+semantic handoff.
+
+Future networking/security work should return only when fresh evidence supports
+a mechanism beyond these six published boundaries. In particular, do not repeat
+transactional rollout, zero-copy ownership, revocation, complete mediation, or
+proxy identity continuity with a new product example alone.
+
+## Completed series — eBPF Observability and Profiling
+
+Working question: **Which important performance and correctness questions remain
+unanswerable with today's eBPF observability stack?**
+
+Published progress:
+
+1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` develops
+   lifetime-aware page provenance and access-weighted attribution.
+2. `2026-08-19`: `/research/profiler-sampling-bias/` is an adjacent profiling
+   detour on aliasing, skid, coverage, and uncertainty.
+3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` is an adjacent GPU
+   profiling report on launch-state attribution.
+4. `2026-08-20`: `/research/gpu-host-device-causality/` is an adjacent GPU
+   report on host/device causal identity and dependency uncertainty.
+5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` develops a
+   versioned semantics manifest and mutation benchmark for application-defined
+   resources.
+6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` develops a
+   diagnostic-contract compiler, state-transition exemplars, coverage-carrying
+   summaries, and equal-budget diagnosis-retention evaluation.
+
+A related question about online confidence and adaptive collection remains valid
+but should be revisited only when fresh evidence supports a mechanism distinct
+from the compression contract.
+
+## Completed series — eBPF Runtime, Extensibility, and Composition
+
+Working question: **What mechanisms are still missing if eBPF is treated as a
+programmable runtime substrate rather than only a kernel observability feature?**
+
+Published progress:
+
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` establishes
+   attachment, capability, state, lifetime, and attribution contracts above ISA
+   compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` develops typed
+   composition semantics for effect visibility, outcomes, shared state, and
+   versioned hooks.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` develops a
+   prepare / migrate / commit / retire generation protocol across programs,
+   links, maps, pinned state, controller recovery, and rollback.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` develops typed,
+   lifetime-aware handoff edges and a ground-truth cross-thread attribution
+   benchmark.
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separates the cBPF
+   admission gate from the eBPF `io_uring_bpf_ops` control surface and develops
+   policy generations, provenance, and capability contracts.
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` develops a
+   target manifest, generation-scoped state ownership, and a placement/provenance
+   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
+
+The Daily Report index already exposes these sequences. Revisit dedicated public
+series hubs only when report-level acquisition or navigation evidence shows a
+retrieval benefit beyond the current index.
 
 ## Queued series — Agent Systems (limited)
 
@@ -356,7 +233,7 @@ Existing anchors:
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-Neither pure-Agent report remains inside the newest ten after the August 22
+Neither pure-Agent report remains inside the newest ten after the August 28
 publication. Pure-Agent publication is allowed by the cap but is not required;
 prefer the technically stronger question after applying the evidence, novelty,
 and editorial-mix gates.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -68,13 +68,276 @@ A daily report must still provide:
 - After a series has at least three strong reports, consider a public series hub
   and stronger internal linking. Do not create thin hub pages in advance.
 
+## Completed series — eBPF Networking and Security
+
+Working question: **Where are eBPF networking and security mechanisms still
+missing deployable abstractions or correctness guarantees?**
+
+This series became active after the `2026-08-22` report completed the normal
+six-report boundary for eBPF Observability and Profiling and reached its own
+normal six-report boundary on `2026-08-28`.
+
+The roadmap initially preferred transactional policy updates across programs,
+maps, links, and userspace control planes. Fresh novelty review on `2026-08-23`
+rejected that candidate because `/research/stateful-ebpf-transactional-upgrade/`
+already develops a prepare / migrate / commit / retire generation protocol across
+programs, links, maps, pinned state, controller recovery, and rollback. Repeating
+the same update transaction with a networking example would not materially
+advance the archive.
+
+The `2026-08-23` report starts the series with a distinct security-policy
+question: how additive Kubernetes `NetworkPolicy`, tiered `ClusterNetworkPolicy`,
+and Cilium L3-L7 policy can compose for multiple owners without losing authority,
+delegation, or source-policy provenance after the result is compiled into an
+eBPF datapath. It develops an authority-aware composition IR, generation-stable
+verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
+
+The `2026-08-24` report advances a second, materially different boundary. AF_XDP,
+io_uring ZC Rx, page_pool, and DPDK all recycle packet memory through native
+ownership protocols, while BPF policy decisions, NIC steering, and userspace
+processing can cross those boundaries. The report develops a generation-scoped
+buffer capability, policy-linked handoff witnesses, and a cross-path zero-copy
+fault benchmark. It is distinct from the earlier io_uring programmability report:
+the missing property is buffer lease ownership and provenance across APIs, not
+BPF execution control inside the ring.
+
+The `2026-08-25` report advances a third boundary: the Linux verifier can prove
+that each loaded BPF program executes safely while the security policy encoded in
+persistent map state still follows an invalid temporal trace. Production policy
+state can be shared across hooks, CPUs, programs, and userspace and can change
+under eviction, map pressure, revocation, restart, or stale control-plane writes.
+The report develops a small temporal policy contract, verifier-cooperative runtime
+transition guards, and an adversarial state-fault benchmark. This is distinct
+from verifier-error diagnosis, transactional upgrade, and policy composition:
+the target property is legal runtime state transition after safe bytecode has
+already been admitted.
+
+The `2026-08-26` report narrows one consequence of persistent state into an
+incident-response property. A policy or identity can be revoked while an old
+allow still survives in connection tracking, authentication caches, socket-local
+storage, or another derived datapath object. The report asks for a measurable
+upper bound on that stale authority rather than another general state-machine
+contract. It develops scoped revocation epochs, a cross-layer completion barrier,
+and a benchmark whose primary outcome is the last stale allow after a revoke.
+
+The `2026-08-27` report advances a fifth boundary by narrowing heterogeneous
+execution placement into a complete-mediation property. Linux representors and
+XDP offload expose host slow paths and device fast paths that can change under
+misses, updates, and faults. The report asks whether every reachable
+policy-relevant packet path still crosses an enforcement point for the current
+policy generation. It develops a path-coverage plan, generation-continuous
+offload/fallback, and a benchmark whose primary outcome is policy escape rather
+than offload throughput.
+
+A broad cross-boundary information-flow candidate was considered again on
+`2026-08-28` but not selected. Existing ActPlane and Eunomia material already
+covers process/file/network effect labels and layered enforcement, so a broad
+version has higher thesis-overlap risk than a narrower cross-boundary property.
+A second candidate limited to fast-path versus proxy allow/deny equivalence was
+also rejected because it overlaps complete mediation and placement without
+capturing what identity the accepted request carries.
+
+The `2026-08-28` report closes the series with a sixth distinct boundary: an L7
+proxy can terminate a policy-bound downstream connection and emit or reuse a new
+upstream socket, so every intended enforcement point can still be present while
+the request loses the principal and policy generation that justified it. The
+report develops generation-scoped handoff capabilities, policy-safe
+multiplexing, and an authorization-lineage benchmark across kernel fast paths
+and proxy slow paths.
+
+### Published progress
+
+1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
+   policy-language semantics from BPF hook composition and update transactions.
+   It asks how several legitimate policy owners can produce one effective
+   network verdict while keeping the deciding owner, tier, delegation path, and
+   source rule inspectable across policy generations. The report is
+   eBPF-centered because the proposed provenance contract is evaluated against
+   the realized BPF policy datapath, not only against Kubernetes objects.
+2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` separates
+   allocator-specific lifetime rules from a cross-path ownership contract. It
+   asks how packet-buffer leases can preserve owner, DMA reachability, recycle
+   generation, and BPF policy provenance across AF_XDP, io_uring ZC Rx, DPDK,
+   userspace eBPF, and NIC handoffs. It is eBPF-centered because policy identity
+   and BPF/user-runtime transitions are part of the correctness contract rather
+   than optional instrumentation.
+3. `2026-08-25`: `/research/ebpf-stateful-policy-verification/` separates
+   per-program verifier safety from temporal correctness of persistent security
+   state. It asks how map-backed policy states can restrict legal transitions,
+   transition authority, generations, expiry, capacity failure, and userspace
+   writes without forcing the Linux verifier to model unbounded event history.
+   It is eBPF-centered because BPF maps, hooks, verifier boundaries, and in-kernel
+   transition enforcement are the central mechanism rather than optional probes.
+4. `2026-08-26`: `/research/ebpf-authorization-revocation/` separates policy
+   rollout from revocation effectiveness. It asks how a previously admitted
+   authorization can be made unusable within a measurable bound across conntrack,
+   auth maps, socket-local state, endpoint policy, and userspace-managed state.
+   It is eBPF-centered because the proposed epoch checks and completion barrier
+   are evaluated on persistent BPF datapath state and hot-path policy reuse.
+5. `2026-08-27`: `/research/ebpf-complete-mediation-offload/` separates backend
+   placement from global security coverage. It asks how host software, SmartNIC
+   fast paths, representor fallback, and DPU/offload execution can preserve one
+   current enforcement point for every reachable policy-relevant packet path.
+   It is eBPF-centered because BPF/XDP attachment, offload capability, policy
+   generations, and cross-backend verdict continuity are the core mechanism.
+6. `2026-08-28`: `/research/ebpf-l7-proxy-policy-identity/` separates path
+   coverage from authorization identity continuity across a semantic proxy
+   boundary. It asks how the original principal, policy generation, and
+   authorization provenance survive proxy termination, connection pooling,
+   multiplexing, retry, and fast/slow-path fallback. It is eBPF-centered because
+   the handoff starts and ends at BPF policy boundaries and the proposed
+   capability/lineage contract is evaluated against the realized BPF datapath.
+
+Future work should return to this series only when fresh evidence supports a
+mechanism beyond these six boundaries. In particular, do not repeat policy
+composition, zero-copy ownership, temporal state verification, revocation,
+complete mediation, or proxy identity continuity with a different product
+example alone.
+
+Before and after the August 28 publication, the newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
+report ages another eBPF-centered report out of the rolling ten.
+
+## Completed series — eBPF Observability and Profiling
+
+Historical roadmap state: **Active series — eBPF Observability and Profiling**
+through the `2026-08-22` report. The series is completed after that publication;
+Networking and Security became the active series for the next normal run.
+
+Working question: **Which important performance and correctness questions remain
+unanswerable with today's eBPF observability stack?**
+
+The `2026-08-18` report started this series with **page-level memory attribution**:
+how to distinguish allocation from pages that were actually touched, faulted,
+reclaimed, migrated, or responsible for sampled memory cost while preserving
+provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
+
+The `2026-08-19` report was a deliberate **adjacent profiling detour** on sampling
+bias. Its central mechanism is general profiler measurement design, not eBPF, so
+it is classified as adjacent systems.
+
+The first `2026-08-20` report was a second adjacent profiling detour required by
+the rolling-window arithmetic. It asks whether a late CUDA kernel start came from
+host scheduling, runtime/command-buffer work, a dependency, or device
+availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
+host tracing can be an optional evidence source but is not essential, so this
+report is adjacent systems rather than eBPF-centered.
+
+The second `2026-08-20` report follows the same adjacent-systems boundary from a
+causality angle. It asks how host API work, runtime handoffs, CUDA Graph replay,
+and device execution can retain a trustworthy causal identity. CUPTI/CUDA
+dependency semantics are central while eBPF is one possible host observer.
+
+The `2026-08-21` report returns to an eBPF-essential question: how dynamic probes
+can observe application-defined pools, queues, caches, and credits without
+silently turning stale program semantics into confident diagnoses. It develops a
+versioned semantics manifest, runtime semantic validation, and a mutation
+benchmark for software evolution.
+
+The `2026-08-22` report closes the series with another eBPF-essential question:
+how always-on collectors can reduce high-rate telemetry before export without
+silently deleting the evidence required for diagnosis. It develops a compiled
+diagnostic contract, bounded state-transition exemplars, coverage-carrying
+summaries, and an equal-budget diagnosis-retention benchmark.
+
+### Published progress
+
+1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` separates
+   allocation intent, residency, working-set evidence, page lifecycle, and
+   sampled memory cost, then develops a lifetime-aware provenance ledger,
+   access-weighted attribution with explicit confidence, and a ground-truth
+   benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
+   migration.
+2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
+   untrustworthy. It compares randomized sampling history, current Linux perf
+   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
+   develops a sampling-schedule contract with aliasing diagnostics, independent
+   profile epochs with uncertainty and rank stability, and uncertainty-triggered
+   selective instrumentation. Because the mechanism applies to profilers in
+   general and does not require eBPF, this report is adjacent systems rather than
+   eBPF-centered.
+3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
+   command-buffer queue/submission, dependency readiness, device availability,
+   and kernel execution. It develops an explicit launch-state ledger, a
+   cross-domain launch identity that survives host handoffs and graph replay, and
+   a ground-truth launch-delay attribution benchmark. The central question is GPU
+   profiling, so it is adjacent systems.
+4. `2026-08-20`: `/research/gpu-host-device-causality/` develops
+   generation-scoped host/device causal identity, dependency-aware critical-path
+   reasoning, explicit unknown/loss states, and a ground-truth causality
+   benchmark. CUPTI/CUDA dependency semantics are essential while eBPF is one
+   possible host observer, so this report is adjacent systems.
+5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF
+   can dynamically observe application-defined resources without hard-coding
+   stale semantics. It develops a versioned resource-semantics manifest compiled
+   into eBPF attachments, runtime semantic validation with explicit confidence
+   loss, and a software-mutation benchmark. Dynamic no-rebuild instrumentation
+   and independent cross-layer validation are central, so this report is
+   eBPF-centered.
+6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` asks how an
+   always-on eBPF collector can reduce telemetry volume before export while
+   preserving later root-cause diagnosis. It develops a diagnostic-contract
+   compiler for BPF retention plans, state-transition exemplars, explicit
+   coverage accounting, and an equal-budget incident benchmark. Source-side BPF
+   aggregation and exemplar retention are central, so this report is
+   eBPF-centered.
+
+Before and after the August 22 publication, the newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
+report ages an eBPF-centered report out of the rolling ten.
+
+A related unresolved question remains: online confidence and adaptive collection
+when trace loss, missing probes, or stale schemas make the current representation
+uncertain. It is intentionally not a seventh report in this series. The August 22
+report first defines what a compact representation promises to preserve; adaptive
+fidelity can be revisited later when fresh evidence supports a distinct mechanism.
+
+## Completed series — eBPF Runtime, Extensibility, and Composition
+
+Working question: **What mechanisms are still missing if eBPF is treated as a
+programmable runtime substrate rather than only a kernel observability feature?**
+
+This series connected kernel and userspace execution, composition, state,
+upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
+execution placement. It reached the normal six-report series boundary on
+`2026-08-17` and is no longer the default topic source for scheduled publication.
+
+### Published progress
+
+1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
+   first-class userspace eBPF needs explicit attachment, capability, state,
+   lifetime, and attribution contracts above ISA compatibility.
+2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
+   multi-program problem beyond dispatch and ordering to effect visibility,
+   outcome resolution, shared-state ownership, and versioned hook composition.
+3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
+   object-level replacement from application-level upgrade and developed an
+   explicit prepare / migrate / commit / retire generation protocol for programs,
+   links, maps, pinned state, controller recovery, and rollback.
+4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
+   execution from logical-work causality and developed typed, lifetime-aware
+   handoff edges, an edge-versus-context measurement budget, and a ground-truth
+   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
+   application-defined resources.
+5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
+   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops`
+   execution-control path, then developed a typed capability contract, versioned
+   ring policy generations, explicit provenance, and a comparative
+   control-boundary benchmark.
+6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
+   backend compatibility from execution placement and developed a target
+   manifest, generation-scoped state ownership, and a ground-truth
+   placement/provenance benchmark across kernel, userspace, NIC/DPU, and
+   GPU-side targets.
+
+The Daily Report index already exposes the sequence. Report-level acquisition and
+navigation evidence is still too young to justify a dedicated public series hub.
+Revisit that decision only when evidence shows a retrieval benefit.
+
 ## Active series — GPU and Heterogeneous Runtime Systems
 
-Working question: **What runtime, programmability, and observability abstractions
-are missing at CPU/GPU and host/device boundaries?**
-
-This roadmap becomes active after the `2026-08-28` report reaches the normal
-six-report boundary for eBPF Networking and Security.
+Working question: **What runtime and observability abstractions are missing at
+CPU/GPU and host/device boundaries?**
 
 Candidate topics include GPU/CPU causal profiling, memory movement, megakernel
 observability, programmable device-side instrumentation, distributed GPU
@@ -82,145 +345,19 @@ coordination, utilization versus allocatability, host-side scheduling noise, and
 eBPF-like programmable monitors near GPU or DPU execution.
 
 Reports in this series count toward the eBPF share only when eBPF or an eBPF-like
-runtime is central to the mechanism being evaluated. A report whose core
-mechanism is CUPTI, CUDA, GPU scheduling, or another general accelerator
-abstraction without essential eBPF machinery is adjacent systems.
+runtime is central to the mechanism being evaluated.
 
-The two August 20 GPU reports are useful existing anchors but do not count as
-progress in the newly active sequence. They establish two boundaries that new
-reports should not simply repeat:
+The two August 20 reports are focused adjacent-systems contributions to this
+roadmap, but they predate activation and do not count as progress in the new
+normal sequence. They establish two boundaries that should not simply be
+repeated: kernel launch-latency attribution and host/device causal tracing.
 
-- `/research/gpu-kernel-launch-latency/` separates queueing/readiness delay from
-  kernel execution time;
-- `/research/gpu-host-device-causality/` develops host/device causal identity and
-  explicit unknown dependency edges.
-
-### Preferred next questions
-
-1. a device-side programmability or policy boundary where an eBPF-like runtime
-   materially changes what can be enforced or adapted without rebuilding the
-   workload;
-2. memory-placement or movement semantics where CPU and GPU observers disagree
-   about ownership, residency, or cost and a deployable cross-domain contract is
-   missing;
-3. fine-grained GPU execution observability only when the question is distinct
-   from launch-latency attribution and host/device causal tracing;
-4. distributed GPU coordination when there is a concrete runtime invariant to
-   test rather than a generic scaling survey;
-5. revisit heterogeneous placement only when fresh evidence exposes a mechanism
-   beyond the already published target-manifest and generation-scoped ownership
-   contract.
-
-After the August 28 publication, the newest ten remain **7 eBPF-centered / 0 pure
-Agent / 3 adjacent systems**. The next report may therefore be either eBPF-centered
-or adjacent, but evidence and thesis quality decide the classification.
-
-## Completed series — eBPF Networking and Security
-
-Working question: **Where are eBPF networking and security mechanisms still
-missing deployable abstractions or correctness guarantees?**
-
-This series became active after the `2026-08-22` report completed eBPF
-Observability and Profiling. It reaches the normal six-report boundary on
-`2026-08-28`.
-
-### Published progress
-
-1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
-   policy-language semantics from BPF hook composition and update transactions.
-   It asks how several legitimate policy owners can produce one effective
-   verdict while keeping the deciding owner, tier, delegation path, and source
-   rule inspectable across policy generations.
-2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` asks how packet
-   buffer leases preserve owner, DMA reachability, recycle generation, and BPF
-   policy provenance across AF_XDP, io_uring ZC Rx, DPDK, userspace eBPF, and NIC
-   handoffs.
-3. `2026-08-25`: `/research/ebpf-stateful-policy-verification/` separates
-   verifier-safe bytecode from legal temporal transitions of persistent policy
-   state shared across hooks, CPUs, maps, and userspace updates.
-4. `2026-08-26`: `/research/ebpf-authorization-revocation/` separates rollout
-   from revocation effectiveness and asks for a measurable bound on stale
-   authority across conntrack, auth maps, socket-local state, and other derived
-   datapath objects.
-5. `2026-08-27`: `/research/ebpf-complete-mediation-offload/` separates backend
-   placement from global security coverage and asks whether every reachable
-   host/SmartNIC/DPU packet path still crosses a policy-equivalent enforcement
-   point for the current generation.
-6. `2026-08-28`: `/research/ebpf-l7-proxy-policy-identity/` separates path
-   coverage from authorization identity continuity. It asks how a principal,
-   policy generation, and authorization provenance survive when eBPF redirects a
-   request into an L7 proxy that terminates the downstream connection and emits
-   or reuses a different upstream socket. It develops generation-scoped handoff
-   capabilities, policy-safe multiplexing, and an authorization-lineage
-   benchmark across kernel fast paths and proxy slow paths.
-
-The sixth report was selected only after rejecting a broad information-flow
-candidate that still overlapped ActPlane effect labels and a narrower fast/slow
-verdict-equivalence candidate that overlapped the complete-mediation report. The
-proxy identity question is distinct because the request can cross every intended
-enforcement point and still be attributed to the wrong principal after the
-semantic handoff.
-
-Future networking/security work should return only when fresh evidence supports
-a mechanism beyond these six published boundaries. In particular, do not repeat
-transactional rollout, zero-copy ownership, revocation, complete mediation, or
-proxy identity continuity with a new product example alone.
-
-## Completed series — eBPF Observability and Profiling
-
-Working question: **Which important performance and correctness questions remain
-unanswerable with today's eBPF observability stack?**
-
-Published progress:
-
-1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` develops
-   lifetime-aware page provenance and access-weighted attribution.
-2. `2026-08-19`: `/research/profiler-sampling-bias/` is an adjacent profiling
-   detour on aliasing, skid, coverage, and uncertainty.
-3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` is an adjacent GPU
-   profiling report on launch-state attribution.
-4. `2026-08-20`: `/research/gpu-host-device-causality/` is an adjacent GPU
-   report on host/device causal identity and dependency uncertainty.
-5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` develops a
-   versioned semantics manifest and mutation benchmark for application-defined
-   resources.
-6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` develops a
-   diagnostic-contract compiler, state-transition exemplars, coverage-carrying
-   summaries, and equal-budget diagnosis-retention evaluation.
-
-A related question about online confidence and adaptive collection remains valid
-but should be revisited only when fresh evidence supports a mechanism distinct
-from the compression contract.
-
-## Completed series — eBPF Runtime, Extensibility, and Composition
-
-Working question: **What mechanisms are still missing if eBPF is treated as a
-programmable runtime substrate rather than only a kernel observability feature?**
-
-Published progress:
-
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` establishes
-   attachment, capability, state, lifetime, and attribution contracts above ISA
-   compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` develops typed
-   composition semantics for effect visibility, outcomes, shared state, and
-   versioned hooks.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` develops a
-   prepare / migrate / commit / retire generation protocol across programs,
-   links, maps, pinned state, controller recovery, and rollback.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` develops typed,
-   lifetime-aware handoff edges and a ground-truth cross-thread attribution
-   benchmark.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separates the cBPF
-   admission gate from the eBPF `io_uring_bpf_ops` control surface and develops
-   policy generations, provenance, and capability contracts.
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` develops a
-   target manifest, generation-scoped state ownership, and a placement/provenance
-   benchmark across kernel, userspace, NIC/DPU, and GPU-side targets.
-
-The Daily Report index already exposes these sequences. Revisit dedicated public
-series hubs only when report-level acquisition or navigation evidence shows a
-retrieval benefit beyond the current index.
+The series becomes active after the `2026-08-28` Networking and Security report
+reaches that series' normal six-report boundary. Preferred next questions are
+runtime or device-side programmability boundaries, memory-placement/movement
+semantics, fine-grained GPU execution observability distinct from the August 20
+reports, and distributed GPU coordination only where a concrete runtime invariant
+can be tested.
 
 ## Queued series — Agent Systems (limited)
 

--- a/.github/seo-data/daily/2026-08-28.md
+++ b/.github/seo-data/daily/2026-08-28.md
@@ -1,0 +1,105 @@
+# Daily SEO and research record — 2026-08-28
+
+## Scope
+
+- Canonical site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Delivery branch: `daily/2026-08-28-ebpf-l7-policy-identity`
+- Baseline default-branch commit: `a94361166c3dd27d99450fdca2bd5385d5f4020d`
+- Technical SEO outcome: no separate implementation change; current evidence does not establish a crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect that justifies one.
+- Mandatory publication: one new bilingual Daily Report on policy identity across an eBPF-to-L7-proxy handoff.
+
+## Data coverage and analysis
+
+### Google Drive
+
+The configured `eunomia.dev SEO Weekly CSV` folder was directly reverified on `2026-08-28`. The newest source-native weekly set remains `2026-08-17..23`; no later weekly set was observed. Missing coverage is not interpreted as zero.
+
+### Search Console
+
+The newest verified date export still contains finalized rows through `2026-08-22`; `2026-08-23` is absent. The longest equal-duration contiguous finalized comparison supported by the available rows remains six days:
+
+- `2026-08-17..22`: **477 clicks / 59,798 impressions / ~0.798% CTR / ~9.56 impression-weighted position**.
+- `2026-08-10..15`: **393 clicks / 66,510 impressions / ~0.591% CTR / ~9.91 position**.
+- Direction: clicks **+21.4%**, impressions **-10.1%**, CTR **+0.207 percentage points**, position improves by about **0.35**.
+
+A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the needed `2026-08-16` and `2026-08-09` rows are absent. Verified history also remains too short for the required 28-day comparison.
+
+The latest page export continues to show demand distributed across the eBPF tutorial, CUDA/GPU material, project pages, and older technical writing rather than a single new page dominating the aggregate. The latest query export likewise contains a broad mixture of eBPF, GPU/CUDA, project-name, and long-tail technical intent. Raw query rows are not copied into Git. The available weekly exports do not contain a date-by-page or date-by-query dimension, so this run does not attribute the six-day aggregate movement to a specific page, title, or topic.
+
+### GA4
+
+The `2026-08-17..23` organic landing-page aggregate is finalized under the configured three-day lag: **984 sessions** at about **49.29% session-weighted engagement**, including **118 `(not set)` sessions**, versus **970 sessions** at about **44.95%** for `2026-08-10..16`. Sessions are about **1.4% higher** and engagement about **4.34 percentage points higher**.
+
+The current landing-page export continues to distribute organic sessions across the homepage, eBPF tutorials, CUDA/GPU material, project pages, and research/writing pages. Because the file is a weekly aggregate without a date dimension, it cannot support within-week causal attribution.
+
+### Cloudflare
+
+Cloudflare analytics remains disabled by repository configuration. No edge-request, bot, cache, country, or status-code conclusion is made from missing Cloudflare data.
+
+### Public site and GitHub
+
+A fresh public homepage fetch on `2026-08-28` shows the expected Eunomia site identity, Daily Report navigation, project taxonomy, and public `9,950+ GitHub stars` badge. The badge is used only as a public project signal, not as an SEO causal metric. Public GitHub evidence remains available; unrelated private/account data is not copied into the operating record.
+
+## Technical SEO/GEO audit
+
+The current repository baseline already generates sitemap, robots, canonical ownership, reciprocal language alternates, structured data, legacy redirect stubs, and static audit artifacts. The fresh homepage renders the canonical project identity and expected navigation. Google evidence does not isolate a current page-level search defect, and no fresh production failure is present in repository state.
+
+Result: **no separate technical SEO/GEO site change today**. Making a speculative title, navigation, canonical, redirect, or structured-data edit from aggregate movement would be weaker than preserving the current baseline.
+
+The pinned `.github/seo-skills` commit remains `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` has advanced to `f42128a3f05c73cf10c786a2711c488bb3a14839`, but the consuming repository explicitly requires contract migration before a pointer-only update because the newer generic closeout contract conflicts with this repository's one-PR / one-closeout-comment daily rule. No submodule movement is made in this run.
+
+## Editorial mix before topic selection
+
+Before today's publication, the newest ten Daily Reports are classified as:
+
+- **7 eBPF-centered**
+- **0 pure Agent-centered**
+- **3 adjacent systems**
+
+Today's selected report is eBPF-centered. The incoming eBPF report ages another eBPF-centered report out of the rolling ten, so the post-publication mix remains **7 / 0 / 3**.
+
+The active series before selection is **eBPF Networking and Security**, with five substantial reports already published. A sixth report is allowed only if it is mechanistically distinct from composition, zero-copy ownership, state-transition verification, revocation, and complete mediation.
+
+## Candidate review
+
+### Rejected: broad cross-boundary information-flow labels
+
+A broad information-flow report still overlaps too strongly with existing ActPlane effect labels and the archive's layered enforcement work. Without a narrower boundary and new mechanism, it would restate existing material rather than advance the series.
+
+### Rejected: fast-path versus proxy verdict equivalence alone
+
+Recent L7FP work makes fast-path/slow-path equivalence timely, but a report limited to whether both paths return the same allow/deny result overlaps the previous complete-mediation and placement work. Verdict equivalence alone does not isolate a new systems property.
+
+### Selected: policy identity across the L7 proxy handoff
+
+Current Cilium documentation provides a concrete production boundary: L7 policies use node-local Envoy; Envoy interacts with the eBPF policy engine; Ingress/Gateway traffic can cross two logical enforcement points and change from an external `world` identity to a special `ingress` identity. Linux sockmap/sockhash provides socket-level redirect and verdict mechanisms, but socket identity does not inherently preserve a logical HTTP/2/gRPC request across proxy termination, pooling, retries, and a new upstream socket. L7FP adds a current fast-path/slow-path split where this identity-continuity question becomes more important.
+
+The selected thesis is therefore narrower than broad information flow: **a security-sensitive eBPF-to-proxy handoff needs request-scoped, generation-aware authorization lineage, not only a trusted proxy socket and not only path coverage**.
+
+## Daily Report publication
+
+- English: `/research/ebpf-l7-proxy-policy-identity/`
+- Chinese: `/zh/research/ebpf-l7-proxy-policy-identity/`
+- Classification: **eBPF-centered**
+- Series: **eBPF Networking and Security**, report 6 of 6
+- Research question: how to preserve the original principal, policy generation, and authorization provenance when eBPF redirects a policy-bound flow to an L7 proxy that terminates and re-originates traffic.
+
+The report develops three mechanisms:
+
+1. generation-scoped proxy handoff capabilities that bind principal, policy generation, destination scope, nonce, expiry/revocation state, and proxy authority;
+2. policy-safe multiplexing that treats request-to-socket coalescing as a security equivalence obligation rather than assuming one identity per upstream socket;
+3. a confused-deputy and fast/slow-path benchmark whose primary metric is an authorization-lineage violation rather than throughput or HTTP allow/deny alone.
+
+Primary evidence includes current Cilium Envoy/L7/Ingress documentation, current Linux sockmap/sockhash documentation, and the May 2026 L7FP paper.
+
+## Continuity decision
+
+This sixth distinct report reaches the normal series boundary for **eBPF Networking and Security**. After publication, that series moves to completed status. The repository's already queued **GPU and Heterogeneous Runtime Systems** series becomes the next active series. Its reports count as eBPF-centered only when eBPF or an eBPF-like runtime is central to the mechanism; otherwise they remain adjacent systems. The rolling `7 / 0 / 3` mix leaves room for either classification, but evidence and novelty still determine the actual next report.
+
+## Delivery state
+
+Pending at record creation: non-draft PR, authoritative CI, complete final diff/generated-output self-review, squash merge, exact-squash production deployment, bilingual production verification, and the single merged-PR closeout comment required by `DAILY_TASK.md`.
+
+No raw analytics, Drive IDs, private identifiers, credentials, or personal information are committed.

--- a/.github/seo-data/daily/2026-08-28.md
+++ b/.github/seo-data/daily/2026-08-28.md
@@ -1,4 +1,4 @@
-# Daily SEO and research record — 2026-08-28
+# SEO operations — 2026-08-28
 
 ## Scope
 
@@ -7,18 +7,23 @@
 - Authoritative task: `DAILY_TASK.md`
 - Delivery branch: `daily/2026-08-28-ebpf-l7-policy-identity`
 - Baseline default-branch commit: `a94361166c3dd27d99450fdca2bd5385d5f4020d`
-- Technical SEO outcome: no separate implementation change; current evidence does not establish a crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect that justifies one.
+- Technical SEO outcome: no separate site implementation change; current evidence does not establish a crawl, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect that justifies one.
 - Mandatory publication: one new bilingual Daily Report on policy identity across an eBPF-to-L7-proxy handoff.
 
-## Data coverage and analysis
+## Data window
 
-### Google Drive
+- Verified raw Google export window: `2026-07-27` through `2026-08-23`.
+- Newest source-native weekly set directly observed in the configured Drive folder: `2026-08-17..23`; no later set was observed on `2026-08-28`.
+- Search Console newest verified finalized row: `2026-08-22`; `2026-08-23` is absent.
+- GA4 newest finalized source-native weekly aggregate: `2026-08-17..23`.
+- Search Console complete latest-seven-days and 28-day comparisons: unavailable because required rows/history are missing; missing coverage is not interpreted as zero.
+- Cloudflare: disabled by repository configuration.
 
-The configured `eunomia.dev SEO Weekly CSV` folder was directly reverified on `2026-08-28`. The newest source-native weekly set remains `2026-08-17..23`; no later weekly set was observed. Missing coverage is not interpreted as zero.
+## Evidence collected
 
-### Search Console
+### Google Search Console
 
-The newest verified date export still contains finalized rows through `2026-08-22`; `2026-08-23` is absent. The longest equal-duration contiguous finalized comparison supported by the available rows remains six days:
+The longest equal-duration contiguous finalized comparison supported by the available rows remains six days:
 
 - `2026-08-17..22`: **477 clicks / 59,798 impressions / ~0.798% CTR / ~9.56 impression-weighted position**.
 - `2026-08-10..15`: **393 clicks / 66,510 impressions / ~0.591% CTR / ~9.91 position**.
@@ -28,7 +33,7 @@ A complete latest-seven-days versus previous-seven-days comparison remains unava
 
 The latest page export continues to show demand distributed across the eBPF tutorial, CUDA/GPU material, project pages, and older technical writing rather than a single new page dominating the aggregate. The latest query export likewise contains a broad mixture of eBPF, GPU/CUDA, project-name, and long-tail technical intent. Raw query rows are not copied into Git. The available weekly exports do not contain a date-by-page or date-by-query dimension, so this run does not attribute the six-day aggregate movement to a specific page, title, or topic.
 
-### GA4
+### Google Analytics 4
 
 The `2026-08-17..23` organic landing-page aggregate is finalized under the configured three-day lag: **984 sessions** at about **49.29% session-weighted engagement**, including **118 `(not set)` sessions**, versus **970 sessions** at about **44.95%** for `2026-08-10..16`. Sessions are about **1.4% higher** and engagement about **4.34 percentage points higher**.
 
@@ -42,7 +47,13 @@ Cloudflare analytics remains disabled by repository configuration. No edge-reque
 
 A fresh public homepage fetch on `2026-08-28` shows the expected Eunomia site identity, Daily Report navigation, project taxonomy, and public `9,950+ GitHub stars` badge. The badge is used only as a public project signal, not as an SEO causal metric. Public GitHub evidence remains available; unrelated private/account data is not copied into the operating record.
 
-## Technical SEO/GEO audit
+### Research evidence
+
+Current Cilium documentation provides a concrete production boundary: L7 policy traffic uses Envoy; Envoy interacts with the eBPF policy engine; Ingress/Gateway traffic can cross two logical enforcement points and change from an external `world` identity to a special `ingress` identity. Current Linux sockmap/sockhash documentation provides socket-level redirect and verdict mechanisms, but socket identity does not inherently preserve a logical HTTP/2 or gRPC request across proxy termination, pooling, retries, and a new upstream socket. The May 2026 L7FP paper adds a current eBPF fast-path / proxy-slow-path split where identity continuity is a distinct correctness question.
+
+## Work performed
+
+### Technical SEO/GEO audit
 
 The current repository baseline already generates sitemap, robots, canonical ownership, reciprocal language alternates, structured data, legacy redirect stubs, and static audit artifacts. The fresh homepage renders the canonical project identity and expected navigation. Google evidence does not isolate a current page-level search defect, and no fresh production failure is present in repository state.
 
@@ -50,35 +61,20 @@ Result: **no separate technical SEO/GEO site change today**. Making a speculativ
 
 The pinned `.github/seo-skills` commit remains `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` has advanced to `f42128a3f05c73cf10c786a2711c488bb3a14839`, but the consuming repository explicitly requires contract migration before a pointer-only update because the newer generic closeout contract conflicts with this repository's one-PR / one-closeout-comment daily rule. No submodule movement is made in this run.
 
-## Editorial mix before topic selection
+### Editorial mix and candidate review
 
-Before today's publication, the newest ten Daily Reports are classified as:
-
-- **7 eBPF-centered**
-- **0 pure Agent-centered**
-- **3 adjacent systems**
-
-Today's selected report is eBPF-centered. The incoming eBPF report ages another eBPF-centered report out of the rolling ten, so the post-publication mix remains **7 / 0 / 3**.
+Before today's publication, the newest ten Daily Reports are **7 eBPF-centered / 0 pure Agent-centered / 3 adjacent systems**. Today's selected report is eBPF-centered. The incoming report ages another eBPF-centered report out of the rolling ten, so the post-publication mix remains **7 / 0 / 3**.
 
 The active series before selection is **eBPF Networking and Security**, with five substantial reports already published. A sixth report is allowed only if it is mechanistically distinct from composition, zero-copy ownership, state-transition verification, revocation, and complete mediation.
 
-## Candidate review
+Rejected candidates:
 
-### Rejected: broad cross-boundary information-flow labels
+- **Broad cross-boundary information-flow labels**: still overlaps too strongly with existing ActPlane effect labels and the archive's layered enforcement work.
+- **Fast-path versus proxy verdict equivalence alone**: L7FP makes the boundary timely, but allow/deny equivalence overlaps the previous complete-mediation and placement work and does not isolate a new property.
 
-A broad information-flow report still overlaps too strongly with existing ActPlane effect labels and the archive's layered enforcement work. Without a narrower boundary and new mechanism, it would restate existing material rather than advance the series.
+Selected candidate: **policy identity across the L7 proxy handoff**. The thesis is narrower: a security-sensitive eBPF-to-proxy handoff needs request-scoped, generation-aware authorization lineage, not only a trusted proxy socket and not only path coverage.
 
-### Rejected: fast-path versus proxy verdict equivalence alone
-
-Recent L7FP work makes fast-path/slow-path equivalence timely, but a report limited to whether both paths return the same allow/deny result overlaps the previous complete-mediation and placement work. Verdict equivalence alone does not isolate a new systems property.
-
-### Selected: policy identity across the L7 proxy handoff
-
-Current Cilium documentation provides a concrete production boundary: L7 policies use node-local Envoy; Envoy interacts with the eBPF policy engine; Ingress/Gateway traffic can cross two logical enforcement points and change from an external `world` identity to a special `ingress` identity. Linux sockmap/sockhash provides socket-level redirect and verdict mechanisms, but socket identity does not inherently preserve a logical HTTP/2/gRPC request across proxy termination, pooling, retries, and a new upstream socket. L7FP adds a current fast-path/slow-path split where this identity-continuity question becomes more important.
-
-The selected thesis is therefore narrower than broad information flow: **a security-sensitive eBPF-to-proxy handoff needs request-scoped, generation-aware authorization lineage, not only a trusted proxy socket and not only path coverage**.
-
-## Daily Report publication
+### Daily Report publication
 
 - English: `/research/ebpf-l7-proxy-policy-identity/`
 - Chinese: `/zh/research/ebpf-l7-proxy-policy-identity/`
@@ -92,14 +88,34 @@ The report develops three mechanisms:
 2. policy-safe multiplexing that treats request-to-socket coalescing as a security equivalence obligation rather than assuming one identity per upstream socket;
 3. a confused-deputy and fast/slow-path benchmark whose primary metric is an authorization-lineage violation rather than throughput or HTTP allow/deny alone.
 
-Primary evidence includes current Cilium Envoy/L7/Ingress documentation, current Linux sockmap/sockhash documentation, and the May 2026 L7FP paper.
+### Repository validation repair
 
-## Continuity decision
+The first PR validation run exposed a stale hard-coded assertion in `.github/workflows/seo-data-validate.yml` that still required the previously completed **eBPF Observability and Profiling** series to be active. The workflow was corrected on the same branch to validate the durable invariant—exactly one `## Active series — ...` heading—rather than a specific series name. The next validation run confirmed that authoritative-task check and then exposed that this new daily record had not used the pinned SEO data schema headings; this file was normalized to the required schema rather than weakening the data validator.
 
-This sixth distinct report reaches the normal series boundary for **eBPF Networking and Security**. After publication, that series moves to completed status. The repository's already queued **GPU and Heterogeneous Runtime Systems** series becomes the next active series. Its reports count as eBPF-centered only when eBPF or an eBPF-like runtime is central to the mechanism; otherwise they remain adjacent systems. The rolling `7 / 0 / 3` mix leaves room for either classification, but evidence and novelty still determine the actual next report.
+## Validation and self-review
 
-## Delivery state
+- Initial `Validate SEO Operations` run `33185454515`: failed on the stale active-series assertion; root daily contract and current series state showed the validator was stale.
+- Corrective workflow commit: `518a4dd751b31509b5a2d9736134ceeb3f380c2f`.
+- Second `Validate SEO Operations` run `33185639590`: authoritative daily-task contract passed; public SEO data validation then correctly failed because today's record lacked the pinned canonical headings.
+- Current correction: align today's record to the required `daily.example.md` / `validate_seo_data.py` schema.
+- Final PR CI and complete final diff/generated-output self-review: pending after this correction.
 
-Pending at record creation: non-draft PR, authoritative CI, complete final diff/generated-output self-review, squash merge, exact-squash production deployment, bilingual production verification, and the single merged-PR closeout comment required by `DAILY_TASK.md`.
+## Delivery
 
-No raw analytics, Drive IDs, private identifiers, credentials, or personal information are committed.
+- Change pull request: `https://github.com/eunomia-bpf/eunomia.dev/pull/178`
+- Pull request state at this record update: open, non-draft.
+- Squash merge: pending.
+- Exact-squash production deployment: pending.
+- Public EN/ZH verification: pending.
+- Required merged-PR closeout comment: pending.
+
+## Decisions and follow-ups
+
+- This sixth distinct report reaches the normal series boundary for **eBPF Networking and Security**. After publication, that series moves to completed status.
+- The repository's already queued **GPU and Heterogeneous Runtime Systems** roadmap becomes the next active series. Reports there count as eBPF-centered only when eBPF or an eBPF-like runtime is central to the mechanism; otherwise they remain adjacent systems.
+- The rolling `7 / 0 / 3` mix leaves room for either classification in the next run, but evidence and novelty determine the actual topic.
+- Recheck Drive freshness on the next run; do not infer missing Search Console rows as zero.
+- Do not attribute aggregate GSC/GA4 movement to a specific page or topic without source-native date-by-page or date-by-query evidence.
+- Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule.
+
+No raw analytics, Drive URLs, private identifiers, credentials, or personal information are committed.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -16,45 +16,109 @@ durable goals and constraints, not duplicated scheduler instructions.
 
 ## Success signals
 
-- Search Console clicks, impressions, CTR, query/page movement, and canonical/indexing state; preserve each metric's source-native meaning.
-- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and configured outcome signals, used to distinguish discovery from useful on-site follow-through.
-- Cloudflare traffic, bot, status-code, and cache evidence once a supported read-only route is available.
-- Stable crawlability, canonical ownership, language alternates, structured data, internal links, rendering, and production verification enforced by repository checks and live inspection.
-- Qualified movement from relevant technical pages to public repositories, papers, tutorials, and demos, without inventing a blended SEO score.
-- Daily analysis records that explain source coverage, movement, uncertainty, competing explanations, and the next discriminating evidence.
-- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
-- Daily Reports that expose a concrete systems gap and develop implementable, testable directions rather than summarizing a trend.
+- Search Console clicks, impressions, CTR, query/page movement, and
+  canonical/indexing state; preserve each metric's source-native meaning.
+- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and
+  configured outcome signals, used to distinguish discovery from useful on-site
+  follow-through.
+- Cloudflare traffic, bot, status-code, and cache evidence once a supported
+  read-only route is available.
+- Stable crawlability, canonical ownership, language alternates, structured data,
+  internal links, rendering, and production verification enforced by repository
+  checks and live inspection.
+- Qualified movement from relevant technical pages to public repositories,
+  papers, tutorials, and demos, without inventing a blended SEO score.
+- Daily analysis records that explain source coverage, movement, uncertainty,
+  competing explanations, and the next discriminating evidence.
+- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of
+  5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
+- Daily Reports that expose a concrete systems gap and develop implementable,
+  testable directions rather than summarizing a trend.
 
 ## Operating constraints
 
-- The external scheduler is already configured and only invokes the repository; the repository owns all operational policy and current state.
-- Data analysis runs every day. A missing private source is marked unavailable, never inferred as zero.
-- Raw analytics, private identifiers, credentials, and personal information stay outside Git.
-- Each run starts from the latest default branch and uses one fresh branch and one real non-draft pull request.
-- Every scheduled run must add exactly one new bilingual Daily Report. A weak candidate is replaced by another approved question rather than published or converted into a no-report day.
-- Technical SEO changes remain evidence-driven and may be skipped on a given day; the Daily Report may not be skipped.
-- Keep the rolling topic mix compliant and classify by the report's actual central mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the daily pull request incoherent; put unrelated durable SEO work in this plan for a focused follow-up.
-- Required and expected CI must pass before a clean final automated self-review and squash merge.
-- Every daily report is a public change, so the exact squash commit must deploy successfully and both language pages must be verified.
-- Do not create a second closeout pull request. Put the verified closeout in one compact comment on the merged daily pull request, then refresh `status.md` in the next run.
+- The external scheduler is already configured and only invokes the repository;
+  the repository owns all operational policy and current state.
+- Data analysis runs every day. A missing private source is marked unavailable,
+  never inferred as zero.
+- Raw analytics, private identifiers, credentials, and personal information stay
+  outside Git.
+- Each run starts from the latest default branch and uses one fresh branch and one
+  real non-draft pull request.
+- Every scheduled run must add exactly one new bilingual Daily Report. A weak
+  candidate is replaced by another approved question rather than published or
+  converted into a no-report day.
+- Technical SEO changes remain evidence-driven and may be skipped on a given day;
+  the Daily Report may not be skipped.
+- Keep the rolling topic mix compliant and classify by the report's actual central
+  mechanism, not by superficial keyword mentions.
+- Do not combine unrelated technical SEO and content work when that makes the
+  daily pull request incoherent; put unrelated durable SEO work in this plan for a
+  focused follow-up.
+- Required and expected CI must pass before a clean final automated self-review
+  and squash merge.
+- Every daily report is a public change, so the exact squash commit must deploy
+  successfully and both language pages must be verified.
+- Do not create a second closeout pull request. Put the verified closeout in one
+  compact comment on the merged daily pull request, then refresh `status.md` in
+  the next run.
 - `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
-- `.agents/skills/eunomia-research-report` owns Daily Report research, quality, writing, and publication gates.
+- `.agents/skills/eunomia-research-report` owns Daily Report research, quality,
+  writing, and publication gates.
 
-Short-term fixes and remediation backlogs belong in GitHub issues. Durable priorities that can guide a later daily run belong below.
+Short-term fixes and remediation backlogs belong in GitHub issues. Durable
+priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically from the actually published archive. Before and after the `2026-08-28` report, the newest ten remain **7 eBPF-centered / 0 pure Agent / 3 adjacent systems** because the incoming eBPF-centered proxy-identity report ages another eBPF-centered report out.
-2. Complete **eBPF Networking and Security** at its normal six-report boundary with the `2026-08-28` proxy handoff report. The series now covers multi-owner policy composition, zero-copy buffer ownership, temporal state correctness, revocation bounds, complete mediation across offload, and request/policy identity across an L7 proxy semantic boundary.
-3. Make the already queued **GPU and Heterogeneous Runtime Systems** roadmap the next active normal series after the August 28 publication. Start with questions where host/device runtime boundaries expose a concrete missing abstraction or correctness guarantee. Count a report as eBPF-centered only when eBPF or an eBPF-like runtime is central to the mechanism; otherwise classify it as adjacent systems.
-4. Use all verified weekly Search Console and GA4 Drive export sets in every run. The configured folder was directly reverified on `2026-08-28`; the newest set remains `2026-08-17..23` and no later weekly set was observed.
-5. Treat the `2026-08-17..23` GA4 aggregate as finalized: 984 organic landing-page sessions at about 49.29% session-weighted engagement versus 970 at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34 percentage points higher. The weekly aggregate still cannot support within-week causal attribution.
-6. Keep complete GSC 7-day and 28-day comparisons unavailable until source history actually supports them. The latest finalized seven-day comparison would require `2026-08-16..22` versus `2026-08-09..15`, but the date exports omit both `2026-08-16` and `2026-08-09`; verified history is also too short for the 28-day comparison.
-7. Use the longest equal-duration finalized GSC comparison supported by contiguous source rows: `2026-08-17..22` has 477 clicks / 59,798 impressions / ~0.798% CTR / ~9.56 weighted position versus 393 / 66,510 / ~0.591% / ~9.91 for `2026-08-10..15`. Clicks are about 21.4% higher, impressions about 10.1% lower, CTR about 0.207 percentage points higher, and weighted position improves by about 0.35 positions.
-8. Use finalized date-by-page or date-by-query evidence before attributing current search movement to one page or query family. Do not turn aggregate movement into a title, copy, navigation, or site-structure change without that evidence.
-9. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and technical SEO questions that require richer source-native evidence rather than as reasons to steer Daily Report topics.
-10. Add Cloudflare coverage only when a supported read-only route is enabled in repository configuration.
-11. Use search behavior, GitHub activity, primary research, kernel changes, and production evidence to order questions inside approved eBPF and adjacent systems series.
-12. Revisit a dedicated public hub for completed eBPF series only after report-level acquisition or navigation evidence shows that it would improve retrieval beyond the existing Daily Report index.
-13. Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule to a newer upstream layout. Upstream movement alone is not evidence that a pointer-only bump is safe.
+1. Preserve the rolling ten-report mix mechanically from the actually published
+   archive. Before and after the `2026-08-28` report, the newest ten remain **7
+   eBPF-centered / 0 pure Agent / 3 adjacent systems** because the incoming
+   eBPF-centered proxy-identity report ages another eBPF-centered report out.
+2. Treat **eBPF Networking and Security** as complete at its normal six-report
+   boundary after the `2026-08-28` proxy handoff report. The series now covers
+   multi-owner policy composition, zero-copy buffer ownership, temporal state
+   correctness, revocation bounds, complete mediation across offload, and
+   request/policy identity across an L7 proxy semantic boundary.
+3. Make the already queued **GPU and Heterogeneous Runtime Systems** roadmap the
+   next active normal series after the August 28 publication. Start with questions
+   where host/device runtime boundaries expose a concrete missing abstraction or
+   correctness guarantee. Count a report as eBPF-centered only when eBPF or an
+   eBPF-like runtime is central to the mechanism; otherwise classify it as
+   adjacent systems.
+4. Use all verified weekly Search Console and GA4 Drive export sets in every run.
+   The configured folder was directly reverified on `2026-08-28`; the newest set
+   remains `2026-08-17..23` and no later weekly set was observed.
+5. Treat the `2026-08-17..23` GA4 aggregate as finalized: 984 organic
+   landing-page sessions at about 49.29% session-weighted engagement versus 970
+   at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and
+   engagement about 4.34 percentage points higher. The weekly aggregate still
+   cannot support within-week causal attribution.
+6. Keep complete GSC 7-day and 28-day comparisons unavailable until source
+   history actually supports them. The latest finalized seven-day comparison
+   would require `2026-08-16..22` versus `2026-08-09..15`, but the date exports
+   omit both `2026-08-16` and `2026-08-09`; verified history is also too short
+   for the 28-day comparison.
+7. Use the longest equal-duration finalized GSC comparison supported by contiguous
+   source rows: `2026-08-17..22` has 477 clicks / 59,798 impressions / ~0.798%
+   CTR / ~9.56 weighted position versus 393 / 66,510 / ~0.591% / ~9.91 for
+   `2026-08-10..15`. Clicks are about 21.4% higher, impressions about 10.1%
+   lower, CTR about 0.207 percentage points higher, and weighted position improves
+   by about 0.35 positions.
+8. Use finalized date-by-page or date-by-query evidence before attributing current
+   search movement to one page or query family. Do not turn aggregate movement
+   into a title, copy, navigation, or site-structure change without that evidence.
+9. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and
+   technical SEO questions that require richer source-native evidence rather than
+   as reasons to steer Daily Report topics.
+10. Add Cloudflare coverage only when a supported read-only route is enabled in
+    repository configuration.
+11. Use search behavior, GitHub activity, primary research, kernel changes, and
+    production evidence to order questions inside approved eBPF and adjacent
+    systems series.
+12. Revisit a dedicated public hub for completed eBPF series only after
+    report-level acquisition or navigation evidence shows that it would improve
+    retrieval beyond the existing Daily Report index.
+13. Migrate the consuming SEO contract before moving the pinned `seo-skills`
+    submodule to a newer upstream layout. Upstream movement alone is not evidence
+    that a pointer-only bump is safe.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -16,108 +16,45 @@ durable goals and constraints, not duplicated scheduler instructions.
 
 ## Success signals
 
-- Search Console clicks, impressions, CTR, query/page movement, and
-  canonical/indexing state; preserve each metric's source-native meaning.
-- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and
-  configured outcome signals, used to distinguish discovery from useful on-site
-  follow-through.
-- Cloudflare traffic, bot, status-code, and cache evidence once a supported
-  read-only route is available.
-- Stable crawlability, canonical ownership, language alternates, structured data,
-  internal links, rendering, and production verification enforced by repository
-  checks and live inspection.
-- Qualified movement from relevant technical pages to public repositories,
-  papers, tutorials, and demos, without inventing a blended SEO score.
-- Daily analysis records that explain source coverage, movement, uncertainty,
-  competing explanations, and the next discriminating evidence.
-- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of
-  5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
-- Daily Reports that expose a concrete systems gap and develop implementable,
-  testable directions rather than summarizing a trend.
+- Search Console clicks, impressions, CTR, query/page movement, and canonical/indexing state; preserve each metric's source-native meaning.
+- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and configured outcome signals, used to distinguish discovery from useful on-site follow-through.
+- Cloudflare traffic, bot, status-code, and cache evidence once a supported read-only route is available.
+- Stable crawlability, canonical ownership, language alternates, structured data, internal links, rendering, and production verification enforced by repository checks and live inspection.
+- Qualified movement from relevant technical pages to public repositories, papers, tutorials, and demos, without inventing a blended SEO score.
+- Daily analysis records that explain source coverage, movement, uncertainty, competing explanations, and the next discriminating evidence.
+- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
+- Daily Reports that expose a concrete systems gap and develop implementable, testable directions rather than summarizing a trend.
 
 ## Operating constraints
 
-- The external scheduler is already configured and only invokes the repository;
-  the repository owns all operational policy and current state.
-- Data analysis runs every day. A missing private source is marked unavailable,
-  never inferred as zero.
-- Raw analytics, private identifiers, credentials, and personal information stay
-  outside Git.
-- Each run starts from the latest default branch and uses one fresh branch and one
-  real non-draft pull request.
-- Every scheduled run must add exactly one new bilingual Daily Report. A weak
-  candidate is replaced by another approved question rather than published or
-  converted into a no-report day.
-- Technical SEO changes remain evidence-driven and may be skipped on a given day;
-  the Daily Report may not be skipped.
-- Keep the rolling topic mix compliant and classify by the report's actual central
-  mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the
-  daily pull request incoherent; put unrelated durable SEO work in this plan for a
-  focused follow-up.
-- Required and expected CI must pass before a clean final automated self-review
-  and squash merge.
-- Every daily report is a public change, so the exact squash commit must deploy
-  successfully and both language pages must be verified.
-- Do not create a second closeout pull request. Put the verified closeout in one
-  compact comment on the merged daily pull request, then refresh `status.md` in
-  the next run.
+- The external scheduler is already configured and only invokes the repository; the repository owns all operational policy and current state.
+- Data analysis runs every day. A missing private source is marked unavailable, never inferred as zero.
+- Raw analytics, private identifiers, credentials, and personal information stay outside Git.
+- Each run starts from the latest default branch and uses one fresh branch and one real non-draft pull request.
+- Every scheduled run must add exactly one new bilingual Daily Report. A weak candidate is replaced by another approved question rather than published or converted into a no-report day.
+- Technical SEO changes remain evidence-driven and may be skipped on a given day; the Daily Report may not be skipped.
+- Keep the rolling topic mix compliant and classify by the report's actual central mechanism, not by superficial keyword mentions.
+- Do not combine unrelated technical SEO and content work when that makes the daily pull request incoherent; put unrelated durable SEO work in this plan for a focused follow-up.
+- Required and expected CI must pass before a clean final automated self-review and squash merge.
+- Every daily report is a public change, so the exact squash commit must deploy successfully and both language pages must be verified.
+- Do not create a second closeout pull request. Put the verified closeout in one compact comment on the merged daily pull request, then refresh `status.md` in the next run.
 - `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
-- `.agents/skills/eunomia-research-report` owns Daily Report research, quality,
-  writing, and publication gates.
+- `.agents/skills/eunomia-research-report` owns Daily Report research, quality, writing, and publication gates.
 
-Short-term fixes and remediation backlogs belong in GitHub issues. Durable
-priorities that can guide a later daily run belong below.
+Short-term fixes and remediation backlogs belong in GitHub issues. Durable priorities that can guide a later daily run belong below.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically from the actually published
-   archive. Before and after the `2026-08-27` report, the newest ten remain **7
-   eBPF-centered / 0 pure Agent / 3 adjacent systems** because the incoming
-   eBPF-centered complete-mediation report ages another eBPF-centered report out.
-2. Keep **eBPF Networking and Security** as the active series. The `2026-08-23`
-   report established multi-owner policy composition; `2026-08-24` established
-   zero-copy buffer ownership; `2026-08-25` established temporal correctness of
-   persistent security state; `2026-08-26` narrowed revocation into bounded stale
-   authorization; and `2026-08-27` treats complete mediation as explicit path
-   coverage across host and offloaded enforcement. This is the fifth report in
-   the series. Publish a sixth only if the next question is mechanistically
-   distinct, preferably a narrow information-flow or cross-boundary enforcement
-   property rather than another placement, composition, state-update, or
-   revocation variant.
-3. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   The configured folder was directly reverified on `2026-08-27`; the newest set
-   remains `2026-08-17..23` and no later weekly set was observed.
-4. Treat the `2026-08-17..23` GA4 aggregate as finalized: 984 organic
-   landing-page sessions at about 49.29% session-weighted engagement versus 970
-   at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and
-   engagement about 4.34 percentage points higher. The weekly aggregate still
-   cannot support within-week causal attribution.
-5. Keep complete GSC 7-day and 28-day comparisons unavailable until source
-   history actually supports them. The latest finalized seven-day comparison
-   would require `2026-08-16..22` versus `2026-08-09..15`, but the date exports
-   omit both `2026-08-16` and `2026-08-09`; verified history is also too short
-   for the 28-day comparison.
-6. Use the longest equal-duration finalized GSC comparison supported by contiguous
-   source rows: `2026-08-17..22` has 477 clicks / 59,798 impressions / ~0.798%
-   CTR / ~9.56 weighted position versus 393 / 66,510 / ~0.591% / ~9.91 for
-   `2026-08-10..15`. Clicks are about 21.4% higher, impressions about 10.1%
-   lower, CTR about 0.207 percentage points higher, and weighted position improves
-   by about 0.35 positions.
-7. Use finalized date-by-page or date-by-query evidence before attributing current
-   search movement to one page or query family. Do not turn aggregate movement
-   into a title, copy, navigation, or site-structure change without that evidence.
-8. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and
-   technical SEO questions that require richer source-native evidence rather than
-   as reasons to steer Daily Report topics.
-9. Add Cloudflare coverage only when a supported read-only route is enabled in
-   repository configuration.
-10. Use search behavior, GitHub activity, primary research, kernel changes, and
-    production evidence to order questions inside approved eBPF and adjacent
-    systems series.
-11. Revisit a dedicated public hub for completed eBPF series only after
-    report-level acquisition or navigation evidence shows that it would improve
-    retrieval beyond the existing Daily Report index.
-12. Migrate the consuming SEO contract before moving the pinned `seo-skills`
-    submodule to a newer upstream layout. Upstream movement alone is not evidence
-    that a pointer-only bump is safe.
+1. Preserve the rolling ten-report mix mechanically from the actually published archive. Before and after the `2026-08-28` report, the newest ten remain **7 eBPF-centered / 0 pure Agent / 3 adjacent systems** because the incoming eBPF-centered proxy-identity report ages another eBPF-centered report out.
+2. Complete **eBPF Networking and Security** at its normal six-report boundary with the `2026-08-28` proxy handoff report. The series now covers multi-owner policy composition, zero-copy buffer ownership, temporal state correctness, revocation bounds, complete mediation across offload, and request/policy identity across an L7 proxy semantic boundary.
+3. Make the already queued **GPU and Heterogeneous Runtime Systems** roadmap the next active normal series after the August 28 publication. Start with questions where host/device runtime boundaries expose a concrete missing abstraction or correctness guarantee. Count a report as eBPF-centered only when eBPF or an eBPF-like runtime is central to the mechanism; otherwise classify it as adjacent systems.
+4. Use all verified weekly Search Console and GA4 Drive export sets in every run. The configured folder was directly reverified on `2026-08-28`; the newest set remains `2026-08-17..23` and no later weekly set was observed.
+5. Treat the `2026-08-17..23` GA4 aggregate as finalized: 984 organic landing-page sessions at about 49.29% session-weighted engagement versus 970 at about 44.95% for `2026-08-10..16`. Sessions are about 1.4% higher and engagement about 4.34 percentage points higher. The weekly aggregate still cannot support within-week causal attribution.
+6. Keep complete GSC 7-day and 28-day comparisons unavailable until source history actually supports them. The latest finalized seven-day comparison would require `2026-08-16..22` versus `2026-08-09..15`, but the date exports omit both `2026-08-16` and `2026-08-09`; verified history is also too short for the 28-day comparison.
+7. Use the longest equal-duration finalized GSC comparison supported by contiguous source rows: `2026-08-17..22` has 477 clicks / 59,798 impressions / ~0.798% CTR / ~9.56 weighted position versus 393 / 66,510 / ~0.591% / ~9.91 for `2026-08-10..15`. Clicks are about 21.4% higher, impressions about 10.1% lower, CTR about 0.207 percentage points higher, and weighted position improves by about 0.35 positions.
+8. Use finalized date-by-page or date-by-query evidence before attributing current search movement to one page or query family. Do not turn aggregate movement into a title, copy, navigation, or site-structure change without that evidence.
+9. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and technical SEO questions that require richer source-native evidence rather than as reasons to steer Daily Report topics.
+10. Add Cloudflare coverage only when a supported read-only route is enabled in repository configuration.
+11. Use search behavior, GitHub activity, primary research, kernel changes, and production evidence to order questions inside approved eBPF and adjacent systems series.
+12. Revisit a dedicated public hub for completed eBPF series only after report-level acquisition or navigation evidence shows that it would improve retrieval beyond the existing Daily Report index.
+13. Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule to a newer upstream layout. Upstream movement alone is not evidence that a pointer-only bump is safe.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -36,7 +36,7 @@
 - GA4 finalized aggregate: `2026-08-17` through `2026-08-23`
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
-The configured folder was directly reverified on `2026-08-27`. It contains weekly Google exports for `2026-07-27..08-02`, `2026-08-03..09`, `2026-08-10..16`, and `2026-08-17..23`; no newer weekly set was observed. Missing rows are not converted to zero.
+The configured folder was directly reverified on `2026-08-28`. It contains weekly Google exports for `2026-07-27..08-02`, `2026-08-03..09`, `2026-08-10..16`, and `2026-08-17..23`; no newer weekly set was observed. Missing rows are not converted to zero.
 
 For Search Console, the newest source-native date export contains rows through `2026-08-22`; `2026-08-23` is absent. Under the configured three-day lag, `2026-08-22` is finalized. The longest equal-duration finalized comparison that the available contiguous rows support remains six days: `2026-08-17..22` versus `2026-08-10..15`. The newer slice reports 477 clicks / 59,798 impressions, about 0.798% CTR, and impression-weighted position about 9.56; the prior slice reports 393 / 66,510, about 0.591%, and position about 9.91. Clicks are about 21.4% higher while impressions are about 10.1% lower; CTR is about 0.207 percentage points higher and average position improves by about 0.35 positions.
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -9,54 +9,47 @@
 - Verified raw Google export window: through `2026-08-23`
 - Search Console verified latest finalized row: `2026-08-22`; `2026-08-23` is absent
 - Latest finalized GA4 weekly organic landing-page aggregate: `2026-08-17` through `2026-08-23`
-- Latest daily record before the current run: `2026-08-26`
-- Last completed Daily Report pull request: `#174`
-- Last verified Daily Report squash commit: `98481bcde511c9a496bae7982a3184c94627501f`
-- Last verified production publication from a Daily Report run: static export commit `7f4bc2f614649b85744cb4d56c48d17cb0f4cdde`
-- Current daily branch: `daily/2026-08-27-ebpf-complete-mediation`
+- Latest completed daily record before the current run: `2026-08-27`
+- Last completed Daily Report pull request: `#177`
+- Last verified Daily Report squash commit: `009d8c058bc5013c7ef41bcbcb71ce91868c95bc`
+- Last verified production publication from a Daily Report run: static export commit `3eac9b9cd9e6296693c3a8083d9c0bae35aaa6a3`
+- Current daily branch: `daily/2026-08-28-ebpf-l7-policy-identity`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#174` is fully closed out. It squash-merged as
-`98481bcde511c9a496bae7982a3184c94627501f`; final PR head
-`5c458ff1f9b99f98459c185c1d55b4ddc86dbf60` passed `Deploy Static App` run
-`32988934060` and `Validate SEO Operations` run `32988934193`. The exact squash
-commit passed `Deploy Static App` run `32991343375` and `Validate SEO Operations`
-run `32991343396`. Production published static export commit
-`7f4bc2f614649b85744cb4d56c48d17cb0f4cdde`, whose commit message binds the
-export to that squash SHA. Exact EN/ZH static artifacts were verified for
-canonical, hreflang, Article JSON-LD, Daily Report navigation, and report
-content. PR `#174` has one merged-PR closeout comment.
+PR `#177` is fully closed out. It squash-merged as
+`009d8c058bc5013c7ef41bcbcb71ce91868c95bc`; exact-merge `Validate SEO Operations`
+run `33091574557` and `Deploy Static App` run `33091574546` succeeded. Production
+published static export commit `3eac9b9cd9e6296693c3a8083d9c0bae35aaa6a3`, whose commit message binds the
+export to that squash SHA. Exact EN/ZH production artifacts and sitemap entries
+were verified, and PR `#177` has exactly one merged-PR closeout comment.
 
 ## Current Daily Report mix
 
-Before the `2026-08-27` report, the actually published newest ten reports are:
+Before the `2026-08-28` report, the actually published newest ten reports are:
 
 - eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
 - adjacent systems: **3 of 10**
 
-Today's `/research/ebpf-complete-mediation-offload/` report is
-**eBPF-centered**. It asks whether every reachable policy-relevant packet path
-still crosses a current, policy-equivalent enforcement point when traffic can
-move between host software, SmartNIC fast paths, and DPU/offload paths. It
-develops an explicit path-coverage plan, generation-continuous fallback, and a
-ground-truth path-escape benchmark. The incoming report ages another
-eBPF-centered report out, so the newest ten remain **7 eBPF / 0 pure Agent / 3
-adjacent**.
+Today's `/research/ebpf-l7-proxy-policy-identity/` report is **eBPF-centered**. It
+asks whether the original principal, policy generation, and authorization
+provenance survive when an eBPF datapath redirects a request through an L7 proxy
+that terminates the downstream connection and emits or reuses a different
+upstream connection. It develops generation-scoped handoff capabilities,
+policy-safe multiplexing, and an authorization-lineage benchmark. The incoming
+report ages another eBPF-centered report out, so the newest ten remain **7 eBPF /
+0 pure Agent / 3 adjacent**.
 
-The active series remains **eBPF Networking and Security**. The `2026-08-23`
-report established multi-owner policy composition and authority provenance. The
-`2026-08-24` report established zero-copy buffer ownership and policy provenance.
-The `2026-08-25` report separated verifier safety from legal temporal state
-transitions. The `2026-08-26` report separated policy rollout from time-bounded
-invalidation of cached authorization. The `2026-08-27` report advances a fifth
-distinct boundary by treating complete mediation as an explicit path-coverage
-invariant across host and offloaded enforcement.
+This is the sixth substantial report in **eBPF Networking and Security**, reaching
+the normal series boundary. After this publication, the already queued **GPU and
+Heterogeneous Runtime Systems** roadmap becomes the next active series. Reports
+in that series count as eBPF-centered only when eBPF or an eBPF-like runtime is
+central to the mechanism being evaluated.
 
 ## Current signals
 
-- Google Drive configured evidence: directly reverified `2026-08-27`; the newest source-native weekly set remains `2026-08-17..23`
-- Public homepage: fresh public fetch on `2026-08-27` shows the expected Eunomia identity and Daily Report navigation
+- Google Drive configured evidence: directly reverified `2026-08-28`; the newest source-native weekly set remains `2026-08-17..23`
+- Public homepage: fresh public fetch on `2026-08-28` shows the expected Eunomia identity and Daily Report navigation
 - Public homepage project signal: `9,950+ GitHub stars` badge visible on the live site; used only as a public project signal, not an SEO causal metric
 - Canonical homepage: `https://eunomia.dev/`
 - Public GitHub repository evidence: available; private repository/account details are not copied into SEO records
@@ -66,26 +59,25 @@ invariant across host and offloaded enforcement.
 - Cloudflare: disabled by repository configuration
 
 The longest directly supported equal-duration finalized Search Console comparison
-is `2026-08-17..22` versus `2026-08-10..15`: **477 clicks / 59,798 impressions**,
-weighted CTR about **0.798%**, and impression-weighted average position about
-**9.56**, versus **393 / 66,510**, **0.591%**, and position about **9.91**.
-Clicks are about **21.4% higher**, impressions about **10.1% lower**, CTR about
-**0.207 percentage points higher**, and average position improves by about
-**0.35 positions**.
+remains `2026-08-17..22` versus `2026-08-10..15`: **477 clicks / 59,798
+impressions**, weighted CTR about **0.798%**, and impression-weighted average
+position about **9.56**, versus **393 / 66,510**, **0.591%**, and position about
+**9.91**. Clicks are about **21.4% higher**, impressions about **10.1% lower**,
+CTR about **0.207 percentage points higher**, and average position improves by
+about **0.35 positions**.
 
 A complete latest-seven-days versus previous-seven-days GSC comparison remains
-unavailable because the latest finalized seven-day window would be
-`2026-08-16..22` versus `2026-08-09..15`, while the available date exports omit
-both `2026-08-16` and `2026-08-09`. The required 28-day comparison also remains
-unavailable because verified export history is too short. No missing row is
-interpreted as zero.
+unavailable because the required windows need the absent `2026-08-16` and
+`2026-08-09` rows. The required 28-day comparison also remains unavailable
+because verified export history is too short. Missing rows are never interpreted
+as zero.
 
-The GA4 `2026-08-17..23` aggregate is finalized as a source-native weekly
-aggregate: **984 sessions** at about **49.29%** session-weighted engagement,
-including **118 `(not set)` sessions**, versus **970 sessions** at about
-**44.95%** engagement for `2026-08-10..16`. Sessions are about **1.4% higher**
-and engagement about **4.34 percentage points higher**. The weekly aggregate has
-no date dimension, so it does not support daily or within-week causal attribution.
+The finalized GA4 `2026-08-17..23` aggregate remains **984 organic landing-page
+sessions** at about **49.29%** session-weighted engagement, including **118
+`(not set)` sessions**, versus **970 sessions** at about **44.95%** engagement for
+`2026-08-10..16`. Sessions are about **1.4% higher** and engagement about **4.34
+percentage points higher**. The weekly aggregate has no date dimension, so it
+does not support daily or within-week causal attribution.
 
 ## Current technical baseline
 
@@ -98,26 +90,30 @@ a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect,
 broken-link, rendering, accessibility, performance, or deployment defect that
 requires a separate technical SEO implementation change today.
 
-Today's research uses current Linux representor and `netdev` XDP capability
-documentation, current Cilium XDP/offload documentation, and hXDP primary
-research. It narrows heterogeneous placement into a security coverage property:
-for every reachable path and policy generation, an equivalent enforcement point
-must remain active through offload and fallback.
+Current research evidence supports a narrower security gap instead. Cilium's
+current L7/Envoy/Ingress documentation exposes a real proxy handoff with eBPF
+policy lookups and two logical enforcement points; Linux sockmap/sockhash is
+socket-oriented; and L7FP demonstrates a current kernel-fast-path / proxy-slow-path
+split. The selected gap is authorization identity continuity across that semantic
+boundary rather than another path-coverage or placement problem.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`; the consuming repository still
-requires contract migration before a pointer-only update.
+`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` is currently
+`f42128a3f05c73cf10c786a2711c488bb3a14839`, but the consuming repository still
+requires contract migration before a pointer-only update because the generic
+closeout workflow conflicts with this repository's explicit single-PR / single
+merged-PR-comment contract.
 
 ## Current focus
 
-1. Complete the `2026-08-27` complete-mediation Daily Report through one non-draft PR, expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. Keep **eBPF Networking and Security** active after this fifth report; publish a sixth report only if a distinct evidence-backed security question remains, preferably a narrow information-flow or cross-boundary property rather than another placement/composition/update variant.
-3. Recheck Drive freshness on the next run. The configured folder is accessible and no weekly set newer than `2026-08-17..23` was observed on `2026-08-27`.
-4. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never fill missing `2026-08-16` or `2026-08-09` rows with zero.
-5. Use finalized date-by-page or date-by-query evidence before attributing current search movement to one page or query family.
-6. Treat the finalized GA4 `2026-08-17..23` movement as aggregate behavioral evidence, not a causal content or SEO result.
+1. Complete the `2026-08-28` L7 proxy policy-identity Daily Report through one non-draft PR, expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. After this sixth Networking and Security report, make **GPU and Heterogeneous Runtime Systems** the active normal series; keep actual report classification evidence-based and the rolling mix within 5–7 eBPF / at most 1–2 pure Agent per ten.
+3. Recheck Drive freshness every run; no weekly set newer than `2026-08-17..23` was observed on `2026-08-28`.
+4. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never fill missing date rows with zero.
+5. Use date-by-page or date-by-query evidence before attributing aggregate search movement to a page, title, or topic family.
+6. Treat finalized GA4 weekly movement as aggregate behavioral evidence, not a causal content or SEO result.
 7. Investigate GA4 `(not set)` and remaining legacy `/en/` traffic only with richer source-native evidence.
-8. Migrate the consuming SEO contract before updating the skill submodule pointer.
+8. Migrate the consuming SEO contract before updating the `seo-skills` submodule pointer.
 9. Add Cloudflare evidence only when a supported read-only path is enabled in repository configuration.
 
 Detailed history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/.github/workflows/seo-data-validate.yml
+++ b/.github/workflows/seo-data-validate.yml
@@ -97,10 +97,14 @@ jobs:
           assert "`no-report`" in daily_flat and "not completion" in daily_flat
           assert "There is no `no-report` outcome" in report_flat
 
-          # Topic mix is a repository-enforced editorial contract.
+          # Topic mix and one current series are repository-enforced editorial contracts.
           assert "5–7 of 10" in series_flat
           assert "Pure AI-agent topics are capped at 1–2 of 10" in series_flat
-          assert "Active series — eBPF Observability and Profiling" in series_flat
+          active_series = [
+              line for line in series.splitlines()
+              if line.startswith("## Active series — ")
+          ]
+          assert len(active_series) == 1, active_series
           PY
 
       - name: Set up Python

--- a/docs/research/ebpf-l7-proxy-policy-identity.md
+++ b/docs/research/ebpf-l7-proxy-policy-identity.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-28
 title: "Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?"
-description: "When eBPF redirects a policy-bound flow through an L7 proxy, the upstream connection can lose the identity and policy generation that justified the request."
+description: "Cilium already carries source identity across proxy connections, but request lineage and policy generations can still diverge under updates, pooling, retries, and fast-path fallback."
 tags:
   - Daily Report
   - eBPF
@@ -10,171 +10,151 @@ tags:
   - Service Mesh
   - Envoy
   - L7
-research_question: "How can an eBPF security datapath preserve the identity, policy generation, and authorization provenance of a request when traffic crosses into an L7 proxy and leaves on a different socket or connection?"
+research_question: "How can an eBPF security datapath preserve request-scoped identity, policy generation, and authorization provenance when traffic crosses an L7 proxy and leaves on a different socket or connection?"
 source_cutoff: 2026-08-28
 status: daily-report
 ---
 
 # Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?
 
-A network policy can make a perfectly reasonable decision before a request enters a proxy and still lose the reason for that decision before the request reaches the backend.
+A network policy can make a correct decision before a request enters a proxy and still lose enough context to make a later decision ambiguous.
 
-The problem appears whenever a datapath crosses a semantic boundary. An eBPF program sees a packet or socket with one source identity and one connection tuple. It redirects the flow to Envoy or another L7 proxy. The proxy terminates the downstream connection, parses HTTP, gRPC, or another application protocol, and opens or reuses a different upstream connection. The backend-side packet now belongs to the proxy's socket and may carry a different tuple, security identity, connection lifetime, and policy context.
+The hard case is not that production systems carry no identity across the proxy. Cilium already does more than that. Its Envoy integration performs policy lookups, its proxy datapath has explicit source-identity marks for upstream traffic, and recent bug reports show connection-tracking entries carrying source security identities into L7 policy processing.
 
-The policy has not become less important. The system still needs to answer a simple question: **which principal and which policy generation justified this particular upstream request?**
+That implementation evidence makes the remaining question narrower and more useful: **what must survive when the security property belongs to a logical request, but the implementation state belongs to a connection?**
 
 <!-- more -->
 
-This report argues that a cross-boundary eBPF security design needs more than path coverage. It needs a **policy-identity handoff contract**: when a request crosses from an eBPF enforcement domain into an L7 proxy and then back into another kernel or network path, the authorization context that matters to the request must survive the handoff in a form that cannot be confused with another request, another connection, or an obsolete policy generation.
+An L7 proxy terminates a downstream connection, parses HTTP or gRPC, then opens or reuses an upstream connection. A single logical request can therefore cross packet, socket, proxy-request, and new-socket representations. Connection pooling can map many requests onto one upstream socket; retry can map one request onto several sockets; policy updates can change the valid identity or generation while an old connection still exists.
 
-This is a narrower problem than the previous Daily Report on [complete mediation across host and offload paths](https://eunomia.dev/research/ebpf-complete-mediation-offload/). Complete mediation asks whether every reachable packet path crosses a valid enforcement point. Here we assume the request does cross enforcement points. The question is whether those points are still talking about the **same security subject and authorization decision** after the proxy has terminated and re-originated traffic.
+This report argues for a **policy-identity handoff contract**. Existing connection-scoped identity propagation should be treated as a strong baseline, not as the end of the problem. The missing property is request-scoped authorization lineage that remains valid across representation changes and is explicitly tied to the policy generation that authorized the request.
 
-It is also different from [multi-owner policy composition](https://eunomia.dev/research/ebpf-network-policy-composition/). Composition decides which policy owner and rule should win. A proxy handoff asks whether the result of that decision remains bound to the request as representation changes from packet to socket to L7 request and back to a new socket.
+This is different from the previous Daily Report on [complete mediation across host and offload paths](https://eunomia.dev/research/ebpf-complete-mediation-offload/). Complete mediation asks whether every reachable path crosses a valid enforcement point. Here we assume the request does cross the intended points and ask whether those points still refer to the same security subject and authorization generation.
 
-## Production systems already expose the boundary
+It is also different from [multi-owner policy composition](https://eunomia.dev/research/ebpf-network-policy-composition/). Composition determines which policy wins. The handoff problem starts after that decision and asks whether the resulting authority remains bound to the correct logical request.
 
-Cilium's current L7 policy documentation makes the basic topology explicit. L7 policy traffic is proxied through a node-local Envoy instance. Cilium's Envoy build contains custom policy-enforcement filters, and the Cilium agent communicates with Envoy over Unix-domain sockets for configuration and access-log exchange. See the current [Cilium Envoy documentation](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) and [Layer 7 policy documentation](https://docs.cilium.io/en/latest/security/policy/layer7/).
+## Production systems already carry identity, but mostly at connection boundaries
 
-The boundary is even clearer in Cilium Ingress and Gateway API. Cilium documents that the per-node Envoy proxy interacts with the eBPF policy engine and performs policy lookups. It also documents two logical policy-enforcement points: traffic can be checked before it reaches Envoy and again after Envoy before it reaches the backend. External traffic commonly begins with the `world` identity and is assigned a special `ingress` identity at the Envoy boundary. See [Cilium's Ingress and Network Policy description](https://docs.cilium.io/en/latest/network/servicemesh/ingress/).
+Cilium's current L7 policy documentation states that L7 policy traffic is proxied through a node-local Envoy instance. Its Envoy build contains custom policy-enforcement filters, and the Cilium agent communicates with Envoy over Unix-domain sockets for configuration, access logs, and administration. See the current [Cilium Envoy documentation](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) and [Layer 7 policy documentation](https://docs.cilium.io/en/latest/security/policy/layer7/).
 
-That design is useful and deployable, but it reveals a general systems question. The identity at the second enforcement point is not necessarily the identity that originated the request. A proxy is intentionally a deputy. It accepts one connection and acts on behalf of the caller by creating or reusing another.
+For Ingress and Gateway API, Cilium documents two logical policy-enforcement points around the per-node Envoy proxy. External traffic commonly starts as the `world` identity and traffic leaving the proxy is evaluated through the special `ingress` identity. See [Cilium Ingress and Network Policy](https://docs.cilium.io/en/latest/network/servicemesh/ingress/).
 
-Linux BPF primitives operate naturally at packet and socket boundaries. `BPF_MAP_TYPE_SOCKMAP` and `BPF_MAP_TYPE_SOCKHASH` can redirect messages between sockets and attach socket-level verdict programs. The kernel documentation also exposes socket cookies to userspace rather than raw kernel socket pointers. These are useful identities for one socket lifetime, but a proxy handoff can create a new socket whose lifetime no longer identifies the original request. See the current Linux [sockmap and sockhash documentation](https://docs.kernel.org/next/bpf/map_sockmap.html).
+The implementation goes further than the high-level documentation. Cilium's current BPF headers define proxy marks such as `MARK_MAGIC_PROXY_INGRESS` and `MARK_MAGIC_PROXY_EGRESS` as carrying a source identity for upstream traffic. See [`bpf/lib/common.h`](https://github.com/cilium/cilium/blob/main/bpf/lib/common.h). A recent production issue also shows Envoy's BPF metadata path applying a source identity to an upstream connection.
 
-The problem becomes more important as L7 work moves into kernel fast paths. [L7FP](https://arxiv.org/abs/2605.31084), published in May 2026, synthesizes an eBPF fast path for common service-mesh L7 policies and falls back to an existing userspace proxy for unsupported policy cases. Its reported performance gains show why such split execution is attractive. But a fast-path/slow-path system creates a new correctness requirement: a request should not silently acquire a different authorization identity simply because one case stayed in eBPF while another crossed the proxy boundary.
+This is important because it rules out a weak thesis. The research gap is not simply "the proxy forgets the source identity." Cilium already has machinery to preserve connection-level identity through the proxy datapath.
+
+The same implementation evidence exposes a more precise failure mode. In [Cilium issue #44912](https://github.com/cilium/cilium/issues/44912), opened in March 2026, an endpoint identity transition can leave an existing conntrack entry with an old `src_sec_id`. After the old identity is garbage-collected, L7 policy processing can fail for the established connection while a new connection uses the new identity. The bug is a concrete example of why identity needs lifetime and generation semantics, not just a numeric value copied across a boundary.
+
+Linux BPF primitives reinforce this distinction. `BPF_MAP_TYPE_SOCKMAP` and `BPF_MAP_TYPE_SOCKHASH` can redirect messages between sockets and attach socket-level verdict programs. Userspace lookup returns a socket cookie rather than a kernel socket pointer. These are useful transport identities, but they identify socket lifetimes, not arbitrary HTTP/2 streams or retry lineages. See the Linux [sockmap and sockhash documentation](https://docs.kernel.org/next/bpf/map_sockmap.html).
+
+The problem becomes more visible when L7 work moves into kernel fast paths. [L7FP](https://arxiv.org/abs/2605.31084), published in May 2026, synthesizes an eBPF fast path for common service-mesh L7 policies and falls back to an existing userspace proxy for unsupported cases. That split is attractive for performance, but it adds a correctness obligation: fast and slow paths should preserve equivalent authorization lineage, not only equivalent allow/deny verdicts.
 
 ## Socket identity is not request identity
 
-For simple TCP forwarding, carrying policy state on a socket can be enough. Once a proxy multiplexes or retries requests, that assumption becomes fragile.
+For simple TCP forwarding, carrying a source identity on an upstream socket may be sufficient. Multiplexing and retries break the one-request-per-socket assumption.
 
-Consider an HTTP/2 proxy connection from Envoy to one backend. The proxy may carry requests from several downstream clients over the same upstream connection. If the eBPF egress path attaches one source identity or one authorization generation to that upstream socket, which request does it describe? The answer can change from stream to stream without the socket changing at all.
+Consider an HTTP/2 connection from a proxy to one backend. Several downstream requests can share that upstream transport. A socket-scoped source identity is meaningful only if every request that can use the connection is equivalent for all policy decisions made after the proxy. If two requests differ in principal, policy generation, or still-relevant L7 authorization, one socket-level label cannot describe both without an additional rule.
 
-Retries create the opposite transformation. One logical request may use several upstream connections over time. A request-level authorization should survive the retry, but a socket-local record alone will not.
+Retry creates the inverse mapping. One logical request may use several upstream connections. Authorization should follow the request, but a socket-local record alone follows only one transport instance.
 
-Connection pooling makes both effects normal rather than exceptional. A correct system therefore needs at least three distinct identifiers:
+A useful model therefore separates three identifiers:
 
-- a **transport identity** for the concrete packet/socket lifetime;
-- a **logical request or stream identity** that survives proxy scheduling, multiplexing, and retries;
-- a **policy identity** containing the security principal, policy generation, and relevant authorization scope.
+- **transport identity**, tied to a concrete packet, flow, or socket lifetime;
+- **logical request identity**, tied to one HTTP, gRPC, or other application request across retries and scheduling;
+- **policy identity**, containing the principal, authorization scope, and policy generation that justify the request.
 
-These identifiers can be related, but they should not be collapsed into one field just because a particular benchmark uses one request per TCP connection.
-
-## The handoff should be a capability, not an informal side channel
-
-A practical design does not need to copy an entire policy object into every request. It needs a compact statement that the next enforcement domain can validate.
-
-Suppose the eBPF datapath decides that downstream principal `A` may send a class of requests toward service `B` under policy generation `g`. Before redirecting to the proxy, the datapath or its control plane can mint a short-lived **handoff capability** containing or referring to:
-
-- the original security identity or principal class;
-- the policy generation that authorized the handoff;
-- a flow or request nonce that prevents reuse for unrelated traffic;
-- the allowed destination or service scope;
-- the L7 capability class that the proxy may refine, such as an HTTP method/path rule family;
-- an expiry or revocation epoch;
-- the proxy instance or trust domain allowed to consume the capability.
-
-The proxy can refine that capability after parsing the request. For example, a packet-level decision may authorize "principal A may enter proxy P for service B," while the L7 filter proves that one HTTP request also matches method/path rule `r`. When Envoy creates or reuses the upstream connection, it produces a derivative witness that binds the L7 decision to the logical request rather than merely to the proxy socket.
-
-The backend-side eBPF path does not need to parse HTTP again. It can validate the derivative witness, current generation, destination scope, and proxy authority before treating the proxy's packet as an authorized continuation of the original request.
-
-This is closer to a capability system than to a trace annotation. A trace label helps explain what happened after the fact. A handoff capability participates in the authorization decision and should fail closed when it is stale, missing, or bound to the wrong request.
+A production design may compress or coalesce these identifiers when it can prove equivalence. It should not assume they are interchangeable.
 
 ## Where current work is still weak
 
-### Two enforcement points do not automatically preserve one principal
+### Connection-scoped source identity lacks an explicit request lineage contract
 
-Cilium explicitly documents policy enforcement before and after Envoy. That is already stronger than treating the proxy as an invisible middlebox. But the two checks can legitimately use different identities, such as `world`, `ingress`, or workload identities.
+Cilium's source-identity propagation is a strong baseline. What is not explicit in the documented contract is how that connection-scoped identity relates to a logical request when a proxy pools, multiplexes, retries, or changes upstream transports.
 
-The missing abstraction is an explicit **lineage relation** between them: the second decision should be able to prove which original principal and policy generation caused this request to exist, not merely that the packet came from a trusted proxy process.
+The missing abstraction is a lineage relation that can answer: which downstream principal, L7 decision, and policy generation caused this specific upstream request?
 
-The gap matters when the proxy is a confused deputy. If one permitted downstream request can cause the proxy to emit an upstream operation outside the original principal's scope, a backend rule that trusts only the proxy identity is weaker than the original policy. Conversely, if the backend repeats the original L3/L4 policy without enough context, it may reject legitimate transformed traffic.
+A discriminating test should mix downstream identities through one proxy, force connection reuse and retries, and verify that every accepted upstream request maps to exactly one valid authorization lineage.
 
-A discriminating test should mix several downstream identities through one proxy, intentionally create overlapping backend destinations, and check whether an upstream request can ever be attributed to the wrong principal or policy generation.
+### Identity transitions need generation-aware lifetime semantics
 
-### Per-socket policy state breaks under multiplexing
+Cilium issue #44912 shows that an established connection can retain an obsolete source security identity after the endpoint has transitioned to a new identity. That is not merely a cache invalidation detail. It demonstrates that the authorization context attached to a long-lived transport can outlive the policy or identity state that made it meaningful.
 
-Socket cookies, socket-local storage, sockmap entries, and connection-tracking state are useful because they avoid repeating expensive work for every packet. They describe transport lifetimes well.
+A robust handoff therefore needs an explicit generation or revocation epoch. The consumer of propagated identity must be able to decide whether that identity is still valid for this request, rather than assuming an established transport freezes authorization forever.
 
-They do not by themselves describe HTTP/2 streams, gRPC requests, retries, or a connection pool shared by several callers. A policy cache that assumes one principal per upstream socket can therefore be correct for HTTP/1.1 without pooling and wrong for a production HTTP/2 workload.
+### Fast-path fallback needs lineage equivalence, not only verdict equivalence
 
-The missing mechanism is a rule for when request-level authorization may be safely **coalesced** into connection-level state. The system should aggregate only if every active request on that connection is equivalent for the policy properties enforced downstream. Otherwise it needs request/stream-level lineage or must keep the decision at the proxy.
+L7FP makes fast-path and proxy-slow-path execution a concrete modern design. Both paths can return the same allow/deny result in a functional test while producing different provenance for an accepted request.
 
-### Fast-path fallback needs policy-equivalent identity, not only policy-equivalent verdicts
-
-L7FP shows a useful split: common policies can stay in an eBPF fast path, while unsupported cases fall back to a userspace proxy. A functional test may verify that both paths allow and deny the same requests.
-
-That is necessary but incomplete. The two paths can return the same verdict in a simple test while attaching different provenance to the accepted request. The difference becomes visible later when a backend policy, audit system, rate limiter, or revocation mechanism depends on the original principal.
-
-The missing evaluation is therefore not only verdict equivalence. It is **authorization-lineage equivalence** across fast and slow paths, including retries, pooling, policy updates, and proxy restarts.
+The missing evaluation is **authorization-lineage equivalence** across fast and slow paths, including pooling, retry, policy updates, identity transitions, and proxy restarts.
 
 ## Promising directions with academic and production value
 
 ### 1. Generation-scoped proxy handoff capabilities
 
-**Gap.** eBPF can authorize and redirect a flow to an L7 proxy, but the proxy's upstream socket does not inherently carry the original principal or policy generation.
+**Gap.** Existing systems can propagate a source identity on proxy-related connections, but connection-scoped identity does not by itself bind one logical request to the policy generation that authorized it.
 
-**Mechanism.** Define a compact handoff capability minted at the eBPF-to-proxy boundary and consumed by an authorized proxy instance. The capability binds principal identity, policy generation, destination scope, nonce, expiry/revocation epoch, and allowed refinement class. After L7 parsing, the proxy derives a request-scoped witness that the backend-side datapath can validate without trusting the proxy's socket identity as the original principal.
+**Mechanism.** Mint a compact capability at the eBPF-to-proxy boundary. It binds the principal, policy generation, destination scope, nonce, expiry or revocation epoch, and the proxy trust domain allowed to refine it. After L7 parsing, the proxy derives a request-scoped witness. A backend-side eBPF path validates the witness and current generation before treating the request as an authorized continuation.
 
-The capability should be unforgeable by ordinary workloads. Implementation choices could include kernel-managed opaque handles, map-backed generation records with restricted lookup, or authenticated tokens passed through a local trusted channel. The first prototype should optimize for clear trust boundaries, not for cryptographic novelty.
+The first prototype should build on existing source-identity propagation rather than replace it. A connection mark or conntrack identity can remain the fast common case, while a generation-scoped handle supplies the missing lifetime and request-lineage semantics.
 
-**Delta.** Complete mediation proves that the request crosses enforcement points. This mechanism proves that the security subject and policy generation remain linked across those points. Multi-owner composition determines the winning rule; the handoff capability carries the resulting authority across a proxy transformation.
+**Delta.** Complete mediation proves that enforcement happened. Existing Cilium source-identity propagation shows that identity can cross a proxy connection. The proposed mechanism adds request scope and policy-generation validity.
 
-**Artifact.** A small eBPF redirect component, a Cilium/Envoy extension or filter, a map-backed capability table, and an egress validator. The artifact should expose a machine-readable explanation linking downstream identity, L7 rule, upstream request, and policy generation.
+**Artifact.** An eBPF redirect component, a small Envoy extension, a generation table, and an egress validator with a machine-readable lineage record.
 
-**Evaluation.** Mix identities through one node-local proxy while repeatedly updating policy, restarting Envoy, rotating proxy instances, retrying requests, and changing backend endpoints. Measure unauthorized upstream requests, stale-generation accepts, incorrect principal attribution, capability lookup cost, added request latency, and state size.
+**Evaluation.** Reproduce identity transitions like the one in issue #44912, then add pooling, HTTP/2 multiplexing, retry, proxy restart, backend changes, and policy churn. Measure stale-generation accepts, principal misattribution, false rejects, state size, lookup cost, and request latency.
 
-**Academic value.** The problem generalizes reference-monitor reasoning across a semantic transformation where one trusted component terminates and re-originates communication.
+**Academic value.** The work extends reference-monitor reasoning across a semantic transformation and across authorization-state lifetime changes.
 
-**Production value.** Service meshes and eBPF policy engines gain a concrete way to preserve least-privilege intent instead of treating the proxy as a universal identity after redirection.
+**Production value.** It provides a concrete path from today's connection-level identity propagation to auditable request-level least privilege.
 
-**Failure condition.** If existing production meshes already expose an equivalent request-scoped, generation-aware handoff that survives proxy restart, pooling, and retry without identity confusion, the research contribution should shift to formalizing and measuring that existing mechanism rather than inventing another one.
+**Failure condition.** If current production meshes already expose a request-scoped, generation-aware mechanism that survives pooling, retry, restart, and identity transition without ambiguity, the research contribution should shift to formalizing and evaluating that mechanism.
 
 ### 2. Policy-safe multiplexing and request-to-socket coalescing
 
-**Gap.** The natural eBPF cache key is often a packet, flow, or socket, while modern L7 proxies schedule several logical requests over shared upstream connections.
+**Gap.** eBPF naturally caches by packet, flow, or socket while modern proxies may multiplex many logical requests over one upstream transport.
 
-**Mechanism.** Treat coalescing as a proof obligation. The proxy or policy runtime groups requests on one upstream transport only when their downstream security contexts are equivalent for the policies that will be enforced after the proxy. If contexts differ, it preserves stream-level witnesses or separates transport pools by an explicit policy-equivalence class.
+**Mechanism.** Treat connection-pool coalescing as a security proof obligation. Requests may share one upstream transport only if their security contexts are equivalent for every policy property enforced after the proxy. Otherwise the proxy preserves request-level witnesses or partitions the pool by a versioned policy-equivalence class.
 
-A compact equivalence class might include destination identity, current policy generation, downstream principal class, and any L7 attributes still relevant to backend enforcement. The class should be versioned. A policy update that changes equivalence must prevent old pooled state from being reused blindly.
+An equivalence class can include destination identity, principal class, policy generation, and the subset of L7 attributes still relevant downstream. A policy update that changes equivalence invalidates or drains incompatible pooled state.
 
-**Delta.** This is not ordinary connection-pool partitioning for performance. The grouping rule is derived from downstream enforcement semantics and is evaluated for authorization lineage. It is also not a demand to expose every HTTP header to eBPF; the proxy can keep protocol details and export only the security equivalence class needed by the next enforcement domain.
+**Delta.** This is not ordinary pool partitioning for performance. The grouping rule is derived from downstream authorization semantics.
 
-**Artifact.** An Envoy connection-pool extension plus a small policy-equivalence API consumed by the eBPF control plane. A debug view should show when two requests were considered safe to share one upstream socket and which policy fields justified that choice.
+**Artifact.** An Envoy connection-pool extension plus a small policy-equivalence API consumed by the eBPF control plane. A debug view should explain why two requests were allowed to share a transport.
 
-**Evaluation.** Exercise HTTP/1.1 keepalive, HTTP/2 multiplexing, gRPC streams, retries, hedged requests, and backend connection reuse across multiple source identities. Compare naive one-identity-per-socket caching, no pooling, and policy-aware coalescing. Measure misattribution, false rejects, connection count, latency, CPU, and policy-update convergence.
+**Evaluation.** Exercise HTTP/1.1 keepalive, HTTP/2, gRPC streams, retries, hedged requests, identity changes, and backend reuse across multiple principals. Compare naive one-identity-per-socket caching, no pooling, and policy-aware coalescing.
 
-**Academic value.** The work connects network policy to a classic systems question: when may many logical principals safely share one cached physical resource?
+**Academic value.** The work asks when many logical principals may safely share one cached physical resource.
 
-**Production value.** It can preserve proxy efficiency while preventing connection pooling from erasing distinctions the kernel-side policy still needs.
+**Production value.** It preserves proxy efficiency without silently erasing distinctions that later enforcement still needs.
 
-**Failure condition.** If backend enforcement never depends on the original principal after L7 authorization, or if production proxies already partition all relevant pools by an equivalent security context, the extra mechanism would add state without improving correctness.
+**Failure condition.** If downstream enforcement never depends on caller identity after L7 authorization, or existing proxies already partition every relevant pool by an equivalent security context, the extra mechanism adds little value.
 
 ### 3. A confused-deputy and fast/slow-path lineage benchmark
 
-**Gap.** Existing network benchmarks usually emphasize throughput, latency, policy-update time, or allow/deny correctness. They rarely make the proxy intentionally act on behalf of several principals while checking whether authorization lineage survives every representation change.
+**Gap.** Network benchmarks usually emphasize throughput, latency, update time, or final allow/deny correctness. They rarely check whether the accepted request still carries the correct authorization lineage after several representation changes.
 
-**Mechanism.** Build a ground-truth harness that assigns each logical request a principal, policy generation, allowed L7 operation, destination scope, and expected backend identity. The harness then forces requests through direct eBPF fast paths, Envoy slow paths, mixed fallback, connection pooling, HTTP/2 multiplexing, retries, policy updates, and proxy restarts.
+**Mechanism.** Build a ground-truth harness that assigns each logical request a principal, policy generation, allowed L7 operation, destination scope, and expected backend identity. Force requests through eBPF fast paths, proxy slow paths, mixed fallback, pooling, multiplexing, retries, identity transitions, policy updates, and proxy restarts.
 
-The primary correctness metric is an **authorization-lineage violation**: an accepted upstream request whose observed principal, generation, destination scope, or L7 authorization cannot be matched to the ground-truth request that caused it. Secondary metrics include stale accepts after revocation, false rejects, lineage-loss rate, throughput, CPU, and latency.
+The primary metric is an **authorization-lineage violation**: an accepted upstream request whose observed principal, generation, destination scope, or L7 authorization cannot be matched to the ground-truth request that caused it.
 
-**Delta.** The previous complete-mediation benchmark looks for a packet that escaped all current enforcement. This benchmark assumes mediation happened and instead asks whether the mediated request carried the wrong identity across the proxy boundary.
+**Delta.** The complete-mediation benchmark finds a packet that escaped enforcement. This benchmark assumes mediation occurred and asks whether the mediated request carried stale or incorrect authority.
 
-**Artifact.** A reproducible Kubernetes testbed, Cilium/Envoy configuration, workload generator with mixed principals, fault injector, reference authorization log, and trace format that can compare kernel fast-path and proxy slow-path execution.
+**Artifact.** A reproducible Kubernetes testbed, Cilium/Envoy configuration, mixed-principal workload generator, fault injector, reference authorization log, and trace format for comparing fast and slow paths.
 
-**Evaluation.** Include simple one-request-per-connection workloads where every system should pass, then progressively add pooling, multiplexing, retries, and policy churn. A proposed mechanism should earn its complexity by eliminating lineage violations in cases where ordinary socket or proxy identity does not.
+**Evaluation.** Start with one-request-per-connection workloads, then progressively add pooling, multiplexing, retry, identity transition, and policy churn. A proposed mechanism earns its complexity only if it removes lineage violations that the existing connection-level baseline exposes.
 
-**Academic value.** The benchmark makes a cross-layer security property measurable and provides a common target for kernel, CNI, service-mesh, and proxy research.
+**Academic value.** The benchmark makes a cross-layer security property measurable across kernel, CNI, service-mesh, and proxy implementations.
 
-**Production value.** Operators can test whether an L7 acceleration or proxy integration preserves the policy subject through real failure and pooling behavior, not only whether a demo request receives HTTP 200 or 403.
+**Production value.** Operators can test whether L7 acceleration and proxy integration preserve authorization meaning under real lifecycle changes, not only whether a request ends with HTTP 200 or 403.
 
-**Failure condition.** If several independent implementations produce zero lineage violations under adversarial multiplexing, restart, update, and fallback workloads, the gap may already be solved well enough by existing practice.
+**Failure condition.** If several independent implementations maintain zero lineage violations under these adversarial workloads, the gap is likely already solved by existing practice.
 
 ## What would change this conclusion?
 
-The argument depends on one assumption: there are production paths where the security identity used before an L7 proxy is not automatically and unambiguously bound to the logical request after the proxy re-originates traffic.
+The strongest evidence against a new handoff mechanism would be a production-grade implementation that already carries request-scoped, tamper-resistant authorization identity and policy generation across downstream termination, upstream pooling, HTTP/2 or gRPC multiplexing, retries, proxy restart, identity transition, policy update, and fast-path fallback.
 
-Strong evidence against a new handoff mechanism would be a production-grade implementation that already carries a request-scoped, tamper-resistant authorization identity and policy generation across downstream termination, upstream connection pooling, HTTP/2 or gRPC multiplexing, retries, proxy restart, policy update, and fast-path fallback. If an adversarial benchmark cannot produce a stale, confused, or unattributable accepted request, the right work is to document and standardize that mechanism.
+Cilium's existing source-identity propagation is evidence that the basic connection handoff is already solvable. Issue #44912 is evidence that lifetime changes can still invalidate a connection-scoped identity. The proposed work is justified only if a benchmark finds failures beyond what existing propagation and invalidation mechanisms handle.
 
-A second boundary is enforcement placement. Some deployments intentionally make Envoy the final authority for all L7 decisions and require backend policies to trust only the proxy identity. In that model, preserving the original principal into a later eBPF enforcement point may not be useful. The proposed capability is valuable only when downstream enforcement, auditing, revocation, rate control, or provenance still depends on the original request identity.
+A second boundary is enforcement placement. Some deployments intentionally make Envoy the final authority for all L7 decisions and require later policy to trust only the proxy identity. In that model, carrying the original caller into a later eBPF decision may not help. Request-scoped lineage matters only when downstream enforcement, auditing, revocation, rate control, or provenance still depends on the original authorization context.
 
-The practical next step is therefore not to put more metadata on every packet. It is to build the benchmark first, make proxy identity confusion observable, and then test whether a compact generation-scoped handoff eliminates failures that current socket and proxy identities cannot.
+The practical next step is therefore the benchmark, not another metadata format. Reproduce stale identity across policy or endpoint transitions, add pooling and retry, then determine whether a compact generation-scoped handoff closes a real gap that existing connection-level identity propagation cannot.

--- a/docs/research/ebpf-l7-proxy-policy-identity.md
+++ b/docs/research/ebpf-l7-proxy-policy-identity.md
@@ -1,0 +1,180 @@
+---
+date: 2026-08-28
+title: "Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?"
+description: "When eBPF redirects a policy-bound flow through an L7 proxy, the upstream connection can lose the identity and policy generation that justified the request."
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - Service Mesh
+  - Envoy
+  - L7
+research_question: "How can an eBPF security datapath preserve the identity, policy generation, and authorization provenance of a request when traffic crosses into an L7 proxy and leaves on a different socket or connection?"
+source_cutoff: 2026-08-28
+status: daily-report
+---
+
+# Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?
+
+A network policy can make a perfectly reasonable decision before a request enters a proxy and still lose the reason for that decision before the request reaches the backend.
+
+The problem appears whenever a datapath crosses a semantic boundary. An eBPF program sees a packet or socket with one source identity and one connection tuple. It redirects the flow to Envoy or another L7 proxy. The proxy terminates the downstream connection, parses HTTP, gRPC, or another application protocol, and opens or reuses a different upstream connection. The backend-side packet now belongs to the proxy's socket and may carry a different tuple, security identity, connection lifetime, and policy context.
+
+The policy has not become less important. The system still needs to answer a simple question: **which principal and which policy generation justified this particular upstream request?**
+
+<!-- more -->
+
+This report argues that a cross-boundary eBPF security design needs more than path coverage. It needs a **policy-identity handoff contract**: when a request crosses from an eBPF enforcement domain into an L7 proxy and then back into another kernel or network path, the authorization context that matters to the request must survive the handoff in a form that cannot be confused with another request, another connection, or an obsolete policy generation.
+
+This is a narrower problem than the previous Daily Report on [complete mediation across host and offload paths](https://eunomia.dev/research/ebpf-complete-mediation-offload/). Complete mediation asks whether every reachable packet path crosses a valid enforcement point. Here we assume the request does cross enforcement points. The question is whether those points are still talking about the **same security subject and authorization decision** after the proxy has terminated and re-originated traffic.
+
+It is also different from [multi-owner policy composition](https://eunomia.dev/research/ebpf-network-policy-composition/). Composition decides which policy owner and rule should win. A proxy handoff asks whether the result of that decision remains bound to the request as representation changes from packet to socket to L7 request and back to a new socket.
+
+## Production systems already expose the boundary
+
+Cilium's current L7 policy documentation makes the basic topology explicit. L7 policy traffic is proxied through a node-local Envoy instance. Cilium's Envoy build contains custom policy-enforcement filters, and the Cilium agent communicates with Envoy over Unix-domain sockets for configuration and access-log exchange. See the current [Cilium Envoy documentation](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) and [Layer 7 policy documentation](https://docs.cilium.io/en/latest/security/policy/layer7/).
+
+The boundary is even clearer in Cilium Ingress and Gateway API. Cilium documents that the per-node Envoy proxy interacts with the eBPF policy engine and performs policy lookups. It also documents two logical policy-enforcement points: traffic can be checked before it reaches Envoy and again after Envoy before it reaches the backend. External traffic commonly begins with the `world` identity and is assigned a special `ingress` identity at the Envoy boundary. See [Cilium's Ingress and Network Policy description](https://docs.cilium.io/en/latest/network/servicemesh/ingress/).
+
+That design is useful and deployable, but it reveals a general systems question. The identity at the second enforcement point is not necessarily the identity that originated the request. A proxy is intentionally a deputy. It accepts one connection and acts on behalf of the caller by creating or reusing another.
+
+Linux BPF primitives operate naturally at packet and socket boundaries. `BPF_MAP_TYPE_SOCKMAP` and `BPF_MAP_TYPE_SOCKHASH` can redirect messages between sockets and attach socket-level verdict programs. The kernel documentation also exposes socket cookies to userspace rather than raw kernel socket pointers. These are useful identities for one socket lifetime, but a proxy handoff can create a new socket whose lifetime no longer identifies the original request. See the current Linux [sockmap and sockhash documentation](https://docs.kernel.org/next/bpf/map_sockmap.html).
+
+The problem becomes more important as L7 work moves into kernel fast paths. [L7FP](https://arxiv.org/abs/2605.31084), published in May 2026, synthesizes an eBPF fast path for common service-mesh L7 policies and falls back to an existing userspace proxy for unsupported policy cases. Its reported performance gains show why such split execution is attractive. But a fast-path/slow-path system creates a new correctness requirement: a request should not silently acquire a different authorization identity simply because one case stayed in eBPF while another crossed the proxy boundary.
+
+## Socket identity is not request identity
+
+For simple TCP forwarding, carrying policy state on a socket can be enough. Once a proxy multiplexes or retries requests, that assumption becomes fragile.
+
+Consider an HTTP/2 proxy connection from Envoy to one backend. The proxy may carry requests from several downstream clients over the same upstream connection. If the eBPF egress path attaches one source identity or one authorization generation to that upstream socket, which request does it describe? The answer can change from stream to stream without the socket changing at all.
+
+Retries create the opposite transformation. One logical request may use several upstream connections over time. A request-level authorization should survive the retry, but a socket-local record alone will not.
+
+Connection pooling makes both effects normal rather than exceptional. A correct system therefore needs at least three distinct identifiers:
+
+- a **transport identity** for the concrete packet/socket lifetime;
+- a **logical request or stream identity** that survives proxy scheduling, multiplexing, and retries;
+- a **policy identity** containing the security principal, policy generation, and relevant authorization scope.
+
+These identifiers can be related, but they should not be collapsed into one field just because a particular benchmark uses one request per TCP connection.
+
+## The handoff should be a capability, not an informal side channel
+
+A practical design does not need to copy an entire policy object into every request. It needs a compact statement that the next enforcement domain can validate.
+
+Suppose the eBPF datapath decides that downstream principal `A` may send a class of requests toward service `B` under policy generation `g`. Before redirecting to the proxy, the datapath or its control plane can mint a short-lived **handoff capability** containing or referring to:
+
+- the original security identity or principal class;
+- the policy generation that authorized the handoff;
+- a flow or request nonce that prevents reuse for unrelated traffic;
+- the allowed destination or service scope;
+- the L7 capability class that the proxy may refine, such as an HTTP method/path rule family;
+- an expiry or revocation epoch;
+- the proxy instance or trust domain allowed to consume the capability.
+
+The proxy can refine that capability after parsing the request. For example, a packet-level decision may authorize "principal A may enter proxy P for service B," while the L7 filter proves that one HTTP request also matches method/path rule `r`. When Envoy creates or reuses the upstream connection, it produces a derivative witness that binds the L7 decision to the logical request rather than merely to the proxy socket.
+
+The backend-side eBPF path does not need to parse HTTP again. It can validate the derivative witness, current generation, destination scope, and proxy authority before treating the proxy's packet as an authorized continuation of the original request.
+
+This is closer to a capability system than to a trace annotation. A trace label helps explain what happened after the fact. A handoff capability participates in the authorization decision and should fail closed when it is stale, missing, or bound to the wrong request.
+
+## Where current work is still weak
+
+### Two enforcement points do not automatically preserve one principal
+
+Cilium explicitly documents policy enforcement before and after Envoy. That is already stronger than treating the proxy as an invisible middlebox. But the two checks can legitimately use different identities, such as `world`, `ingress`, or workload identities.
+
+The missing abstraction is an explicit **lineage relation** between them: the second decision should be able to prove which original principal and policy generation caused this request to exist, not merely that the packet came from a trusted proxy process.
+
+The gap matters when the proxy is a confused deputy. If one permitted downstream request can cause the proxy to emit an upstream operation outside the original principal's scope, a backend rule that trusts only the proxy identity is weaker than the original policy. Conversely, if the backend repeats the original L3/L4 policy without enough context, it may reject legitimate transformed traffic.
+
+A discriminating test should mix several downstream identities through one proxy, intentionally create overlapping backend destinations, and check whether an upstream request can ever be attributed to the wrong principal or policy generation.
+
+### Per-socket policy state breaks under multiplexing
+
+Socket cookies, socket-local storage, sockmap entries, and connection-tracking state are useful because they avoid repeating expensive work for every packet. They describe transport lifetimes well.
+
+They do not by themselves describe HTTP/2 streams, gRPC requests, retries, or a connection pool shared by several callers. A policy cache that assumes one principal per upstream socket can therefore be correct for HTTP/1.1 without pooling and wrong for a production HTTP/2 workload.
+
+The missing mechanism is a rule for when request-level authorization may be safely **coalesced** into connection-level state. The system should aggregate only if every active request on that connection is equivalent for the policy properties enforced downstream. Otherwise it needs request/stream-level lineage or must keep the decision at the proxy.
+
+### Fast-path fallback needs policy-equivalent identity, not only policy-equivalent verdicts
+
+L7FP shows a useful split: common policies can stay in an eBPF fast path, while unsupported cases fall back to a userspace proxy. A functional test may verify that both paths allow and deny the same requests.
+
+That is necessary but incomplete. The two paths can return the same verdict in a simple test while attaching different provenance to the accepted request. The difference becomes visible later when a backend policy, audit system, rate limiter, or revocation mechanism depends on the original principal.
+
+The missing evaluation is therefore not only verdict equivalence. It is **authorization-lineage equivalence** across fast and slow paths, including retries, pooling, policy updates, and proxy restarts.
+
+## Promising directions with academic and production value
+
+### 1. Generation-scoped proxy handoff capabilities
+
+**Gap.** eBPF can authorize and redirect a flow to an L7 proxy, but the proxy's upstream socket does not inherently carry the original principal or policy generation.
+
+**Mechanism.** Define a compact handoff capability minted at the eBPF-to-proxy boundary and consumed by an authorized proxy instance. The capability binds principal identity, policy generation, destination scope, nonce, expiry/revocation epoch, and allowed refinement class. After L7 parsing, the proxy derives a request-scoped witness that the backend-side datapath can validate without trusting the proxy's socket identity as the original principal.
+
+The capability should be unforgeable by ordinary workloads. Implementation choices could include kernel-managed opaque handles, map-backed generation records with restricted lookup, or authenticated tokens passed through a local trusted channel. The first prototype should optimize for clear trust boundaries, not for cryptographic novelty.
+
+**Delta.** Complete mediation proves that the request crosses enforcement points. This mechanism proves that the security subject and policy generation remain linked across those points. Multi-owner composition determines the winning rule; the handoff capability carries the resulting authority across a proxy transformation.
+
+**Artifact.** A small eBPF redirect component, a Cilium/Envoy extension or filter, a map-backed capability table, and an egress validator. The artifact should expose a machine-readable explanation linking downstream identity, L7 rule, upstream request, and policy generation.
+
+**Evaluation.** Mix identities through one node-local proxy while repeatedly updating policy, restarting Envoy, rotating proxy instances, retrying requests, and changing backend endpoints. Measure unauthorized upstream requests, stale-generation accepts, incorrect principal attribution, capability lookup cost, added request latency, and state size.
+
+**Academic value.** The problem generalizes reference-monitor reasoning across a semantic transformation where one trusted component terminates and re-originates communication.
+
+**Production value.** Service meshes and eBPF policy engines gain a concrete way to preserve least-privilege intent instead of treating the proxy as a universal identity after redirection.
+
+**Failure condition.** If existing production meshes already expose an equivalent request-scoped, generation-aware handoff that survives proxy restart, pooling, and retry without identity confusion, the research contribution should shift to formalizing and measuring that existing mechanism rather than inventing another one.
+
+### 2. Policy-safe multiplexing and request-to-socket coalescing
+
+**Gap.** The natural eBPF cache key is often a packet, flow, or socket, while modern L7 proxies schedule several logical requests over shared upstream connections.
+
+**Mechanism.** Treat coalescing as a proof obligation. The proxy or policy runtime groups requests on one upstream transport only when their downstream security contexts are equivalent for the policies that will be enforced after the proxy. If contexts differ, it preserves stream-level witnesses or separates transport pools by an explicit policy-equivalence class.
+
+A compact equivalence class might include destination identity, current policy generation, downstream principal class, and any L7 attributes still relevant to backend enforcement. The class should be versioned. A policy update that changes equivalence must prevent old pooled state from being reused blindly.
+
+**Delta.** This is not ordinary connection-pool partitioning for performance. The grouping rule is derived from downstream enforcement semantics and is evaluated for authorization lineage. It is also not a demand to expose every HTTP header to eBPF; the proxy can keep protocol details and export only the security equivalence class needed by the next enforcement domain.
+
+**Artifact.** An Envoy connection-pool extension plus a small policy-equivalence API consumed by the eBPF control plane. A debug view should show when two requests were considered safe to share one upstream socket and which policy fields justified that choice.
+
+**Evaluation.** Exercise HTTP/1.1 keepalive, HTTP/2 multiplexing, gRPC streams, retries, hedged requests, and backend connection reuse across multiple source identities. Compare naive one-identity-per-socket caching, no pooling, and policy-aware coalescing. Measure misattribution, false rejects, connection count, latency, CPU, and policy-update convergence.
+
+**Academic value.** The work connects network policy to a classic systems question: when may many logical principals safely share one cached physical resource?
+
+**Production value.** It can preserve proxy efficiency while preventing connection pooling from erasing distinctions the kernel-side policy still needs.
+
+**Failure condition.** If backend enforcement never depends on the original principal after L7 authorization, or if production proxies already partition all relevant pools by an equivalent security context, the extra mechanism would add state without improving correctness.
+
+### 3. A confused-deputy and fast/slow-path lineage benchmark
+
+**Gap.** Existing network benchmarks usually emphasize throughput, latency, policy-update time, or allow/deny correctness. They rarely make the proxy intentionally act on behalf of several principals while checking whether authorization lineage survives every representation change.
+
+**Mechanism.** Build a ground-truth harness that assigns each logical request a principal, policy generation, allowed L7 operation, destination scope, and expected backend identity. The harness then forces requests through direct eBPF fast paths, Envoy slow paths, mixed fallback, connection pooling, HTTP/2 multiplexing, retries, policy updates, and proxy restarts.
+
+The primary correctness metric is an **authorization-lineage violation**: an accepted upstream request whose observed principal, generation, destination scope, or L7 authorization cannot be matched to the ground-truth request that caused it. Secondary metrics include stale accepts after revocation, false rejects, lineage-loss rate, throughput, CPU, and latency.
+
+**Delta.** The previous complete-mediation benchmark looks for a packet that escaped all current enforcement. This benchmark assumes mediation happened and instead asks whether the mediated request carried the wrong identity across the proxy boundary.
+
+**Artifact.** A reproducible Kubernetes testbed, Cilium/Envoy configuration, workload generator with mixed principals, fault injector, reference authorization log, and trace format that can compare kernel fast-path and proxy slow-path execution.
+
+**Evaluation.** Include simple one-request-per-connection workloads where every system should pass, then progressively add pooling, multiplexing, retries, and policy churn. A proposed mechanism should earn its complexity by eliminating lineage violations in cases where ordinary socket or proxy identity does not.
+
+**Academic value.** The benchmark makes a cross-layer security property measurable and provides a common target for kernel, CNI, service-mesh, and proxy research.
+
+**Production value.** Operators can test whether an L7 acceleration or proxy integration preserves the policy subject through real failure and pooling behavior, not only whether a demo request receives HTTP 200 or 403.
+
+**Failure condition.** If several independent implementations produce zero lineage violations under adversarial multiplexing, restart, update, and fallback workloads, the gap may already be solved well enough by existing practice.
+
+## What would change this conclusion?
+
+The argument depends on one assumption: there are production paths where the security identity used before an L7 proxy is not automatically and unambiguously bound to the logical request after the proxy re-originates traffic.
+
+Strong evidence against a new handoff mechanism would be a production-grade implementation that already carries a request-scoped, tamper-resistant authorization identity and policy generation across downstream termination, upstream connection pooling, HTTP/2 or gRPC multiplexing, retries, proxy restart, policy update, and fast-path fallback. If an adversarial benchmark cannot produce a stale, confused, or unattributable accepted request, the right work is to document and standardize that mechanism.
+
+A second boundary is enforcement placement. Some deployments intentionally make Envoy the final authority for all L7 decisions and require backend policies to trust only the proxy identity. In that model, preserving the original principal into a later eBPF enforcement point may not be useful. The proposed capability is valuable only when downstream enforcement, auditing, revocation, rate control, or provenance still depends on the original request identity.
+
+The practical next step is therefore not to put more metadata on every packet. It is to build the benchmark first, make proxy identity confusion observable, and then test whether a compact generation-scoped handoff eliminates failures that current socket and proxy identities cannot.

--- a/docs/research/ebpf-l7-proxy-policy-identity.zh.md
+++ b/docs/research/ebpf-l7-proxy-policy-identity.zh.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-28
 title: "eBPF 在 L7 代理交接时还能保住策略身份吗？"
-description: "当 eBPF 把带策略身份的流量交给 L7 代理时，上游新连接可能丢失最初的主体身份、策略 generation 和授权来源。"
+description: "Cilium 已经会把源身份带过代理连接，但在身份更新、连接复用、重试和快慢路径切换时，请求级授权链路仍可能失去一致性。"
 tags:
   - Daily Report
   - eBPF
@@ -10,171 +10,151 @@ tags:
   - Service Mesh
   - Envoy
   - L7
-research_question: "当流量进入 L7 代理，并从另一个 socket 或连接重新发出时，eBPF 安全数据路径怎样保留请求原始身份、策略 generation 和授权 provenance？"
+research_question: "当流量经过 L7 代理并从新的 socket 或连接发出时，eBPF 安全数据路径怎样保留请求级身份、策略 generation 和授权来源？"
 source_cutoff: 2026-08-28
 status: daily-report
 ---
 
 # eBPF 在 L7 代理交接时还能保住策略身份吗？
 
-一个网络策略可以在请求进入代理之前做出完全正确的判断，却在请求真正到达后端之前丢掉这个判断成立的理由。
+网络策略可以在请求进入代理之前做出正确判断，却在后续路径上失去足够的上下文，使下一次判断变得含糊。
 
-问题出现在数据路径跨过语义边界时。eBPF 程序先看到一个带源身份和连接 tuple 的 packet 或 socket，然后把流量重定向到 Envoy 等 L7 proxy。代理终止下游连接，解析 HTTP、gRPC 或其他应用层协议，再创建或复用另一条上游连接。到了后端一侧，packet 属于代理自己的 socket，tuple、security identity、连接生命周期和 policy context 都可能已经改变。
+这里真正的问题并不是“生产系统完全不会把身份带过代理”。Cilium 已经做得更多：Envoy 会参与策略查询，代理数据路径会给上游流量携带源身份，近期的实际 bug 也说明连接跟踪里的源安全身份会被 L7 策略处理继续使用。
 
-策略的重要性没有改变。系统仍然需要回答一个简单的问题：**这个具体的上游请求，究竟是哪个主体、在哪个 policy generation 下被允许的？**
+因此更值得研究的问题是：**当安全属性属于一个逻辑请求，而实现状态主要绑定在连接上时，哪些授权信息必须继续保持一致？**
 
 <!-- more -->
 
-本文认为，跨边界的 eBPF 安全设计除了 path coverage，还需要一个 **policy-identity handoff contract**。请求从 eBPF enforcement domain 进入 L7 proxy，再回到新的 kernel/network path 时，真正决定授权的上下文必须以一种不会被另一个请求、另一条连接或旧策略 generation 混淆的形式继续存在。
+L7 代理会终止下游连接，解析 HTTP 或 gRPC，然后创建或复用上游连接。一个逻辑请求因此会先后表现为 packet、socket、代理内的 request，再变成新的 socket。连接池会让多个请求共用一条上游连接；重试会让一个请求先后使用多条连接；策略或身份更新则可能在旧连接仍存活时改变当前有效的授权状态。
 
-这比上一篇 [主机与卸载路径之间的 complete mediation](https://eunomia.dev/zh/research/ebpf-complete-mediation-offload/) 更窄。Complete mediation 问的是每条可达 packet path 是否都经过有效 enforcement point。本文先假设请求确实经过了多个 enforcement point，然后追问：proxy 把流量终止并重新发起之后，这些 enforcement point 还在讨论**同一个安全主体和同一次授权判断**吗？
+本文提出一个 **policy-identity handoff contract**。现有的连接级身份传递应该被视为很强的基线，而不是问题的终点。真正缺少的是请求级授权 lineage：它要跨表示变化保持一致，并且明确绑定到批准该请求的策略 generation。
 
-它也不同于 [多 owner 网络策略组合](https://eunomia.dev/zh/research/ebpf-network-policy-composition/)。Policy composition 决定哪一个 owner 和 rule 应该产生最终 verdict；proxy handoff 则问这个 verdict 在表示从 packet 变成 socket、L7 request，再变成另一个 socket 时，是否仍然绑定在原来的请求上。
+这和上一篇 [主机与卸载路径之间的 complete mediation](https://eunomia.dev/zh/research/ebpf-complete-mediation-offload/) 不同。Complete mediation 关心每条可达路径是否都经过有效 enforcement point。这里先假设 enforcement point 都存在，再问这些位置看到的是否仍然是同一个安全主体和同一代授权。
 
-## 生产系统已经把这个边界暴露出来了
+它也不同于 [多 owner 网络策略组合](https://eunomia.dev/zh/research/ebpf-network-policy-composition/)。Policy composition 解决“哪条策略最终生效”；proxy handoff 则从这个结果出发，检查产生的 authority 是否仍绑定在正确的逻辑请求上。
 
-Cilium 当前的 L7 policy 文档明确说明：L7 policy traffic 会经过 node-local Envoy。Cilium 的 Envoy 构建包含自定义 policy enforcement filter，Cilium agent 通过 Unix-domain socket 给 Envoy 下发配置并接收 access log。可以直接参考当前的 [Cilium Envoy 文档](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) 和 [Layer 7 policy 文档](https://docs.cilium.io/en/latest/security/policy/layer7/)。
+## 生产系统已经会传递身份，但主要仍以连接为边界
 
-在 Cilium Ingress 和 Gateway API 中，这个边界更加明显。Cilium 文档说明 per-node Envoy 会和 eBPF policy engine 交互并执行 policy lookup，而且存在两个逻辑 policy enforcement point：流量在进入 Envoy 前可以检查一次，在 Envoy 即将把流量发往 backend 时再检查一次。外部流量通常先带有 `world` identity，到了 Envoy 边界又会被赋予特殊的 `ingress` identity。见 [Cilium Ingress 与 Network Policy 文档](https://docs.cilium.io/en/latest/network/servicemesh/ingress/)。
+Cilium 当前文档说明，L7 policy 流量会经过 node-local Envoy。Cilium 的 Envoy 包含定制 policy-enforcement filter，Cilium agent 与 Envoy 通过 Unix-domain socket 交换配置、access log 和管理信息。可参考当前的 [Cilium Envoy 文档](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) 和 [Layer 7 Policy 文档](https://docs.cilium.io/en/latest/security/policy/layer7/)。
 
-这个设计本身很实用，但它也暴露出更一般的系统问题。第二个 enforcement point 看到的 identity 不一定就是最初发起请求的 identity。Proxy 本来就是一个 deputy：它接受调用者的连接，再代表调用者去创建或复用另一条连接。
+在 Ingress 和 Gateway API 中，Cilium 还明确记录了 Envoy 前后的两个逻辑策略执行点。外部流量通常先带 `world` identity，经过代理边界后则通过特殊的 `ingress` identity 进入后续策略判断。见 [Cilium Ingress 与 Network Policy](https://docs.cilium.io/en/latest/network/servicemesh/ingress/)。
 
-Linux BPF 的很多原语天然落在 packet 和 socket 边界。`BPF_MAP_TYPE_SOCKMAP` 与 `BPF_MAP_TYPE_SOCKHASH` 可以在 socket 之间 redirect message，也可以挂 socket-level verdict program。内核文档还会把 socket cookie 暴露给用户态，而不是把 kernel socket pointer 直接暴露出去。这些机制非常适合标识一个 transport lifetime，但 proxy handoff 会创建新的 socket，它已经无法单独表示原始请求。见 Linux 当前的 [sockmap / sockhash 文档](https://docs.kernel.org/next/bpf/map_sockmap.html)。
+实现本身比高层文档走得更远。Cilium 当前的 BPF 头文件定义了 `MARK_MAGIC_PROXY_INGRESS` 和 `MARK_MAGIC_PROXY_EGRESS` 等 mark，用来在上游代理流量中携带 source identity。见 [`bpf/lib/common.h`](https://github.com/cilium/cilium/blob/main/bpf/lib/common.h)。近期的生产问题也展示了 Envoy 的 BPF metadata 路径把 source identity 写到上游连接上的实际行为。
 
-随着更多 L7 工作进入 kernel fast path，这个问题会更加重要。2026 年 5 月发布的 [L7FP](https://arxiv.org/abs/2605.31084) 会为常见 service-mesh L7 policy 合成 eBPF fast path，对无法支持的 policy 再 fallback 到现有 userspace proxy。它的性能结果说明这种 fast/slow split 很有吸引力，但也带来新的 correctness requirement：一个 request 不能仅仅因为这一次留在 eBPF fast path，而另一次经过 proxy，就悄悄换掉 authorization identity。
+这条证据排除了一个太弱的论文命题：问题不是“proxy 一定会忘记源身份”。Cilium 已经有连接级身份连续性机制。
+
+但同一实现也暴露了更精确的失败模式。[Cilium issue #44912](https://github.com/cilium/cilium/issues/44912) 在 2026 年 3 月报告：endpoint identity 发生变化后，已有 conntrack entry 可能仍保留旧 `src_sec_id`。旧 identity 被回收后，已建立连接的 L7 policy 处理会失败，而新连接已经使用新的 identity。这个 bug 说明，跨边界传递一个数字身份还不够，身份还需要明确的生命周期和 generation 语义。
+
+Linux BPF 的 socket 原语也体现了这一点。`BPF_MAP_TYPE_SOCKMAP` 和 `BPF_MAP_TYPE_SOCKHASH` 可以在 socket 之间 redirect message，也能挂 socket-level verdict program。用户态查询拿到的是 socket cookie，而不是 kernel socket pointer。这些机制很适合标识 transport lifetime，却不会天然标识任意 HTTP/2 stream 或一次跨多连接的 retry。见 Linux [sockmap / sockhash 文档](https://docs.kernel.org/next/bpf/map_sockmap.html)。
+
+当更多 L7 工作进入 kernel fast path 后，这个区别更明显。[L7FP](https://arxiv.org/abs/2605.31084) 在 2026 年 5 月提出为常见 service-mesh L7 policy 合成 eBPF fast path，不支持的情况再 fallback 到已有 userspace proxy。这个设计有明显性能吸引力，但也增加了一条 correctness requirement：快路径和慢路径不仅要给出相同 allow/deny verdict，还应该保持等价的授权 lineage。
 
 ## Socket identity 不等于 request identity
 
-对于简单 TCP forwarding，把 policy state 绑定在 socket 上可能足够。但一旦 proxy 开始 multiplex 或 retry，这个假设就很脆弱。
+对简单 TCP forwarding 来说，把 source identity 绑到 upstream socket 上可能已经足够。Multiplexing 和 retry 会打破“一条连接对应一个请求”的假设。
 
-例如 Envoy 到 backend 之间只有一条 HTTP/2 connection，但里面可能同时承载多个 downstream client 的请求。如果 eBPF egress path 给这个 upstream socket 绑定一个 source identity 或一个 authorization generation，它到底描述的是哪个请求？同一个 socket 不变，stream 之间的答案却可能完全不同。
+例如 proxy 到 backend 之间只有一条 HTTP/2 connection，却可以承载多个 downstream request。如果后续策略仍然区分 caller、policy generation 或某些 L7 授权，那么一个 socket-level identity 只有在这些 request 对后续策略完全等价时才足够。
 
-Retry 是相反的变化。一个 logical request 可能先后使用多条 upstream connection。Request-level authorization 应该跨 retry 保留，但 socket-local record 自己做不到。
+Retry 则是相反的映射：一个 logical request 可能先后走多条 upstream connection。授权应该跟随 request，而 socket-local state 只跟随其中一段 transport lifetime。
 
-Connection pooling 让这两种情况成为日常行为，而不是 corner case。因此一个正确系统至少需要区分三种 identity：
+因此更合适的模型至少区分三类 identity：
 
-- 具体 packet/socket lifetime 的 **transport identity**；
-- 能跨 proxy scheduling、multiplexing 和 retry 的 **logical request / stream identity**；
-- 包含安全主体、policy generation 和授权范围的 **policy identity**。
+- **transport identity**：绑定具体 packet、flow 或 socket 生命周期；
+- **logical request identity**：绑定 HTTP、gRPC 等一次逻辑请求，并跨 retry 和调度保持一致；
+- **policy identity**：包含 principal、授权范围以及批准该请求的 policy generation。
 
-它们可以关联，但不应该因为 benchmark 恰好使用 one-request-per-TCP-connection 就被压成同一个字段。
-
-## Handoff 更像 capability，而不是普通 trace annotation
-
-实际系统不需要把完整 policy object 放进每个 request。它需要的是下一层 enforcement domain 能验证的一小段授权声明。
-
-假设 eBPF datapath 判断 downstream principal `A` 可以在 policy generation `g` 下向 service `B` 发起某一类请求。在 redirect 到 proxy 之前，datapath 或 control plane 可以生成一个短生命周期的 **handoff capability**，其中包含或引用：
-
-- 原始 security identity 或 principal class；
-- 授权这次 handoff 的 policy generation；
-- 防止 capability 被拿去复用到无关流量的 flow/request nonce；
-- 允许的 destination 或 service scope；
-- proxy 可以进一步收窄的 L7 capability class，例如某一组 HTTP method/path rule；
-- expiry 或 revocation epoch；
-- 允许消费这个 capability 的 proxy instance 或 trust domain。
-
-Proxy 在解析 L7 request 之后可以进一步 refine 这个 capability。例如 packet-level decision 只允许“principal A 可以进入 proxy P 去访问 service B”，L7 filter 再证明某一个 HTTP request 同时匹配 method/path rule `r`。当 Envoy 创建或复用 upstream connection 时，它产生一个绑定 logical request 的 derivative witness，而不是只给整个 proxy socket 一个 identity。
-
-后端一侧的 eBPF 不需要再次解析 HTTP。它只要验证 derivative witness、当前 generation、destination scope 和 proxy authority，就可以判断这个 packet 是否真的是原始授权 request 的 continuation。
-
-这更接近 capability system，而不是 tracing label。Trace label 主要帮助事后解释发生了什么；handoff capability 直接参与 authorization decision，在 stale、缺失或绑定到错误 request 时应该 fail closed。
+实现可以在证明安全等价时压缩这些状态，但不能默认三者天然相同。
 
 ## 当前工作还薄弱在哪里
 
-### 两个 enforcement point 并不会自动保留同一个 principal
+### 连接级 source identity 缺少显式的 request lineage contract
 
-Cilium 已经明确记录 Envoy 前后都存在 policy enforcement。这比把 proxy 当作透明 middlebox 强得多。但前后两个 check 完全可能合法地使用不同 identity，例如 `world`、`ingress` 或 workload identity。
+Cilium 的 source-identity propagation 是很好的基线。文档和现有接口没有明确给出的，是这份连接级 identity 在 pooling、multiplexing、retry 或 upstream transport 变化后，怎样对应到某一个 logical request。
 
-缺少的抽象是一条显式 **lineage relation**：第二个 decision 应该能证明是哪一个原始 principal 和 policy generation 导致了这个 request，而不是只证明 packet 来自一个受信任的 proxy process。
+缺少的抽象是一条可验证 lineage relation：后续 enforcement point 应该能回答“哪个 downstream principal、哪次 L7 decision、哪个 policy generation 产生了这个具体 upstream request”。
 
-当 proxy 变成 confused deputy 时，这个 gap 会直接影响安全性。如果一个被允许的 downstream request 可以让 proxy 发出超出原 principal scope 的 upstream operation，那么 backend 只信 proxy identity 的规则就比原始 policy 更弱。反过来，如果 backend 想重新执行原始 L3/L4 policy，却拿不到转换后的上下文，也可能误杀合法流量。
+一个有区分力的测试应该让多个 downstream identity 共用 proxy，强制 connection reuse 与 retry，并检查每个 accepted upstream request 是否都只能映射到一条有效授权 lineage。
 
-一个有区分力的测试应该让多个 downstream identity 共用一个 proxy，故意让 backend destination 重叠，再检查任意 upstream request 是否可能被归因到错误 principal 或旧 policy generation。
+### Identity transition 需要 generation-aware 生命周期
 
-### Per-socket policy state 在 multiplexing 下会失效
+Cilium issue #44912 说明，endpoint 已切换到新 security identity 后，旧 established connection 仍可能保留过时身份。它不只是普通 cache invalidation bug，而是直接说明 transport lifetime 可能长于授权状态的有效期。
 
-Socket cookie、socket-local storage、sockmap entry 和 connection-tracking state 都很有价值，因为它们能避免每个 packet 重做昂贵工作。它们也确实适合描述 transport lifetime。
+因此 handoff state 需要显式 generation 或 revocation epoch。消费 propagated identity 的位置必须能判断“这个 identity 对当前 request 是否仍有效”，而不能把 established connection 理解为永久冻结授权。
 
-但这些状态自己无法描述 HTTP/2 stream、gRPC request、retry，或者多个 caller 共享的 connection pool。如果 policy cache 默认“一条 upstream socket 对应一个 principal”，它可能在不用 pooling 的 HTTP/1.1 benchmark 里完全正确，在真实 HTTP/2 workload 里却是错的。
+### Fast-path fallback 需要 lineage equivalence，而不只是 verdict equivalence
 
-缺少的机制是：什么时候 request-level authorization 可以安全地 **coalesce** 成 connection-level state？只有当同一条 connection 上所有 active request 对下游仍需执行的 policy property 都等价时，系统才应该聚合。否则就要保留 request/stream-level lineage，或者把最终 decision 留在 proxy 内部。
+L7FP 让 kernel fast path 与 proxy slow path 成为一个很具体的现代设计。两条路径可以在功能测试里都返回相同 allow/deny，却给 accepted request 留下不同 provenance。
 
-### Fast-path fallback 需要 identity equivalence，不只是 verdict equivalence
-
-L7FP 展示了一种很有用的 split：常见 policy 走 eBPF fast path，unsupported case 回到 userspace proxy。功能测试可以验证两条路径对同一个 request 是否都 allow 或 deny。
-
-这是必要条件，但还不够。简单测试中，两条路径即使给出相同 verdict，也可能给 accepted request 留下不同 provenance。等到 backend policy、audit、rate limiter 或 revocation mechanism 依赖原始 principal 时，这个差异才暴露出来。
-
-所以缺少的 evaluation 不只是 verdict equivalence，而是 fast/slow path 之间的 **authorization-lineage equivalence**，而且要覆盖 retry、pooling、policy update 和 proxy restart。
+因此真正缺少的 evaluation 是 **authorization-lineage equivalence**，并且要覆盖 pooling、retry、identity transition、policy update 和 proxy restart。
 
 ## 兼具学术价值和生产价值的方向
 
 ### 1. Generation-scoped proxy handoff capability
 
-**Gap。** eBPF 可以授权并 redirect 一个 flow 到 L7 proxy，但 proxy 的 upstream socket 并不会天然携带原始 principal 或 policy generation。
+**Gap。** 现有系统可以把 source identity 带到 proxy-related connection 上，但连接级 identity 自己无法把一个 logical request 绑定到批准它的 policy generation。
 
-**Mechanism。** 在 eBPF-to-proxy 边界定义一个 compact handoff capability，由可信 datapath 生成，只允许被授权 proxy instance 消费。Capability 绑定 principal identity、policy generation、destination scope、nonce、expiry/revocation epoch 和允许 refine 的 capability class。完成 L7 parsing 之后，proxy 再产生 request-scoped witness，让 backend-side datapath 可以验证原始授权，而不是把 proxy socket identity 当成原始 principal。
+**Mechanism。** 在 eBPF-to-proxy 边界生成一个 compact capability，绑定 principal、policy generation、destination scope、nonce、expiry/revocation epoch，以及允许 refine 它的 proxy trust domain。完成 L7 parsing 后，proxy 再派生 request-scoped witness。Backend-side eBPF 在把流量视为原始授权的 continuation 之前，先验证 witness 和当前 generation。
 
-Capability 不能被普通 workload 伪造。第一版实现可以选择 kernel-managed opaque handle、受限访问的 map-backed generation record，或者经本地可信 channel 传递的 authenticated token。重点应该先放在 trust boundary 清晰，而不是追求密码学花样。
+第一版应该建立在已有 source-identity propagation 之上，而不是重做整套数据路径。Connection mark 或 conntrack identity 可以继续承担 common fast path，generation-scoped handle 只补上生命周期与 request lineage 语义。
 
-**Delta。** Complete mediation 证明 request 穿过了 enforcement point；这里证明 security subject 和 policy generation 跨这些 point 仍然是同一个。Multi-owner composition 决定 winning rule；handoff capability 把这个 authority 跨 proxy transformation 带过去。
+**Delta。** Complete mediation 证明 enforcement 确实发生。Cilium 已经证明 identity 可以跨 proxy connection 传递。这里增加的是 request scope 与 policy-generation validity。
 
-**Artifact。** 一个小型 eBPF redirect 组件、Cilium/Envoy extension 或 filter、map-backed capability table 和 egress validator。Debug view 应该能把 downstream identity、L7 rule、upstream request 与 policy generation 连起来。
+**Artifact。** 一个 eBPF redirect 组件、一个小型 Envoy extension、generation table，以及能输出 machine-readable lineage 的 egress validator。
 
-**Evaluation。** 让多个 identity 共用 node-local proxy，同时反复更新 policy、重启 Envoy、替换 proxy instance、触发 retry 和改变 backend endpoint。测量 unauthorized upstream request、stale-generation accept、principal misattribution、capability lookup cost、额外 request latency 和 state size。
+**Evaluation。** 先复现 issue #44912 一类 identity transition，再加入 pooling、HTTP/2 multiplexing、retry、proxy restart、backend change 和 policy churn。测量 stale-generation accept、principal misattribution、false reject、state size、lookup cost 和 request latency。
 
-**Academic value。** 这个问题可以推广为：一个 trusted component 终止并重新发起通信时，reference-monitor reasoning 怎样跨 semantic transformation 保持成立。
+**Academic value。** 把 reference-monitor reasoning 扩展到 semantic transformation 和授权状态生命周期变化同时存在的场景。
 
-**Production value。** Service mesh 与 eBPF policy engine 可以保住 least-privilege intent，而不是一旦 redirect 就把 proxy 当成万能身份。
+**Production value。** 给今天的连接级身份传播补上一条可审计的 request-level least-privilege 路径。
 
-**Failure condition。** 如果现有 production mesh 已经有等价的 request-scoped、generation-aware handoff，而且在 proxy restart、pooling 和 retry 下都不会 identity confusion，那么研究重点应该转向形式化和测量已有机制，而不是再造一个协议。
+**Failure condition。** 如果现有 production mesh 已经有 request-scoped、generation-aware 机制，并能在 pooling、retry、restart 和 identity transition 下保持无歧义，那么研究重点应该转向形式化和评测已有机制。
 
 ### 2. Policy-safe multiplexing 与 request-to-socket coalescing
 
-**Gap。** eBPF 自然容易用 packet、flow 或 socket 做 cache key，但现代 L7 proxy 会在共享 upstream connection 上调度多个 logical request。
+**Gap。** eBPF 很自然地按 packet、flow 或 socket cache，而现代 proxy 可能让许多 logical request 共用一条 upstream transport。
 
-**Mechanism。** 把 coalescing 变成一个 proof obligation。只有多个 request 对 proxy 之后仍需执行的 policy 来说具有等价 downstream security context，proxy/runtime 才允许它们共享 upstream transport；如果 context 不同，就保留 stream-level witness，或者按照显式 policy-equivalence class 拆分 connection pool。
+**Mechanism。** 把 connection-pool coalescing 变成 security proof obligation。只有当多个 request 对 proxy 之后仍要执行的所有 policy property 都具有等价 security context 时，才允许共用 upstream transport；否则就保留 request-level witness，或者按 versioned policy-equivalence class 拆分 pool。
 
-一个 compact equivalence class 可以包含 destination identity、当前 policy generation、downstream principal class，以及 downstream enforcement 仍然需要的 L7 attribute。这个 class 必须 versioned。Policy update 一旦改变 equivalence，旧 pooled state 就不能继续无条件复用。
+这个 equivalence class 可以包含 destination identity、principal class、policy generation，以及下游仍然需要的少量 L7 attribute。Policy update 一旦改变 equivalence，就必须使不兼容的 pooled state 失效或 drain。
 
-**Delta。** 这不是为了性能做普通 connection-pool partition。Grouping rule 来自下游 security semantics，并用 authorization lineage 来评估。它也不要求把每个 HTTP header 暴露给 eBPF；proxy 可以保留 protocol detail，只输出下一层 enforcement 所需的 security equivalence class。
+**Delta。** 这不是为了性能做普通 pool partition，分组规则来自下游 authorization semantics。
 
-**Artifact。** Envoy connection-pool extension，加一个由 eBPF control plane 消费的 policy-equivalence API。Debug view 需要解释两个 request 为什么可以安全共享一条 upstream socket，以及依据了哪些 policy field。
+**Artifact。** Envoy connection-pool extension，加一个供 eBPF control plane 使用的 policy-equivalence API。Debug view 需要解释两个 request 为什么可以安全共享 transport。
 
-**Evaluation。** 覆盖 HTTP/1.1 keepalive、HTTP/2 multiplexing、gRPC stream、retry、hedged request，以及多 source identity 的 backend connection reuse。比较 naive one-identity-per-socket cache、完全禁用 pooling 和 policy-aware coalescing。测量 misattribution、false reject、connection count、latency、CPU 与 policy-update convergence。
+**Evaluation。** 覆盖 HTTP/1.1 keepalive、HTTP/2、gRPC stream、retry、hedged request、identity change 和多 principal 的 backend reuse。比较 naive one-identity-per-socket、禁用 pooling 和 policy-aware coalescing。
 
-**Academic value。** 它把 network policy 连到一个经典系统问题：多个 logical principal 在什么条件下可以安全共享一个 cached physical resource？
+**Academic value。** 它问的是一个经典系统问题：多个 logical principal 在什么条件下可以安全共享一个 cached physical resource？
 
-**Production value。** 在保留 proxy efficiency 的同时，避免 connection pooling 把 kernel-side policy 仍然需要的身份差异抹掉。
+**Production value。** 保住 proxy efficiency，同时不让 pooling 抹掉后续 enforcement 仍然需要的身份差异。
 
-**Failure condition。** 如果 proxy 之后的 backend enforcement 永远不依赖原始 principal，或者现有 production proxy 已经按等价 security context 把所有 pool 完整分开，这个机制只会增加状态而不会改善 correctness。
+**Failure condition。** 如果 L7 授权之后的下游 enforcement 从不依赖 caller identity，或者现有 proxy 已经按等价 security context 完整拆分 pool，那么额外机制价值有限。
 
 ### 3. Confused-deputy 与 fast/slow-path lineage benchmark
 
-**Gap。** 现有 network benchmark 通常强调 throughput、latency、policy-update time 或 allow/deny correctness，很少故意让 proxy 同时代表多个 principal，再检查 authorization lineage 是否跨每次 representation change 保留下来。
+**Gap。** 现有 network benchmark 通常关注 throughput、latency、update time 或最终 allow/deny，很少检查 accepted request 在多次表示变化后是否仍带着正确的授权来源。
 
-**Mechanism。** 构建 ground-truth harness，为每个 logical request 指定 principal、policy generation、允许的 L7 operation、destination scope 和预期 backend identity，然后强制 request 经过 direct eBPF fast path、Envoy slow path、混合 fallback、connection pooling、HTTP/2 multiplexing、retry、policy update 和 proxy restart。
+**Mechanism。** 构建 ground-truth harness，为每个 logical request 指定 principal、policy generation、允许的 L7 operation、destination scope 和预期 backend identity，再强制请求经过 eBPF fast path、proxy slow path、混合 fallback、pooling、multiplexing、retry、identity transition、policy update 和 proxy restart。
 
-主要 correctness metric 是 **authorization-lineage violation**：一个被接受的 upstream request，如果其 principal、generation、destination scope 或 L7 authorization 无法和真正触发它的 ground-truth request 对应，就记为 violation。Secondary metric 再包括 revocation 后的 stale accept、false reject、lineage-loss rate、throughput、CPU 和 latency。
+主要 metric 是 **authorization-lineage violation**：一个被接受的 upstream request，如果其 principal、generation、destination scope 或 L7 authorization 无法对应到真正触发它的 ground-truth request，就记为 violation。
 
-**Delta。** 上一篇 complete-mediation benchmark 找的是完全绕过 current enforcement 的 packet。这里假设 mediation 已经发生，继续检查被 mediation 的 request 是否带着错误 identity 穿过 proxy boundary。
+**Delta。** Complete-mediation benchmark 找完全逃过 enforcement 的 packet。这里先假设 mediation 已发生，再检查 request 是否带着 stale 或错误 authority 穿过边界。
 
-**Artifact。** 可复现 Kubernetes testbed、Cilium/Envoy 配置、mixed-principal workload generator、fault injector、reference authorization log，以及可以对比 kernel fast path 和 proxy slow path 的 trace format。
+**Artifact。** 可复现 Kubernetes testbed、Cilium/Envoy 配置、mixed-principal workload generator、fault injector、reference authorization log，以及可比较 fast/slow path 的 trace format。
 
-**Evaluation。** 先包含 one-request-per-connection 这种所有实现都应通过的简单 workload，再逐步加入 pooling、multiplexing、retry 和 policy churn。新机制必须在 ordinary socket/proxy identity 会产生 lineage failure 的场景里真正消除错误，才值得增加复杂度。
+**Evaluation。** 从 one-request-per-connection 开始，再逐步加入 pooling、multiplexing、retry、identity transition 和 policy churn。只有当新机制能消除 connection-level baseline 暴露出的 lineage violation 时，复杂度才值得。
 
-**Academic value。** Benchmark 把 cross-layer security property 变成可测量目标，也给 kernel、CNI、service-mesh 和 proxy research 一个共同评测面。
+**Academic value。** 把一个 cross-layer security property 变成 kernel、CNI、service mesh 和 proxy 都能测的共同目标。
 
-**Production value。** Operator 可以测试一个 L7 acceleration 或 proxy integration 在真实 failure/pooling 行为下是否保住 policy subject，而不是只看 demo request 最后得到 HTTP 200 还是 403。
+**Production value。** Operator 可以检查 L7 acceleration 与 proxy integration 在真实生命周期变化下是否保持授权含义，而不是只看最后得到 HTTP 200 还是 403。
 
-**Failure condition。** 如果多个独立实现都能在 adversarial multiplexing、restart、update 和 fallback workload 下保持零 lineage violation，那么这个 gap 可能已经被现有实践解决得足够好。
+**Failure condition。** 如果多个独立实现都能在这些 adversarial workload 下保持零 lineage violation，那么这个 gap 很可能已经被现有实践解决。
 
 ## 什么证据会改变这个结论？
 
-本文依赖一个假设：生产数据路径里，L7 proxy 前使用的 security identity 并不会自动、无歧义地绑定到 proxy 重新发出的 logical request。
+最强的反证是一套 production-grade 实现：它已经能把 request-scoped、不可伪造的 authorization identity 与 policy generation 穿过 downstream termination、upstream pooling、HTTP/2 或 gRPC multiplexing、retry、proxy restart、identity transition、policy update 和 fast-path fallback。
 
-最强的反证会是一套 production-grade 实现：它已经能把 request-scoped、不可伪造的 authorization identity 和 policy generation 穿过 downstream termination、upstream connection pooling、HTTP/2 或 gRPC multiplexing、retry、proxy restart、policy update 和 fast-path fallback；而且 adversarial benchmark 无法制造 stale、confused 或无法归因却被接受的 request。那时真正需要做的是标准化和系统评测，而不是再增加新的 handoff protocol。
+Cilium 已有的 source-identity propagation 说明基本的连接级 handoff 是可以解决的；issue #44912 则说明生命周期变化仍可能让连接级 identity 失效。只有 benchmark 还能找出已有 propagation 与 invalidation 机制覆盖不到的 failure，新增 handoff mechanism 才有充分理由。
 
-第二个边界是 enforcement placement。有些部署明确把 Envoy 当成所有 L7 decision 的最终 authority，并要求 backend policy 只信 proxy identity。在这种模型里，把原始 principal 继续带到后面的 eBPF enforcement point 可能没有价值。只有当 downstream enforcement、audit、revocation、rate control 或 provenance 仍然依赖 original request identity 时，handoff capability 才值得存在。
+另一个边界是 enforcement placement。有些部署明确让 Envoy 成为所有 L7 decision 的最终 authority，后续策略只信 proxy identity。在这种模型里，把 original caller 继续带给后面的 eBPF decision 未必有价值。只有 downstream enforcement、audit、revocation、rate control 或 provenance 仍依赖原始授权上下文时，request-scoped lineage 才值得保留。
 
-所以最实际的下一步不是先给每个 packet 塞更多 metadata，而是先做 benchmark，让 proxy identity confusion 可观测，再验证一个 compact generation-scoped handoff 是否真的能消除普通 socket/proxy identity 无法避免的错误。
+因此最实际的下一步不是先设计新的 metadata format，而是先做 benchmark：复现 policy/endpoint transition 后的 stale identity，再加入 pooling 和 retry，最后确认 compact generation-scoped handoff 是否真的解决了现有 connection-level identity propagation 无法覆盖的问题。

--- a/docs/research/ebpf-l7-proxy-policy-identity.zh.md
+++ b/docs/research/ebpf-l7-proxy-policy-identity.zh.md
@@ -1,0 +1,180 @@
+---
+date: 2026-08-28
+title: "eBPF 在 L7 代理交接时还能保住策略身份吗？"
+description: "当 eBPF 把带策略身份的流量交给 L7 代理时，上游新连接可能丢失最初的主体身份、策略 generation 和授权来源。"
+tags:
+  - Daily Report
+  - eBPF
+  - Networking
+  - Security
+  - Service Mesh
+  - Envoy
+  - L7
+research_question: "当流量进入 L7 代理，并从另一个 socket 或连接重新发出时，eBPF 安全数据路径怎样保留请求原始身份、策略 generation 和授权 provenance？"
+source_cutoff: 2026-08-28
+status: daily-report
+---
+
+# eBPF 在 L7 代理交接时还能保住策略身份吗？
+
+一个网络策略可以在请求进入代理之前做出完全正确的判断，却在请求真正到达后端之前丢掉这个判断成立的理由。
+
+问题出现在数据路径跨过语义边界时。eBPF 程序先看到一个带源身份和连接 tuple 的 packet 或 socket，然后把流量重定向到 Envoy 等 L7 proxy。代理终止下游连接，解析 HTTP、gRPC 或其他应用层协议，再创建或复用另一条上游连接。到了后端一侧，packet 属于代理自己的 socket，tuple、security identity、连接生命周期和 policy context 都可能已经改变。
+
+策略的重要性没有改变。系统仍然需要回答一个简单的问题：**这个具体的上游请求，究竟是哪个主体、在哪个 policy generation 下被允许的？**
+
+<!-- more -->
+
+本文认为，跨边界的 eBPF 安全设计除了 path coverage，还需要一个 **policy-identity handoff contract**。请求从 eBPF enforcement domain 进入 L7 proxy，再回到新的 kernel/network path 时，真正决定授权的上下文必须以一种不会被另一个请求、另一条连接或旧策略 generation 混淆的形式继续存在。
+
+这比上一篇 [主机与卸载路径之间的 complete mediation](https://eunomia.dev/zh/research/ebpf-complete-mediation-offload/) 更窄。Complete mediation 问的是每条可达 packet path 是否都经过有效 enforcement point。本文先假设请求确实经过了多个 enforcement point，然后追问：proxy 把流量终止并重新发起之后，这些 enforcement point 还在讨论**同一个安全主体和同一次授权判断**吗？
+
+它也不同于 [多 owner 网络策略组合](https://eunomia.dev/zh/research/ebpf-network-policy-composition/)。Policy composition 决定哪一个 owner 和 rule 应该产生最终 verdict；proxy handoff 则问这个 verdict 在表示从 packet 变成 socket、L7 request，再变成另一个 socket 时，是否仍然绑定在原来的请求上。
+
+## 生产系统已经把这个边界暴露出来了
+
+Cilium 当前的 L7 policy 文档明确说明：L7 policy traffic 会经过 node-local Envoy。Cilium 的 Envoy 构建包含自定义 policy enforcement filter，Cilium agent 通过 Unix-domain socket 给 Envoy 下发配置并接收 access log。可以直接参考当前的 [Cilium Envoy 文档](https://docs.cilium.io/en/latest/security/network/proxy/envoy/) 和 [Layer 7 policy 文档](https://docs.cilium.io/en/latest/security/policy/layer7/)。
+
+在 Cilium Ingress 和 Gateway API 中，这个边界更加明显。Cilium 文档说明 per-node Envoy 会和 eBPF policy engine 交互并执行 policy lookup，而且存在两个逻辑 policy enforcement point：流量在进入 Envoy 前可以检查一次，在 Envoy 即将把流量发往 backend 时再检查一次。外部流量通常先带有 `world` identity，到了 Envoy 边界又会被赋予特殊的 `ingress` identity。见 [Cilium Ingress 与 Network Policy 文档](https://docs.cilium.io/en/latest/network/servicemesh/ingress/)。
+
+这个设计本身很实用，但它也暴露出更一般的系统问题。第二个 enforcement point 看到的 identity 不一定就是最初发起请求的 identity。Proxy 本来就是一个 deputy：它接受调用者的连接，再代表调用者去创建或复用另一条连接。
+
+Linux BPF 的很多原语天然落在 packet 和 socket 边界。`BPF_MAP_TYPE_SOCKMAP` 与 `BPF_MAP_TYPE_SOCKHASH` 可以在 socket 之间 redirect message，也可以挂 socket-level verdict program。内核文档还会把 socket cookie 暴露给用户态，而不是把 kernel socket pointer 直接暴露出去。这些机制非常适合标识一个 transport lifetime，但 proxy handoff 会创建新的 socket，它已经无法单独表示原始请求。见 Linux 当前的 [sockmap / sockhash 文档](https://docs.kernel.org/next/bpf/map_sockmap.html)。
+
+随着更多 L7 工作进入 kernel fast path，这个问题会更加重要。2026 年 5 月发布的 [L7FP](https://arxiv.org/abs/2605.31084) 会为常见 service-mesh L7 policy 合成 eBPF fast path，对无法支持的 policy 再 fallback 到现有 userspace proxy。它的性能结果说明这种 fast/slow split 很有吸引力，但也带来新的 correctness requirement：一个 request 不能仅仅因为这一次留在 eBPF fast path，而另一次经过 proxy，就悄悄换掉 authorization identity。
+
+## Socket identity 不等于 request identity
+
+对于简单 TCP forwarding，把 policy state 绑定在 socket 上可能足够。但一旦 proxy 开始 multiplex 或 retry，这个假设就很脆弱。
+
+例如 Envoy 到 backend 之间只有一条 HTTP/2 connection，但里面可能同时承载多个 downstream client 的请求。如果 eBPF egress path 给这个 upstream socket 绑定一个 source identity 或一个 authorization generation，它到底描述的是哪个请求？同一个 socket 不变，stream 之间的答案却可能完全不同。
+
+Retry 是相反的变化。一个 logical request 可能先后使用多条 upstream connection。Request-level authorization 应该跨 retry 保留，但 socket-local record 自己做不到。
+
+Connection pooling 让这两种情况成为日常行为，而不是 corner case。因此一个正确系统至少需要区分三种 identity：
+
+- 具体 packet/socket lifetime 的 **transport identity**；
+- 能跨 proxy scheduling、multiplexing 和 retry 的 **logical request / stream identity**；
+- 包含安全主体、policy generation 和授权范围的 **policy identity**。
+
+它们可以关联，但不应该因为 benchmark 恰好使用 one-request-per-TCP-connection 就被压成同一个字段。
+
+## Handoff 更像 capability，而不是普通 trace annotation
+
+实际系统不需要把完整 policy object 放进每个 request。它需要的是下一层 enforcement domain 能验证的一小段授权声明。
+
+假设 eBPF datapath 判断 downstream principal `A` 可以在 policy generation `g` 下向 service `B` 发起某一类请求。在 redirect 到 proxy 之前，datapath 或 control plane 可以生成一个短生命周期的 **handoff capability**，其中包含或引用：
+
+- 原始 security identity 或 principal class；
+- 授权这次 handoff 的 policy generation；
+- 防止 capability 被拿去复用到无关流量的 flow/request nonce；
+- 允许的 destination 或 service scope；
+- proxy 可以进一步收窄的 L7 capability class，例如某一组 HTTP method/path rule；
+- expiry 或 revocation epoch；
+- 允许消费这个 capability 的 proxy instance 或 trust domain。
+
+Proxy 在解析 L7 request 之后可以进一步 refine 这个 capability。例如 packet-level decision 只允许“principal A 可以进入 proxy P 去访问 service B”，L7 filter 再证明某一个 HTTP request 同时匹配 method/path rule `r`。当 Envoy 创建或复用 upstream connection 时，它产生一个绑定 logical request 的 derivative witness，而不是只给整个 proxy socket 一个 identity。
+
+后端一侧的 eBPF 不需要再次解析 HTTP。它只要验证 derivative witness、当前 generation、destination scope 和 proxy authority，就可以判断这个 packet 是否真的是原始授权 request 的 continuation。
+
+这更接近 capability system，而不是 tracing label。Trace label 主要帮助事后解释发生了什么；handoff capability 直接参与 authorization decision，在 stale、缺失或绑定到错误 request 时应该 fail closed。
+
+## 当前工作还薄弱在哪里
+
+### 两个 enforcement point 并不会自动保留同一个 principal
+
+Cilium 已经明确记录 Envoy 前后都存在 policy enforcement。这比把 proxy 当作透明 middlebox 强得多。但前后两个 check 完全可能合法地使用不同 identity，例如 `world`、`ingress` 或 workload identity。
+
+缺少的抽象是一条显式 **lineage relation**：第二个 decision 应该能证明是哪一个原始 principal 和 policy generation 导致了这个 request，而不是只证明 packet 来自一个受信任的 proxy process。
+
+当 proxy 变成 confused deputy 时，这个 gap 会直接影响安全性。如果一个被允许的 downstream request 可以让 proxy 发出超出原 principal scope 的 upstream operation，那么 backend 只信 proxy identity 的规则就比原始 policy 更弱。反过来，如果 backend 想重新执行原始 L3/L4 policy，却拿不到转换后的上下文，也可能误杀合法流量。
+
+一个有区分力的测试应该让多个 downstream identity 共用一个 proxy，故意让 backend destination 重叠，再检查任意 upstream request 是否可能被归因到错误 principal 或旧 policy generation。
+
+### Per-socket policy state 在 multiplexing 下会失效
+
+Socket cookie、socket-local storage、sockmap entry 和 connection-tracking state 都很有价值，因为它们能避免每个 packet 重做昂贵工作。它们也确实适合描述 transport lifetime。
+
+但这些状态自己无法描述 HTTP/2 stream、gRPC request、retry，或者多个 caller 共享的 connection pool。如果 policy cache 默认“一条 upstream socket 对应一个 principal”，它可能在不用 pooling 的 HTTP/1.1 benchmark 里完全正确，在真实 HTTP/2 workload 里却是错的。
+
+缺少的机制是：什么时候 request-level authorization 可以安全地 **coalesce** 成 connection-level state？只有当同一条 connection 上所有 active request 对下游仍需执行的 policy property 都等价时，系统才应该聚合。否则就要保留 request/stream-level lineage，或者把最终 decision 留在 proxy 内部。
+
+### Fast-path fallback 需要 identity equivalence，不只是 verdict equivalence
+
+L7FP 展示了一种很有用的 split：常见 policy 走 eBPF fast path，unsupported case 回到 userspace proxy。功能测试可以验证两条路径对同一个 request 是否都 allow 或 deny。
+
+这是必要条件，但还不够。简单测试中，两条路径即使给出相同 verdict，也可能给 accepted request 留下不同 provenance。等到 backend policy、audit、rate limiter 或 revocation mechanism 依赖原始 principal 时，这个差异才暴露出来。
+
+所以缺少的 evaluation 不只是 verdict equivalence，而是 fast/slow path 之间的 **authorization-lineage equivalence**，而且要覆盖 retry、pooling、policy update 和 proxy restart。
+
+## 兼具学术价值和生产价值的方向
+
+### 1. Generation-scoped proxy handoff capability
+
+**Gap。** eBPF 可以授权并 redirect 一个 flow 到 L7 proxy，但 proxy 的 upstream socket 并不会天然携带原始 principal 或 policy generation。
+
+**Mechanism。** 在 eBPF-to-proxy 边界定义一个 compact handoff capability，由可信 datapath 生成，只允许被授权 proxy instance 消费。Capability 绑定 principal identity、policy generation、destination scope、nonce、expiry/revocation epoch 和允许 refine 的 capability class。完成 L7 parsing 之后，proxy 再产生 request-scoped witness，让 backend-side datapath 可以验证原始授权，而不是把 proxy socket identity 当成原始 principal。
+
+Capability 不能被普通 workload 伪造。第一版实现可以选择 kernel-managed opaque handle、受限访问的 map-backed generation record，或者经本地可信 channel 传递的 authenticated token。重点应该先放在 trust boundary 清晰，而不是追求密码学花样。
+
+**Delta。** Complete mediation 证明 request 穿过了 enforcement point；这里证明 security subject 和 policy generation 跨这些 point 仍然是同一个。Multi-owner composition 决定 winning rule；handoff capability 把这个 authority 跨 proxy transformation 带过去。
+
+**Artifact。** 一个小型 eBPF redirect 组件、Cilium/Envoy extension 或 filter、map-backed capability table 和 egress validator。Debug view 应该能把 downstream identity、L7 rule、upstream request 与 policy generation 连起来。
+
+**Evaluation。** 让多个 identity 共用 node-local proxy，同时反复更新 policy、重启 Envoy、替换 proxy instance、触发 retry 和改变 backend endpoint。测量 unauthorized upstream request、stale-generation accept、principal misattribution、capability lookup cost、额外 request latency 和 state size。
+
+**Academic value。** 这个问题可以推广为：一个 trusted component 终止并重新发起通信时，reference-monitor reasoning 怎样跨 semantic transformation 保持成立。
+
+**Production value。** Service mesh 与 eBPF policy engine 可以保住 least-privilege intent，而不是一旦 redirect 就把 proxy 当成万能身份。
+
+**Failure condition。** 如果现有 production mesh 已经有等价的 request-scoped、generation-aware handoff，而且在 proxy restart、pooling 和 retry 下都不会 identity confusion，那么研究重点应该转向形式化和测量已有机制，而不是再造一个协议。
+
+### 2. Policy-safe multiplexing 与 request-to-socket coalescing
+
+**Gap。** eBPF 自然容易用 packet、flow 或 socket 做 cache key，但现代 L7 proxy 会在共享 upstream connection 上调度多个 logical request。
+
+**Mechanism。** 把 coalescing 变成一个 proof obligation。只有多个 request 对 proxy 之后仍需执行的 policy 来说具有等价 downstream security context，proxy/runtime 才允许它们共享 upstream transport；如果 context 不同，就保留 stream-level witness，或者按照显式 policy-equivalence class 拆分 connection pool。
+
+一个 compact equivalence class 可以包含 destination identity、当前 policy generation、downstream principal class，以及 downstream enforcement 仍然需要的 L7 attribute。这个 class 必须 versioned。Policy update 一旦改变 equivalence，旧 pooled state 就不能继续无条件复用。
+
+**Delta。** 这不是为了性能做普通 connection-pool partition。Grouping rule 来自下游 security semantics，并用 authorization lineage 来评估。它也不要求把每个 HTTP header 暴露给 eBPF；proxy 可以保留 protocol detail，只输出下一层 enforcement 所需的 security equivalence class。
+
+**Artifact。** Envoy connection-pool extension，加一个由 eBPF control plane 消费的 policy-equivalence API。Debug view 需要解释两个 request 为什么可以安全共享一条 upstream socket，以及依据了哪些 policy field。
+
+**Evaluation。** 覆盖 HTTP/1.1 keepalive、HTTP/2 multiplexing、gRPC stream、retry、hedged request，以及多 source identity 的 backend connection reuse。比较 naive one-identity-per-socket cache、完全禁用 pooling 和 policy-aware coalescing。测量 misattribution、false reject、connection count、latency、CPU 与 policy-update convergence。
+
+**Academic value。** 它把 network policy 连到一个经典系统问题：多个 logical principal 在什么条件下可以安全共享一个 cached physical resource？
+
+**Production value。** 在保留 proxy efficiency 的同时，避免 connection pooling 把 kernel-side policy 仍然需要的身份差异抹掉。
+
+**Failure condition。** 如果 proxy 之后的 backend enforcement 永远不依赖原始 principal，或者现有 production proxy 已经按等价 security context 把所有 pool 完整分开，这个机制只会增加状态而不会改善 correctness。
+
+### 3. Confused-deputy 与 fast/slow-path lineage benchmark
+
+**Gap。** 现有 network benchmark 通常强调 throughput、latency、policy-update time 或 allow/deny correctness，很少故意让 proxy 同时代表多个 principal，再检查 authorization lineage 是否跨每次 representation change 保留下来。
+
+**Mechanism。** 构建 ground-truth harness，为每个 logical request 指定 principal、policy generation、允许的 L7 operation、destination scope 和预期 backend identity，然后强制 request 经过 direct eBPF fast path、Envoy slow path、混合 fallback、connection pooling、HTTP/2 multiplexing、retry、policy update 和 proxy restart。
+
+主要 correctness metric 是 **authorization-lineage violation**：一个被接受的 upstream request，如果其 principal、generation、destination scope 或 L7 authorization 无法和真正触发它的 ground-truth request 对应，就记为 violation。Secondary metric 再包括 revocation 后的 stale accept、false reject、lineage-loss rate、throughput、CPU 和 latency。
+
+**Delta。** 上一篇 complete-mediation benchmark 找的是完全绕过 current enforcement 的 packet。这里假设 mediation 已经发生，继续检查被 mediation 的 request 是否带着错误 identity 穿过 proxy boundary。
+
+**Artifact。** 可复现 Kubernetes testbed、Cilium/Envoy 配置、mixed-principal workload generator、fault injector、reference authorization log，以及可以对比 kernel fast path 和 proxy slow path 的 trace format。
+
+**Evaluation。** 先包含 one-request-per-connection 这种所有实现都应通过的简单 workload，再逐步加入 pooling、multiplexing、retry 和 policy churn。新机制必须在 ordinary socket/proxy identity 会产生 lineage failure 的场景里真正消除错误，才值得增加复杂度。
+
+**Academic value。** Benchmark 把 cross-layer security property 变成可测量目标，也给 kernel、CNI、service-mesh 和 proxy research 一个共同评测面。
+
+**Production value。** Operator 可以测试一个 L7 acceleration 或 proxy integration 在真实 failure/pooling 行为下是否保住 policy subject，而不是只看 demo request 最后得到 HTTP 200 还是 403。
+
+**Failure condition。** 如果多个独立实现都能在 adversarial multiplexing、restart、update 和 fallback workload 下保持零 lineage violation，那么这个 gap 可能已经被现有实践解决得足够好。
+
+## 什么证据会改变这个结论？
+
+本文依赖一个假设：生产数据路径里，L7 proxy 前使用的 security identity 并不会自动、无歧义地绑定到 proxy 重新发出的 logical request。
+
+最强的反证会是一套 production-grade 实现：它已经能把 request-scoped、不可伪造的 authorization identity 和 policy generation 穿过 downstream termination、upstream connection pooling、HTTP/2 或 gRPC multiplexing、retry、proxy restart、policy update 和 fast-path fallback；而且 adversarial benchmark 无法制造 stale、confused 或无法归因却被接受的 request。那时真正需要做的是标准化和系统评测，而不是再增加新的 handoff protocol。
+
+第二个边界是 enforcement placement。有些部署明确把 Envoy 当成所有 L7 decision 的最终 authority，并要求 backend policy 只信 proxy identity。在这种模型里，把原始 principal 继续带到后面的 eBPF enforcement point 可能没有价值。只有当 downstream enforcement、audit、revocation、rate control 或 provenance 仍然依赖 original request identity 时，handoff capability 才值得存在。
+
+所以最实际的下一步不是先给每个 packet 塞更多 metadata，而是先做 benchmark，让 proxy identity confusion 可观测，再验证一个 compact generation-scoped handoff 是否真的能消除普通 socket/proxy identity 无法避免的错误。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?](https://eunomia.dev/research/ebpf-l7-proxy-policy-identity/)
+
+An L7 proxy terminates one policy-bound connection and emits or reuses another, so socket identity can stop representing the principal that caused an upstream request. This report develops generation-scoped handoff capabilities, policy-safe multiplexing, and a benchmark for authorization-lineage violations across fast and slow paths.
+
 ### [Can eBPF Preserve Complete Mediation Across Host and Offload Paths?](https://eunomia.dev/research/ebpf-complete-mediation-offload/)
 
 Host software, SmartNIC fast paths, and DPU offload can all execute network policy while traffic changes paths during misses, updates, and faults. This report develops an explicit path-coverage contract, generation-continuous fallback, and a benchmark that measures policy escapes rather than offload throughput alone.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 在 L7 代理交接时还能保住策略身份吗？](https://eunomia.dev/zh/research/ebpf-l7-proxy-policy-identity/)
+
+L7 proxy 会终止一条带策略身份的连接，再创建或复用新的上游连接，因此 socket identity 可能不再代表真正触发请求的 principal。本文提出 generation-scoped handoff capability、policy-safe multiplexing，以及检测 fast/slow path authorization-lineage violation 的 benchmark。
+
 ### [eBPF 在主机与卸载路径之间还能保证完整中介吗？](https://eunomia.dev/zh/research/ebpf-complete-mediation-offload/)
 
 主机软件、SmartNIC 快速路径与 DPU 卸载都可能执行网络策略，而流量会在 miss、更新和故障期间改变路径。本文提出显式 path-coverage contract、跨 generation 连续的 fallback，以及直接测量 policy escape 而不只测 offload 吞吐的 benchmark。


### PR DESCRIPTION
## Evidence

- Reverified the configured Google Drive folder on 2026-08-28; the newest source-native weekly set remains 2026-08-17..23.
- GSC finalized coverage still supports only the contiguous six-day comparison 2026-08-17..22 vs 2026-08-10..15; missing date rows are not treated as zero.
- Finalized GA4 2026-08-17..23 remains 984 organic landing-page sessions at ~49.29% session-weighted engagement vs 970 at ~44.95% in the prior weekly aggregate.
- Fresh live-site inspection found no evidence-backed technical SEO defect that justifies a separate implementation change.
- Current Cilium documentation exposes eBPF policy lookups around Envoy and two logical policy enforcement points; Linux sockmap/sockhash is socket-oriented; L7FP provides a current fast-path/proxy-fallback boundary. This supports a distinct policy-identity continuity question rather than another path-coverage report.

## Scope

- Publish exactly one bilingual Daily Report: `ebpf-l7-proxy-policy-identity`.
- Add it to the EN/ZH Daily Report indexes.
- Refresh the 2026-08-28 operating record, current status, source watermark, blocker record, durable plan, and editorial-series state.
- Close the normal six-report `eBPF Networking and Security` series and activate the already queued `GPU and Heterogeneous Runtime Systems` roadmap for the next normal run.
- No unrelated technical SEO implementation change.
- No `seo-skills` pointer bump: upstream moved, but the consuming contract still requires migration before adopting the generic closeout semantics.

## Validation

Expected repository checks: `Validate SEO Operations` and `Deploy Static App`. Final acceptance also requires complete final diff/generated-output self-review after green CI, squash merge, exact-squash production deployment, and live EN/ZH verification.

## Production acceptance

Verify after the exact squash commit deploys:

- `https://eunomia.dev/research/ebpf-l7-proxy-policy-identity/`
- `https://eunomia.dev/zh/research/ebpf-l7-proxy-policy-identity/`

Both routes must show Daily Report navigation, locale-correct canonical URLs, reciprocal `en`/`zh` hreflang plus `x-default`, Article JSON-LD, intended internal links, the required gap and developed-direction sections, and the conclusion/falsifier boundary. The production sitemap must contain both locale routes with the expected alternates.