### PR TITLE
Daily: make GPU memory placement evidence explicit

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -18,7 +18,7 @@ already configured and enabled; it is not a blocker.
 ## Current data-history constraint
 
 Google Drive access is verified and is not a blocker. The configured folder was
-directly rechecked on `2026-08-28`; it contains weekly export sets through
+directly rechecked on `2026-08-29`; it contains weekly export sets through
 `2026-08-17..23` and no newer set was observed.
 
 For Search Console, the verified latest date export contains rows through

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -194,9 +194,10 @@ composition, zero-copy ownership, temporal state verification, revocation,
 complete mediation, or proxy identity continuity with a different product
 example alone.
 
-Before and after the August 28 publication, the newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
-report ages another eBPF-centered report out of the rolling ten.
+A direct recount on `2026-08-29` corrected the previous rolling-window arithmetic.
+Immediately before the August 29 publication, the newest ten contain **8
+eBPF-centered / 0 pure Agent / 2 adjacent systems**, not `7 / 0 / 3`. This is an
+operating-record correction only; no report classification changed.
 
 ## Completed series — eBPF Observability and Profiling
 
@@ -352,12 +353,41 @@ roadmap, but they predate activation and do not count as progress in the new
 normal sequence. They establish two boundaries that should not simply be
 repeated: kernel launch-latency attribution and host/device causal tracing.
 
-The series becomes active after the `2026-08-28` Networking and Security report
-reaches that series' normal six-report boundary. Preferred next questions are
-runtime or device-side programmability boundaries, memory-placement/movement
-semantics, fine-grained GPU execution observability distinct from the August 20
-reports, and distributed GPU coordination only where a concrete runtime invariant
-can be tested.
+The series became active after the `2026-08-28` Networking and Security report
+reached that series' normal six-report boundary.
+
+The `2026-08-29` report is the first substantial post-activation contribution. It
+asks what evidence a GPU runtime needs before migrating, evicting, prefetching,
+replicating, or remotely mapping Unified Memory pages under HBM oversubscription.
+Recent systems add sampled resident-page activity, compiler-derived access
+semantics, object/phase behavior, or future scheduling knowledge because a demand
+fault alone does not reveal future reuse. The report develops evidence-carrying
+placement decisions, placement intent with observable compliance, and a
+counterexample benchmark that measures decision regret while progressively
+revealing richer evidence. It is adjacent systems because eBPF is optional
+instrumentation rather than the central mechanism.
+
+### Published progress
+
+1. `2026-08-29`: `/research/gpu-memory-placement-evidence/` separates address
+   validity and demand faults from the evidence needed to make a placement
+   decision under oversubscription. It compares CUDA UVM, Linux HMM, HIP managed
+   memory, sampled resident-page observability, compiler/object semantics, and
+   schedule-aware memory management, then proposes an evidence-to-decision
+   contract and fixed-budget evaluation. It is adjacent systems.
+
+After the August 29 publication, the newest ten contain **8 eBPF-centered / 0
+pure Agent / 2 adjacent systems**. The adjacent report displaces an older adjacent
+GPU report, so the rolling mix does not change today. This is one eBPF report
+above the normal target band. Do not repair it through classification. Prefer a
+second genuinely adjacent GPU/runtime report on the next normal run; it will age
+an older eBPF report out and return the rolling window to **7 / 0 / 3**.
+
+Preferred next questions are runtime/device-side programmability boundaries,
+fine-grained GPU execution observability distinct from the August 20 reports,
+and distributed GPU coordination only where a concrete runtime invariant can be
+tested. A second memory-placement report should be selected only if it advances a
+different mechanism rather than repeating evidence quality or eviction policy.
 
 ## Queued series — Agent Systems (limited)
 

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -377,11 +377,14 @@ instrumentation rather than the central mechanism.
    contract and fixed-budget evaluation. It is adjacent systems.
 
 After the August 29 publication, the newest ten contain **8 eBPF-centered / 0
-pure Agent / 2 adjacent systems**. The adjacent report displaces an older adjacent
-GPU report, so the rolling mix does not change today. This is one eBPF report
-above the normal target band. Do not repair it through classification. Prefer a
-second genuinely adjacent GPU/runtime report on the next normal run; it will age
-an older eBPF report out and return the rolling window to **7 / 0 / 3**.
+pure Agent / 2 adjacent systems**. The adjacent report displaces one of the two
+August 20 adjacent GPU reports, so the rolling mix does not change today. This is
+one eBPF report above the normal target band. An adjacent report on the next
+normal run would displace the remaining August 20 adjacent report and still leave
+**8 / 0 / 2**. A second consecutive adjacent report after that would displace the
+August 21 eBPF report and restore **7 / 0 / 3**. Prefer genuinely adjacent
+GPU/runtime questions over the next two normal runs when the quality gates permit;
+do not repair the ratio through classification.
 
 Preferred next questions are runtime/device-side programmability boundaries,
 fine-grained GPU execution observability distinct from the August 20 reports,

--- a/.github/seo-data/daily/2026-08-29.md
+++ b/.github/seo-data/daily/2026-08-29.md
@@ -1,0 +1,119 @@
+# SEO operations — 2026-08-29
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Delivery branch: `daily/2026-08-29-gpu-memory-placement-evidence`
+- Baseline default-branch commit: `e9d46c6d7d91d83667ea30305834685bfb764c4b`
+- Run type: data analysis, technical SEO/GEO audit, and one mandatory bilingual Daily Report
+- Technical SEO outcome: no separate implementation change; current evidence does not establish a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, performance, or deployment defect that justifies one.
+- Mandatory publication: one new bilingual Daily Report on evidence for GPU memory placement under oversubscription.
+
+## Data window
+
+- Verified raw Google export window: `2026-07-27` through `2026-08-23`.
+- The configured Drive folder was directly rechecked on `2026-08-29`; the newest source-native weekly set remains `2026-08-17..23`, with no later set observed.
+- Search Console newest verified finalized row: `2026-08-22`; `2026-08-23` is absent.
+- GA4 newest finalized source-native weekly aggregate: `2026-08-17..23`.
+- Search Console complete latest-seven-days and 28-day comparisons: unavailable because required rows/history are missing; missing coverage is not interpreted as zero.
+- Cloudflare: disabled by repository configuration.
+
+## Evidence collected
+
+### Google Search Console
+
+The longest equal-duration contiguous finalized comparison supported by the available rows remains six days:
+
+- `2026-08-17..22`: **477 clicks / 59,798 impressions / ~0.798% CTR / ~9.56 impression-weighted position**.
+- `2026-08-10..15`: **393 clicks / 66,510 impressions / ~0.591% CTR / ~9.91 position**.
+- Direction: clicks **+21.4%**, impressions **-10.1%**, CTR **+0.207 percentage points**, position improves by about **0.35**.
+
+A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the required windows need the absent `2026-08-16` and `2026-08-09` rows. Verified history also remains too short for the required 28-day comparison.
+
+Current page/query exports continue to distribute search demand across eBPF tutorials, GPU/CUDA material, project pages, and long-tail technical content. The weekly exports do not provide date-by-page or date-by-query dimensions, so this run does not attribute aggregate movement to one page, title, or report family.
+
+### Google Analytics 4
+
+The finalized `2026-08-17..23` organic landing-page aggregate contains **984 sessions** at about **49.29% session-weighted engagement**, including **118 `(not set)` sessions**, versus **970 sessions** at about **44.95%** for `2026-08-10..16`. Sessions are about **1.4% higher** and engagement about **4.34 percentage points higher**.
+
+GPU/CUDA tutorial and profiling pages remain visible among meaningful organic landing pages. This supports the technical relevance of the active GPU series but does not establish that a GPU report will improve search performance. The aggregate has no date dimension and cannot support within-week causal attribution.
+
+### Cloudflare
+
+Cloudflare analytics remains disabled by repository configuration. No edge-request, bot, cache, country, or status-code conclusion is made from missing Cloudflare data.
+
+### Public site and GitHub
+
+The fresh automated public-safe site brief generated on `2026-08-29 13:14 UTC` observed homepage `200`, robots `200`, sitemap `200`, 710 sitemap entries, and canonical homepage `https://eunomia.dev/`. The same brief observed 99 active non-fork public repositories and 9,846 aggregate stars at collection time. These repository values are used only as public project signals, not as SEO causal metrics.
+
+A fresh live homepage inspection also shows the expected Eunomia identity and Daily Report navigation. The independent public crawler's `/research/` snapshot can lag recent deployments, so stale crawler content is not treated as proof of a current site defect or as deployment acceptance evidence.
+
+### Research evidence
+
+The selected question is supported by current vendor/kernel documentation and recent systems work. CUDA Unified Memory separates addressability from residency: preferred location is a performance hint rather than a guarantee, and prefetch/advice can change migration behavior. Linux HMM and HIP managed memory expose similar dynamic migration boundaries with implementation-specific capabilities.
+
+Recent systems demonstrate that fault-only demand information is often insufficient for oversubscribed GPU memory. ObservUVM adds sampled HBM-resident access visibility and reports a 34% geometric-mean speedup over the evaluated UVM baseline across fourteen applications. SUV adds compiler-derived access semantics, OASIS uses object/phase behavior, ARIADNE derives runtime sharing information and chooses between GPU memory and zero-copy, and MSched couples future scheduling knowledge to proactive memory preparation. Nsight Systems documents that full Unified Memory page-fault tracing itself can be expensive, so a useful design must account for evidence cost and incompleteness rather than simply collecting every event.
+
+## Work performed
+
+### Technical SEO/GEO audit
+
+The repository baseline already generates sitemap, robots, canonical ownership, reciprocal language alternates, structured data, legacy redirect stubs, and static audit artifacts. The fresh site brief reports healthy homepage, robots, and sitemap responses, and current Google evidence does not isolate a page-level indexing or retrievability defect.
+
+Result: **no separate technical SEO/GEO site change today**. A speculative title, canonical, navigation, or schema edit would not be supported by the available source-native evidence.
+
+The pinned `.github/seo-skills` commit remains `516e9e2dcf012506a677a749049d64c5914643e9`; no pointer-only update is made because the consuming repository still requires contract migration before adopting the newer generic closeout layout.
+
+### Editorial mix and candidate review
+
+A direct recount of the actually published Daily Report index corrected a stale operating-state arithmetic error. Before today's publication, the newest ten reports are **8 eBPF-centered / 0 pure Agent-centered / 2 adjacent systems**, not `7 / 0 / 3`.
+
+The active series is **GPU and Heterogeneous Runtime Systems**. An eBPF-centered report today would worsen the newest-ten mix to `9 / 0 / 1`, so the selected report is honestly classified as adjacent systems. Because it displaces an older adjacent GPU report, the post-publication mix remains **8 / 0 / 2**. This is one eBPF report above the normal 5–7 band. It cannot be repaired in one run without misclassification or violating the exactly-one-report rule. One more genuinely adjacent report in the next run would rotate an older eBPF report out and naturally restore **7 / 0 / 3**.
+
+Candidate directions reviewed inside the active series included device-side programmability, fine-grained GPU execution observability, and GPU memory placement/movement semantics. Fine-grained profiling risked repeating the two August 20 launch-latency and host/device-causality reports. Device-side programmability remains promising but had a less discriminating evidence gap for this run. Memory placement passed the thesis/gap gate because recent systems independently add different kinds of evidence to overcome the same fault-only decision boundary, while no common evidence-to-placement contract exists.
+
+### Daily Report publication
+
+- English: `/research/gpu-memory-placement-evidence/`
+- Chinese: `/zh/research/gpu-memory-placement-evidence/`
+- Classification: **adjacent systems**
+- Series: **GPU and Heterogeneous Runtime Systems**, first substantial post-activation report
+- Research question: what evidence a GPU runtime should expose and preserve so that migration, eviction, prefetch, remote access, and replication decisions remain explainable and testable under memory oversubscription.
+
+The report develops three mechanisms:
+
+1. evidence-carrying placement decisions with region generations, evidence age/coverage, pressure state, policy generation, and confidence;
+2. placement intent with observable compliance and explicit degraded-state reporting rather than assuming best-effort hints were satisfied;
+3. a counterexample benchmark that progressively reveals fault, sampled-access, object/phase, and scheduling evidence while measuring decision regret under fixed memory, link, and observability budgets.
+
+### Series continuity and operating-state repair
+
+`status.md` and `plan.md` were refreshed from verified PR #178 closeout facts and the current Drive/site evidence. The stale rolling-mix arithmetic was corrected without changing any report classification. `block.md` now records the `2026-08-29` Drive freshness check. `content-series.md` is updated in this same daily branch so the GPU series, report progress, and corrected `8 / 0 / 2` rolling state remain authoritative for the next run.
+
+## Validation and self-review
+
+- Repository-authoritative PR CI: pending after branch publication.
+- Complete pull-request diff self-review: pending after final branch state.
+- Generated static output review: pending repository workflow.
+- Exactly one new Daily Report topic is added in English and Chinese; no second report or unrelated SEO implementation change is in scope.
+
+## Delivery
+
+- Change pull request: pending creation from `daily/2026-08-29-gpu-memory-placement-evidence`.
+- Squash merge: pending successful expected CI and final self-review.
+- Exact-squash production deployment: pending.
+- Public EN/ZH verification: pending production deployment.
+- Required merged-PR closeout comment: pending.
+
+## Decisions and follow-ups
+
+- Keep **GPU and Heterogeneous Runtime Systems** active.
+- Prefer another genuinely adjacent GPU/runtime question in the next run so the rolling newest-ten mix can return naturally from `8 / 0 / 2` to `7 / 0 / 3`; do not repair the mix by relabeling eBPF as incidental or publishing an extra report.
+- Recheck Drive freshness on the next run; do not infer missing Search Console rows as zero.
+- Do not attribute aggregate GSC/GA4 movement to a specific page or topic without source-native date-by-page or date-by-query evidence.
+- Keep Cloudflare conclusions unavailable until a supported read-only source is enabled.
+- Preserve the current site SEO baseline unless a later run identifies a concrete observable defect.
+
+Do not paste raw analytics rows, private identifiers, email addresses, tokens, IP addresses, or full API responses into this report.

--- a/.github/seo-data/daily/2026-08-29.md
+++ b/.github/seo-data/daily/2026-08-29.md
@@ -70,7 +70,7 @@ The pinned `.github/seo-skills` commit remains `516e9e2dcf012506a677a749049d64c5
 
 A direct recount of the actually published Daily Report index corrected a stale operating-state arithmetic error. Before today's publication, the newest ten reports are **8 eBPF-centered / 0 pure Agent-centered / 2 adjacent systems**, not `7 / 0 / 3`.
 
-The active series is **GPU and Heterogeneous Runtime Systems**. An eBPF-centered report today would worsen the newest-ten mix to `9 / 0 / 1`, so the selected report is honestly classified as adjacent systems. Because it displaces an older adjacent GPU report, the post-publication mix remains **8 / 0 / 2**. This is one eBPF report above the normal 5–7 band. It cannot be repaired in one run without misclassification or violating the exactly-one-report rule. One more genuinely adjacent report in the next run would rotate an older eBPF report out and naturally restore **7 / 0 / 3**.
+The active series is **GPU and Heterogeneous Runtime Systems**. An eBPF-centered report today would worsen the newest-ten mix to `9 / 0 / 1`, so the selected report is honestly classified as adjacent systems. Because it displaces one of the two August 20 adjacent GPU reports, the post-publication mix remains **8 / 0 / 2**. This is one eBPF report above the normal 5–7 band and cannot be repaired in this run without misclassification or violating the exactly-one-report rule. An adjacent report on the next run would displace the remaining August 20 adjacent report and still leave **8 / 0 / 2**. Two additional adjacent reports after today are therefore needed to restore **7 / 0 / 3**: the first keeps **8 / 0 / 2**, while the second rotates the August 21 eBPF report out. Prefer that sequence only when both questions independently pass the normal evidence and quality gates.
 
 Candidate directions reviewed inside the active series included device-side programmability, fine-grained GPU execution observability, and GPU memory placement/movement semantics. Fine-grained profiling risked repeating the two August 20 launch-latency and host/device-causality reports. Device-side programmability remains promising but had a less discriminating evidence gap for this run. Memory placement passed the thesis/gap gate because recent systems independently add different kinds of evidence to overcome the same fault-only decision boundary, while no common evidence-to-placement contract exists.
 
@@ -94,14 +94,14 @@ The report develops three mechanisms:
 
 ## Validation and self-review
 
-- Repository-authoritative PR CI: pending after branch publication.
+- Repository-authoritative PR CI: pending after final branch publication.
 - Complete pull-request diff self-review: pending after final branch state.
 - Generated static output review: pending repository workflow.
 - Exactly one new Daily Report topic is added in English and Chinese; no second report or unrelated SEO implementation change is in scope.
 
 ## Delivery
 
-- Change pull request: pending creation from `daily/2026-08-29-gpu-memory-placement-evidence`.
+- Change pull request: `#179`, from `daily/2026-08-29-gpu-memory-placement-evidence`.
 - Squash merge: pending successful expected CI and final self-review.
 - Exact-squash production deployment: pending.
 - Public EN/ZH verification: pending production deployment.
@@ -110,7 +110,7 @@ The report develops three mechanisms:
 ## Decisions and follow-ups
 
 - Keep **GPU and Heterogeneous Runtime Systems** active.
-- Prefer another genuinely adjacent GPU/runtime question in the next run so the rolling newest-ten mix can return naturally from `8 / 0 / 2` to `7 / 0 / 3`; do not repair the mix by relabeling eBPF as incidental or publishing an extra report.
+- Prefer genuinely adjacent GPU/runtime questions over the next two normal runs when they independently pass the quality gates. The first would leave the newest-ten window at `8 / 0 / 2`; the second would rotate the August 21 eBPF report out and restore `7 / 0 / 3`. Do not repair the ratio by relabeling eBPF as incidental or publishing an extra report.
 - Recheck Drive freshness on the next run; do not infer missing Search Console rows as zero.
 - Do not attribute aggregate GSC/GA4 movement to a specific page or topic without source-native date-by-page or date-by-query evidence.
 - Keep Cloudflare conclusions unavailable until a supported read-only source is enabled.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -75,13 +75,16 @@ priorities that can guide a later daily run belong below.
    archive. A direct recount on `2026-08-29` corrected the stale `7 / 0 / 3`
    record: before today's publication the newest ten are **8 eBPF-centered / 0
    pure Agent / 2 adjacent systems**. Today's GPU memory-placement report is
-   adjacent systems and displaces an older adjacent GPU report, so the newest ten
-   remain **8 / 0 / 2**. This is one eBPF report above the target band and cannot
-   be repaired honestly in one run without misclassifying a report or publishing
-   more than the required one report. Prefer another genuinely adjacent GPU
-   systems question next; when today's report is followed by one adjacent report,
-   the rolling window naturally returns to **7 / 0 / 3** as an older eBPF report
-   rotates out.
+   adjacent systems and displaces one of the two `2026-08-20` adjacent GPU
+   reports, so the newest ten remain **8 / 0 / 2**. This is one eBPF report above
+   the target band and cannot be repaired honestly in one run without
+   misclassifying a report or publishing more than the required one report. An
+   adjacent report on the next normal run would displace the remaining August 20
+   adjacent report and still leave **8 / 0 / 2**; a second consecutive adjacent
+   report after that would displace the August 21 eBPF report and restore **7 / 0
+   / 3**. Prefer genuinely adjacent GPU/runtime questions over the next two
+   normal runs when the quality gates permit; never repair the ratio through
+   classification.
 2. Treat **eBPF Networking and Security** as complete at its normal six-report
    boundary after the `2026-08-28` proxy handoff report. The series covers
    multi-owner policy composition, zero-copy buffer ownership, temporal state

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -72,22 +72,33 @@ priorities that can guide a later daily run belong below.
 ## Current priorities
 
 1. Preserve the rolling ten-report mix mechanically from the actually published
-   archive. Before and after the `2026-08-28` report, the newest ten remain **7
-   eBPF-centered / 0 pure Agent / 3 adjacent systems** because the incoming
-   eBPF-centered proxy-identity report ages another eBPF-centered report out.
+   archive. A direct recount on `2026-08-29` corrected the stale `7 / 0 / 3`
+   record: before today's publication the newest ten are **8 eBPF-centered / 0
+   pure Agent / 2 adjacent systems**. Today's GPU memory-placement report is
+   adjacent systems and displaces an older adjacent GPU report, so the newest ten
+   remain **8 / 0 / 2**. This is one eBPF report above the target band and cannot
+   be repaired honestly in one run without misclassifying a report or publishing
+   more than the required one report. Prefer another genuinely adjacent GPU
+   systems question next; when today's report is followed by one adjacent report,
+   the rolling window naturally returns to **7 / 0 / 3** as an older eBPF report
+   rotates out.
 2. Treat **eBPF Networking and Security** as complete at its normal six-report
-   boundary after the `2026-08-28` proxy handoff report. The series now covers
+   boundary after the `2026-08-28` proxy handoff report. The series covers
    multi-owner policy composition, zero-copy buffer ownership, temporal state
    correctness, revocation bounds, complete mediation across offload, and
    request/policy identity across an L7 proxy semantic boundary.
-3. Make the already queued **GPU and Heterogeneous Runtime Systems** roadmap the
-   next active normal series after the August 28 publication. Start with questions
-   where host/device runtime boundaries expose a concrete missing abstraction or
-   correctness guarantee. Count a report as eBPF-centered only when eBPF or an
-   eBPF-like runtime is central to the mechanism; otherwise classify it as
-   adjacent systems.
+3. Treat **GPU and Heterogeneous Runtime Systems** as the active normal series.
+   The `2026-08-29` report starts the post-activation sequence with GPU memory
+   placement under oversubscription: it compares page faults, sampled resident
+   access, object/phase semantics, and scheduling knowledge, then develops
+   evidence-carrying placement decisions, observable placement-intent compliance,
+   and a fixed-budget decision-regret benchmark. It is adjacent systems because
+   eBPF is not required by the central mechanism. Continue with distinct runtime,
+   fine-grained execution-observability, device-side programmability, or
+   distributed-GPU invariants rather than repeating the August 20 launch-latency
+   and host/device-causality reports.
 4. Use all verified weekly Search Console and GA4 Drive export sets in every run.
-   The configured folder was directly reverified on `2026-08-28`; the newest set
+   The configured folder was directly reverified on `2026-08-29`; the newest set
    remains `2026-08-17..23` and no later weekly set was observed.
 5. Treat the `2026-08-17..23` GA4 aggregate as finalized: 984 organic
    landing-page sessions at about 49.29% session-weighted engagement versus 970

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -9,48 +9,58 @@
 - Verified raw Google export window: through `2026-08-23`
 - Search Console verified latest finalized row: `2026-08-22`; `2026-08-23` is absent
 - Latest finalized GA4 weekly organic landing-page aggregate: `2026-08-17` through `2026-08-23`
-- Latest completed daily record before the current run: `2026-08-27`
-- Last completed Daily Report pull request: `#177`
-- Last verified Daily Report squash commit: `009d8c058bc5013c7ef41bcbcb71ce91868c95bc`
-- Last verified production publication from a Daily Report run: static export commit `3eac9b9cd9e6296693c3a8083d9c0bae35aaa6a3`
-- Current daily branch: `daily/2026-08-28-ebpf-l7-policy-identity`
+- Latest completed daily record before the current run: `2026-08-28`
+- Last completed Daily Report pull request: `#178`
+- Last verified Daily Report squash commit: `201133f68661952596fa5489c621d08ffce685da`
+- Last verified production publication from a Daily Report run: static export commit `8a470b4c4510ae09397112335d4d7a94781e6af4`
+- Current daily branch: `daily/2026-08-29-gpu-memory-placement-evidence`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#177` is fully closed out. It squash-merged as
-`009d8c058bc5013c7ef41bcbcb71ce91868c95bc`; exact-merge `Validate SEO Operations`
-run `33091574557` and `Deploy Static App` run `33091574546` succeeded. Production
-published static export commit `3eac9b9cd9e6296693c3a8083d9c0bae35aaa6a3`, whose commit message binds the
-export to that squash SHA. Exact EN/ZH production artifacts and sitemap entries
-were verified, and PR `#177` has exactly one merged-PR closeout comment.
+PR `#178` is fully closed out. It squash-merged as
+`201133f68661952596fa5489c621d08ffce685da`; exact-merge `Validate SEO Operations`
+run `33189308226` and `Deploy Static App` run `33189308343` succeeded. Production
+published static export commit `8a470b4c4510ae09397112335d4d7a94781e6af4`,
+whose commit message binds the export to that squash SHA. Exact EN/ZH production
+artifacts and sitemap entries were verified, and PR `#178` has exactly one
+merged-PR closeout comment.
 
 ## Current Daily Report mix
 
-Before the `2026-08-28` report, the actually published newest ten reports are:
+A direct recount of the actually published Daily Report index on `2026-08-29`
+corrects the stale `7 / 0 / 3` operating record. Before today's report, the newest
+ten are:
 
-- eBPF-centered: **7 of 10**
+- eBPF-centered: **8 of 10**
 - pure Agent-centered: **0 of 10**
-- adjacent systems: **3 of 10**
+- adjacent systems: **2 of 10**
 
-Today's `/research/ebpf-l7-proxy-policy-identity/` report is **eBPF-centered**. It
-asks whether the original principal, policy generation, and authorization
-provenance survive when an eBPF datapath redirects a request through an L7 proxy
-that terminates the downstream connection and emits or reuses a different
-upstream connection. It develops generation-scoped handoff capabilities,
-policy-safe multiplexing, and an authorization-lineage benchmark. The incoming
-report ages another eBPF-centered report out, so the newest ten remain **7 eBPF /
-0 pure Agent / 3 adjacent**.
+Today's `/research/gpu-memory-placement-evidence/` report is **adjacent systems**.
+Its central mechanism is GPU Unified Memory placement under oversubscription: it
+compares demand faults, sampled resident-page activity, object/phase semantics,
+and scheduling knowledge, then develops evidence-carrying placement records,
+placement intent with observable compliance, and a fixed-budget decision-regret
+benchmark. eBPF can contribute instrumentation but is not required by the
+mechanism, so reclassifying the report as eBPF-centered would be inaccurate.
 
-This is the sixth substantial report in **eBPF Networking and Security**, reaching
-the normal series boundary. After this publication, the already queued **GPU and
-Heterogeneous Runtime Systems** roadmap becomes the next active series. Reports
-in that series count as eBPF-centered only when eBPF or an eBPF-like runtime is
-central to the mechanism being evaluated.
+The incoming adjacent report ages an older adjacent GPU report out of the newest
+ten, so after publication the mix remains **8 eBPF / 0 pure Agent / 2 adjacent**.
+This is one eBPF report above the repository target band. A single run cannot
+repair it without publishing more than one report or misclassifying content. The
+next normal run should prefer another genuinely adjacent question in the active
+GPU series; that will naturally rotate an older eBPF report out and return the
+window to **7 / 0 / 3**.
+
+**GPU and Heterogeneous Runtime Systems** is now the active normal series. The
+August 20 GPU launch-latency and host/device-causality reports are useful anchors
+but predate activation. Today's memory-placement report is the first substantial
+post-activation contribution and is intentionally distinct from those profiling
+questions.
 
 ## Current signals
 
-- Google Drive configured evidence: directly reverified `2026-08-28`; the newest source-native weekly set remains `2026-08-17..23`
-- Public homepage: fresh public fetch on `2026-08-28` shows the expected Eunomia identity and Daily Report navigation
-- Public homepage project signal: `9,950+ GitHub stars` badge visible on the live site; used only as a public project signal, not an SEO causal metric
+- Google Drive configured evidence: directly reverified `2026-08-29`; the newest source-native weekly set remains `2026-08-17..23`
+- Fresh automated site brief generated `2026-08-29 13:14 UTC`: homepage `200`, robots `200`, sitemap `200`, and 710 sitemap entries observed
+- Public homepage: current live fetch shows expected Eunomia identity and Daily Report navigation
 - Canonical homepage: `https://eunomia.dev/`
 - Public GitHub repository evidence: available; private repository/account details are not copied into SEO records
 - Public web and primary-source evidence: available
@@ -76,8 +86,11 @@ The finalized GA4 `2026-08-17..23` aggregate remains **984 organic landing-page
 sessions** at about **49.29%** session-weighted engagement, including **118
 `(not set)` sessions**, versus **970 sessions** at about **44.95%** engagement for
 `2026-08-10..16`. Sessions are about **1.4% higher** and engagement about **4.34
-percentage points higher**. The weekly aggregate has no date dimension, so it
-does not support daily or within-week causal attribution.
+percentage points higher**. GPU/CUDA tutorial and profiling pages remain visible
+among meaningful organic landing pages, which supports the technical relevance
+of the active series but does not establish a causal SEO effect. The weekly
+aggregate has no date dimension, so it cannot support daily or within-week causal
+attribution.
 
 ## Current technical baseline
 
@@ -85,30 +98,23 @@ The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
 structured data, legacy redirect stubs, and static audit artifacts. Production
 deploys through `Deploy Static App`.
 
-Fresh live-site inspection and current repository/Google evidence do not establish
-a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect,
-broken-link, rendering, accessibility, performance, or deployment defect that
-requires a separate technical SEO implementation change today.
-
-Current research evidence supports a narrower security gap instead. Cilium's
-current L7/Envoy/Ingress documentation exposes a real proxy handoff with eBPF
-policy lookups and two logical enforcement points; Linux sockmap/sockhash is
-socket-oriented; and L7FP demonstrates a current kernel-fast-path / proxy-slow-path
-split. The selected gap is authorization identity continuity across that semantic
-boundary rather than another path-coverage or placement problem.
+Fresh live-site inspection, the `2026-08-29` automated site brief, and current
+Google evidence do not establish a crawl, robots, sitemap, canonical, hreflang,
+structured-data, redirect, broken-link, rendering, accessibility, performance,
+or deployment defect that justifies a separate technical SEO implementation
+change today. The public web crawler's `/research/` snapshot can lag production;
+that cache is not treated as a site defect or as deployment evidence.
 
 The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Upstream `main` is currently
-`f42128a3f05c73cf10c786a2711c488bb3a14839`, but the consuming repository still
-requires contract migration before a pointer-only update because the generic
-closeout workflow conflicts with this repository's explicit single-PR / single
-merged-PR-comment contract.
+`516e9e2dcf012506a677a749049d64c5914643e9`. The repository still requires a
+contract migration before a pointer-only update to a newer upstream layout, so no
+skill-submodule movement is part of this run.
 
 ## Current focus
 
-1. Complete the `2026-08-28` L7 proxy policy-identity Daily Report through one non-draft PR, expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. After this sixth Networking and Security report, make **GPU and Heterogeneous Runtime Systems** the active normal series; keep actual report classification evidence-based and the rolling mix within 5–7 eBPF / at most 1–2 pure Agent per ten.
-3. Recheck Drive freshness every run; no weekly set newer than `2026-08-17..23` was observed on `2026-08-28`.
+1. Complete the `2026-08-29` GPU memory-placement Daily Report through one non-draft PR, expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
+2. Keep **GPU and Heterogeneous Runtime Systems** active. Prefer another genuinely adjacent GPU systems question next so the rolling newest-ten window returns from `8 / 0 / 2` to the target-compatible `7 / 0 / 3` without dishonest classification.
+3. Recheck Drive freshness every run; no weekly set newer than `2026-08-17..23` was observed on `2026-08-29`.
 4. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never fill missing date rows with zero.
 5. Use date-by-page or date-by-query evidence before attributing aggregate search movement to a page, title, or topic family.
 6. Treat finalized GA4 weekly movement as aggregate behavioral evidence, not a causal content or SEO result.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -42,13 +42,16 @@ placement intent with observable compliance, and a fixed-budget decision-regret
 benchmark. eBPF can contribute instrumentation but is not required by the
 mechanism, so reclassifying the report as eBPF-centered would be inaccurate.
 
-The incoming adjacent report ages an older adjacent GPU report out of the newest
-ten, so after publication the mix remains **8 eBPF / 0 pure Agent / 2 adjacent**.
-This is one eBPF report above the repository target band. A single run cannot
-repair it without publishing more than one report or misclassifying content. The
-next normal run should prefer another genuinely adjacent question in the active
-GPU series; that will naturally rotate an older eBPF report out and return the
-window to **7 / 0 / 3**.
+The incoming adjacent report displaces one of the two August 20 adjacent GPU
+reports, so after publication the mix remains **8 eBPF / 0 pure Agent / 2
+adjacent**. This is one eBPF report above the repository target band. A single run
+cannot repair it without publishing more than one report or misclassifying
+content. An adjacent report on the next normal run would displace the remaining
+August 20 adjacent report and still leave **8 / 0 / 2**; a second consecutive
+adjacent report after that would displace the August 21 eBPF report and restore
+**7 / 0 / 3**. Prefer genuinely adjacent GPU/runtime questions over the next two
+normal runs when the quality gates permit; do not repair the ratio through
+classification.
 
 **GPU and Heterogeneous Runtime Systems** is now the active normal series. The
 August 20 GPU launch-latency and host/device-causality reports are useful anchors
@@ -113,7 +116,7 @@ skill-submodule movement is part of this run.
 ## Current focus
 
 1. Complete the `2026-08-29` GPU memory-placement Daily Report through one non-draft PR, expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and one merged-PR closeout comment.
-2. Keep **GPU and Heterogeneous Runtime Systems** active. Prefer another genuinely adjacent GPU systems question next so the rolling newest-ten window returns from `8 / 0 / 2` to the target-compatible `7 / 0 / 3` without dishonest classification.
+2. Keep **GPU and Heterogeneous Runtime Systems** active. Prefer genuinely adjacent GPU/runtime questions over the next two normal runs when they pass the quality gates: the first would leave the newest-ten mix at `8 / 0 / 2`, while the second would rotate the August 21 eBPF report out and restore the target-compatible `7 / 0 / 3` without dishonest classification.
 3. Recheck Drive freshness every run; no weekly set newer than `2026-08-17..23` was observed on `2026-08-29`.
 4. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them; never fill missing date rows with zero.
 5. Use date-by-page or date-by-query evidence before attributing aggregate search movement to a page, title, or topic family.

--- a/docs/research/gpu-memory-placement-evidence.md
+++ b/docs/research/gpu-memory-placement-evidence.md
@@ -1,0 +1,210 @@
+---
+date: 2026-08-29
+title: "Can a GPU Runtime Place Memory Well With Only Page Faults?"
+description: "GPU memory oversubscription turns page placement into a policy problem. This report asks what evidence a runtime needs before migrating or evicting UVM pages."
+tags:
+  - Daily Report
+  - GPU
+  - Unified Memory
+  - Memory Management
+  - Runtime
+research_question: "What evidence should a GPU runtime expose and preserve so that memory migration, prefetch, eviction, and remote-access decisions remain explainable and testable under memory oversubscription?"
+source_cutoff: 2026-08-29
+status: daily-report
+---
+
+# Can a GPU Runtime Place Memory Well With Only Page Faults?
+
+Suppose two GPU jobs together touch 120 GB of data on a GPU with 80 GB of HBM. Unified memory lets both jobs keep one virtual address space even though some pages must live in host DRAM. Eventually a kernel touches a page that is not in HBM, the GPU faults, and the runtime has to make room.
+
+The fault answers one question: this page was needed and was not resident here. It does not answer the harder questions. Which resident page should leave? Is the faulting page worth migrating, or should the GPU access it remotely? Will the evicted page be needed again in 200 microseconds? Is the current access part of a short phase, a repeatedly reused tensor, or a task that is about to be descheduled?
+
+Those questions decide whether oversubscription costs a few transfers or collapses into migration thrashing. Recent GPU memory systems increasingly answer them with more evidence than faults alone: sampled HBM access activity, compiler-derived object semantics, application-object phases, or future scheduling information. The common problem is no longer simply how to move a page. It is how the runtime knows enough to justify a placement decision.
+
+<!-- more -->
+
+This report argues for an **evidence-carrying GPU memory placement contract**. A runtime should preserve which observations caused a migration, prefetch, eviction, replication, or remote-access decision; how current those observations are; and which stronger application or scheduler intent the decision is trying to satisfy. That would make placement policies comparable across different observability mechanisms instead of treating every policy as a private driver heuristic.
+
+This is an adjacent-systems report, not an eBPF-centered report. eBPF-like instrumentation could help collect host-side or runtime evidence, and [bpftime's GPU work](https://eunomia.dev/bpftime/documents/gpu/) is relevant to programmable instrumentation, but the core problem exists independently of eBPF.
+
+## Unified memory already separates addressability from residency
+
+CUDA Unified Memory gives CPU and GPU code a common addressable allocation while the runtime manages where backing pages reside. The current [CUDA Programming Guide](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html) is explicit that `cudaMemAdviseSetPreferredLocation` is a performance hint, not a residency guarantee. `cudaMemPrefetchAsync` may move a region toward a specified processor, and later accesses or other hints may move it again.
+
+The current [CUDA Runtime API](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html) exposes an especially useful warning about policy semantics. A preferred GPU location can override the driver's normal page-thrashing response. Without the preference, repeatedly bouncing pages may eventually be pinned in host memory; with a GPU preferred location, those pages can continue to migrate. The application has expressed intent, but that intent changes the driver's policy rather than creating a hard placement contract.
+
+Linux Heterogeneous Memory Management makes the lower layer equally dynamic. The current [Linux HMM documentation](https://docs.kernel.org/mm/hmm.html) describes migration between system memory and device-private memory using `migrate_vma_*()`. The driver chooses which pages actually migrate, updates device mappings, and handles races where individual pages fail or lose the migration race. A virtual range can therefore remain valid while the physical placement of its pages changes over time.
+
+AMD exposes a similar model. [HIP managed memory](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html) can migrate pages between host and device when HMM and recoverable page faults are available. The exact capabilities depend on GPU architecture, kernel support, and XNACK configuration.
+
+Across these interfaces, addressability is portable in a way residency is not. The application can often keep using the same pointer, while the runtime keeps making placement decisions underneath it.
+
+## Recent systems keep adding evidence because faults are too weak
+
+A page fault is excellent evidence of immediate demand. It is poor evidence of future reuse.
+
+The 2026 ISCA paper [Observability-aided GPU Memory Oversubscription](https://www.csa.iisc.ac.in/~arkapravab/papers/ISCA26_ObservUVM.pdf) shows the consequence inside NVIDIA UVM. The CPU-side driver sees faults for pages outside HBM but normally cannot directly observe accesses to pages that are already resident in HBM. Its default eviction order is therefore based on migration recency, which can evict a page that is still actively used. The paper repurposes hardware access counters to sample activity in HBM-resident regions and builds ObservUVM, which moves eviction and prefetch policies into userspace. Across fourteen applications, its evaluated observability-aided policies report a 34% geometric-mean speedup over the UVM baseline.
+
+That result is useful for a reason beyond the speedup. The extra information changes which page should be evicted. The fault stream itself did not contain that information.
+
+Other systems add different evidence. [SUV](https://www.csa.iisc.ac.in/~arkapravab/papers/MICRO24_SUV.pdf), published at MICRO 2024, uses compiler-inferred access semantics plus runtime information to decide which objects or object regions deserve scarce HBM and when to prefetch them. [OASIS](https://yueqiwang42.github.io/assets/pdf/papers/OASIS_HPCA25.pdf), from HPCA 2025, observes that one placement policy is not best for every object or every phase of the same object in a multi-GPU program, and uses object-aware runtime behavior to choose among migration and duplication strategies.
+
+The 2026 HPCA paper [ARIADNE](https://doi.org/10.1109/HPCA68181.2026.11408564) stays inside the UVM abstraction but derives a runtime sharing-degree signal, pipelines fault handling, and dynamically chooses between GPU memory and zero-copy placement. Its [artifact](https://zenodo.org/records/17830000) makes the driver-level implementation available for reproduction.
+
+A different direction appears in [MSched](https://arxiv.org/abs/2512.24637). Instead of treating each fault as an isolated surprise, MSched couples GPU task scheduling with memory management. Kernel launch information and a known scheduling timeline let it predict working sets and prepare memory before a context switch. Its reported gains over demand paging become very large under the evaluated multi-task oversubscription workloads.
+
+These systems disagree on the best source of knowledge, but they agree on the underlying diagnosis: immediate faults are not enough. Placement improves when the runtime knows something about resident-page activity, object meaning, execution phase, or future demand.
+
+The site's earlier report on [page-level eBPF memory attribution](https://eunomia.dev/research/page-level-ebpf-memory-attribution/) asked how to connect memory cost back to the application object that caused it. The problem here is different. Even if attribution is perfect, the GPU memory manager still needs to decide what should remain in HBM next.
+
+## Observability itself has a cost and a failure mode
+
+More evidence is not automatically better. ObservUVM deliberately samples because tracking every HBM access at full bandwidth is impractical. NVIDIA [Nsight Systems](https://docs.nvidia.com/nsight-systems/UserGuide/index.html) can record Unified Memory CPU and GPU page faults, but its documentation warns that collecting those fault traces can add up to 70% overhead in testing.
+
+Static information has a different failure mode. Compiler-derived access patterns can be precise for code the compiler understands, but closed-source libraries, data-dependent indexing, and runtime phase changes can invalidate the prediction. Object-level policies improve semantics but need stable object identity across allocators and libraries. Scheduler knowledge is powerful in a controlled multitasking runtime but weaker when kernels arrive from independent processes or external services.
+
+So the design problem is not "collect every signal." A production runtime needs to know which signal supports which decision, and when that signal is stale, sampled, missing, or contradicted by another source.
+
+## Where current work is still weak
+
+### Placement evidence has no common semantics
+
+A GPU fault says that an address was demanded while non-resident. An access-counter notification says that a sampled region crossed an activity threshold. Static analysis predicts future accesses from code structure. Object-aware systems attach behavior to a logical allocation. A task scheduler can expose when a process is likely to run again.
+
+All of these can influence the same eviction decision, but they do not share a common evidence model. That makes it difficult to compare policies or to combine them without hard-coding one system's assumptions into another.
+
+A material test is to present several policies with the same workload and the same fixed observability budget, then ask whether they can explain each migration in terms of evidence available before the decision. If two policies report the same throughput but one repeatedly acts on stale or contradictory evidence, the difference should be visible.
+
+### Placement hints do not expose whether the runtime satisfied the intent
+
+CUDA intentionally defines memory advice as hints. That preserves implementation freedom, but it also leaves a control-plane gap for production systems. An application can request a preferred location or issue a prefetch, yet there is no portable service-level object saying "this 8 GB region should stay GPU-resident through this inference phase unless pressure exceeds X, and if that cannot be honored, report why."
+
+The missing capability is not a stronger version of `cudaMemAdvise` for every application. It is an optional contract above vendor hints that records desired placement, allowed degradation, and the runtime's observed compliance.
+
+The test is a workload with two classes of data, one latency-sensitive and one spillable, under controlled pressure. A contract-aware runtime should preserve the requested priority or explicitly report that it could not. A hint-only baseline may silently violate it.
+
+### Policy evaluation rarely measures decision quality directly
+
+Most GPU memory papers reasonably optimize application runtime, page-fault count, migration traffic, or throughput. Those metrics do not tell us whether a policy made good decisions for the right reason.
+
+A policy can get lucky on one access pattern. It can also reduce faults by over-prefetching and spend extra PCIe bandwidth that becomes harmful when another workload shares the link. A shared benchmark needs ground truth for future reuse and a fixed evidence budget so it can measure decision regret, not only final runtime.
+
+### Cross-vendor portability stops at the point where policy needs meaning
+
+CUDA UVM, HIP managed memory, and Linux HMM all support forms of shared addressing and migration, but their hardware signals, fault behavior, coherence options, and policy hooks differ. A portable runtime cannot simply rename vendor events and assume they mean the same thing.
+
+The useful abstraction is therefore not one universal eviction algorithm. It is a small vocabulary for evidence, placement intent, action, and uncertainty, with adapters that preserve vendor-specific facts rather than erasing them.
+
+## Promising directions with academic and production value
+
+### 1. Evidence-carrying placement decisions
+
+**Gap.** Current memory managers can use faults, access sampling, object semantics, or scheduling predictions, but the reason for an individual placement action is usually buried inside one driver or policy implementation.
+
+**Mechanism.** Give every managed virtual region a lifetime-scoped region ID and generation. Whenever the runtime changes placement, emit a compact decision record:
+
+```text
+region_generation
+virtual_range
+action = migrate | evict | prefetch | remote-map | replicate | keep
+evidence = [fault, sampled_access, object_phase, kernel_prediction, schedule]
+evidence_age
+coverage_or_sampling_rate
+pressure_state
+policy_generation
+confidence
+```
+
+The record does not claim that every signal is equally strong. A fault can be exact about one access while a sampled-access estimate is probabilistic. A scheduler prediction can expire. A compiler claim can identify a region but miss data-dependent accesses. The schema preserves those distinctions.
+
+For high-frequency decisions, the driver can aggregate records by policy generation and retain exemplars for surprising or high-cost migrations. Operators can then ask why a page moved without enabling full memory-access tracing.
+
+**Delta from related work.** ObservUVM separates mechanism from policy and supplies sampled access evidence. SUV, OASIS, and MSched each add richer semantics. The proposed layer standardizes the evidence-to-decision boundary rather than proposing another eviction heuristic.
+
+**Artifact.** A trace schema, CUDA/HIP/HMM adapters, and a query tool that reconstructs `why-moved <region>` from placement decisions. The existing [bpftime GPU runtime work](https://github.com/eunomia-bpf/bpftime) could consume such records for experimentation, but the schema should remain independent of bpftime.
+
+**Evaluation.** Run oversubscribed scientific kernels, graph workloads, DNN inference, LLM inference, and mixed multi-process workloads. Compare UVM fault-only traces, sampled-access policies, compiler/object-informed policies, and schedule-aware policies. Measure record overhead, unexplained decisions, stale-evidence rate, and whether postmortem queries identify the actual reason for migrations.
+
+**Academic value.** This turns the boundary between GPU memory observability and placement policy into an explicit object that can be compared across mechanisms.
+
+**Production value.** A runtime or cloud operator can distinguish "the application exceeded HBM" from "the policy evicted a still-hot region" without collecting every memory access.
+
+**Failure condition.** If decision records do not improve diagnosis or policy comparison beyond existing fault and migration traces, the extra metadata is not worth retaining.
+
+### 2. Placement intent with observable compliance
+
+**Gap.** Existing advice APIs express useful preferences, but a higher-level scheduler cannot tell whether the runtime honored an application's phase-specific memory priority.
+
+**Mechanism.** Add an optional runtime object above vendor-specific advice. A region generation can declare:
+
+- preferred residence set, such as GPU 0 HBM or host DRAM;
+- access modes that may use remote mapping instead of migration;
+- a migration deadline or phase boundary;
+- eviction priority relative to other region generations;
+- maximum tolerated remote-access or migration budget;
+- an expiry condition tied to a kernel, graph, request, or scheduler epoch.
+
+The memory manager maps this intent onto CUDA advice, HIP advice, HMM migration, or its own policy. If the request cannot be satisfied because of capacity, topology, coherence, or another higher-priority region, the runtime records a degraded state and reason rather than pretending the hint succeeded.
+
+The important detail is generation. A tensor buffer or virtual range may be reused for a different phase. Old placement intent must expire with the logical lifetime instead of sticking to an address forever.
+
+**Delta from related work.** CUDA and HIP already expose placement and prefetch hints; MSched adds scheduling knowledge; OASIS attaches policy to objects and phases. The proposed contract makes the requested outcome and observed compliance explicit across these mechanisms.
+
+**Artifact.** A userspace controller and small region-intent API implemented first on NVIDIA UVM, with a HIP/HMM compatibility prototype. The controller would expose both best-effort hints and a stronger "report degradation" mode without requiring a new correctness guarantee from existing hardware.
+
+**Evaluation.** Use paired regions with different latency sensitivity under 110%, 150%, and 250% HBM subscription. Include multi-GPU peer access, CPU-GPU ping-pong, phase changes, and concurrent jobs. Measure intent satisfaction, migration bytes, remote-access bytes, tail kernel delay, throughput, and control overhead against plain UVM and static advice.
+
+**Academic value.** The research question is whether memory placement can be treated as an explicit resource contract rather than an invisible side effect of faults.
+
+**Production value.** Inference and training runtimes can express that a KV-cache working set, communication buffer, or imminent batch deserves HBM more than cold model state, while still receiving a truthful failure signal under pressure.
+
+**Failure condition.** If simple static advice achieves the same tail latency and migration cost across phase-changing and multi-tenant workloads, the extra contract is unnecessary.
+
+### 3. A counterexample benchmark for GPU placement evidence
+
+**Gap.** Existing evaluations make performance differences visible but rarely force two policies to make a decision from deliberately ambiguous evidence.
+
+**Mechanism.** Build workload pairs that preserve one observable signal while changing the correct placement action:
+
+| Pair | Signal held similar | Hidden fact that changes the best action |
+| --- | --- | --- |
+| repeated faults | fault stream | one page is reused next, the other is dead |
+| equal access counts | sampled hotness | one region's accesses are imminent, the other's are far in the future |
+| same allocation size | object metadata | one phase touches 5%, another touches 95% |
+| same current residency | HBM state | one task is about to be scheduled out |
+| same preferred location | advice | one job has a strict latency budget, the other is spillable |
+
+The harness knows future references and task order, so it can compute an oracle placement under the same HBM and PCIe constraints. It then reveals evidence incrementally: fault-only, sampled access, object/phase semantics, then scheduler knowledge.
+
+**Delta from related work.** ARIADNE, ObservUVM, SUV, OASIS, and MSched demonstrate useful policy mechanisms. The benchmark isolates the marginal value of each evidence class and makes hidden assumptions fail on purpose.
+
+**Artifact.** An open trace corpus, replayable oversubscription workloads, oracle solver, and evaluator. The harness should support NVIDIA UVM first and preserve a vendor-neutral trace format so HIP/HMM experiments can be added later.
+
+**Evaluation.** Primary metrics are application runtime, fault stall time, migration and remote-access bytes, useful-prefetch ratio, decision regret versus the oracle, false-confidence rate, and observability overhead. Every policy receives the same memory, link, and evidence budget.
+
+**Academic value.** The benchmark asks a general systems question: how much extra information is required before an online resource manager can make a materially better placement decision?
+
+**Production value.** Runtime developers can choose whether an extra profiler, compiler analysis, or scheduler integration earns its complexity on their workload instead of adopting it because a paper reports a speedup elsewhere.
+
+**Failure condition.** If additional evidence barely reduces regret or end-to-end cost over a fault-only policy, simpler UVM behavior should remain the default.
+
+## What would change this conclusion?
+
+The evidence today supports a narrow conclusion: GPU memory placement under oversubscription benefits from information that a demand fault alone cannot provide, and recent systems obtain that information from several incompatible layers. It does not prove that one universal placement policy or one universal signal should replace vendor UVM heuristics.
+
+Three results would weaken the case for an evidence-carrying contract. First, a broad reproduction could show that modern default UVM already approaches the best specialized policies once current drivers and hardware are used. Second, sampled HBM observability, compiler semantics, and scheduler knowledge might improve disjoint workload classes so rarely that a common contract has little practical reuse. Third, the metadata and control path needed to expose decisions could cost more than the migrations it helps avoid.
+
+The strongest next experiment is therefore not another isolated eviction heuristic. It is a fixed-budget comparison where the same placement controller receives progressively richer evidence and the benchmark measures how often that extra evidence changes a decision that matters.
+
+## References
+
+- NVIDIA. [CUDA Programming Guide: Unified Memory](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html), CUDA 13.x documentation, accessed 2026-08-29.
+- NVIDIA. [CUDA Runtime API: Memory Management](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html), accessed 2026-08-29.
+- NVIDIA. [Nsight Systems User Guide](https://docs.nvidia.com/nsight-systems/UserGuide/index.html), Unified Memory page-fault tracing, accessed 2026-08-29.
+- Linux kernel documentation. [Heterogeneous Memory Management](https://docs.kernel.org/mm/hmm.html), accessed 2026-08-29.
+- AMD. [HIP Unified Memory Management](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html), accessed 2026-08-29.
+- Pratheek B, Khushit Shah, Arkaprava Basu. [Observability-aided GPU Memory Oversubscription](https://www.csa.iisc.ac.in/~arkapravab/papers/ISCA26_ObservUVM.pdf). ISCA 2026.
+- Hyunkyun Shin, Seongtae Bang, Hyungwon Park, Daehoon Kim. [ARIADNE: Adaptive UVM Management for Efficient GPU Memory Oversubscription](https://doi.org/10.1109/HPCA68181.2026.11408564). HPCA 2026. [Artifact](https://zenodo.org/records/17830000).
+- Yueqi Wang et al. [OASIS: Object-Aware Page Management for Multi-GPU Systems](https://yueqiwang42.github.io/assets/pdf/papers/OASIS_HPCA25.pdf). HPCA 2025.
+- Pratheek B, Guilherme Cox, Jan Vesely, Arkaprava Basu. [SUV: Static Analysis Guided Unified Virtual Memory](https://www.csa.iisc.ac.in/~arkapravab/papers/MICRO24_SUV.pdf). MICRO 2024.
+- Weihang Shen, Yinqiu Chen, Rong Chen, Haibo Chen. [MSched: GPU Multitasking via Proactive Memory Scheduling](https://arxiv.org/abs/2512.24637). arXiv:2512.24637, 2026.

--- a/docs/research/gpu-memory-placement-evidence.zh.md
+++ b/docs/research/gpu-memory-placement-evidence.zh.md
@@ -1,0 +1,210 @@
+---
+date: 2026-08-29
+title: "GPU 运行时只看页故障，能把内存放对地方吗？"
+description: "GPU 显存超配会把页面放置变成持续变化的运行时决策。本文分析页故障、访问采样、对象语义和调度信息各能证明什么，并提出可验证的内存放置证据契约。"
+tags:
+  - Daily Report
+  - GPU
+  - Unified Memory
+  - Memory Management
+  - Runtime
+research_question: "GPU 运行时需要暴露并保留哪些证据，才能让显存超配下的迁移、预取、驱逐和远程访问决策可解释、可比较并可验证？"
+source_cutoff: 2026-08-29
+status: daily-report
+---
+
+# GPU 运行时只看页故障，能把内存放对地方吗？
+
+假设两个 GPU 任务合起来会访问 120 GB 数据，而 GPU 只有 80 GB HBM。Unified Memory 让两个任务继续使用统一虚拟地址，不要求应用自己把所有数据切成 host 和 device 两套；代价是总有一部分页面必须留在 host DRAM。某个 kernel 最终访问了一个不在 HBM 的页面，于是 GPU 触发页故障，运行时还得先腾出空间。
+
+这个 fault 只能确定一件事：当前确实需要这个页面，而且它此刻不在这里。它回答不了后面的决策。应该驱逐哪一个 HBM 页面？新页面值得真的迁进来，还是让 GPU 远程访问更划算？被赶走的页面会不会 200 微秒后马上又被用到？当前访问只是一次短暂 phase，还是一个会被反复读取的 tensor？正在运行的任务是不是马上就会被切走？
+
+这些信息决定了 oversubscription 最后只是多几次传输，还是演变成持续的 page thrashing。近两年的 GPU memory systems 也越来越少只靠 fault 做判断：有的增加 HBM access sampling，有的利用 compiler 推断出的对象访问语义，有的跟踪 object/phase，还有的直接把 GPU scheduling timeline 交给 memory manager。真正缺的已经不只是“怎么移动一个页面”，而是“运行时凭什么认为这次移动是对的”。
+
+<!-- more -->
+
+本文提出一个 **携带证据的 GPU 内存放置契约（evidence-carrying GPU memory placement contract）**：每次 migration、prefetch、eviction、replication 或 remote access 决策，不只留下动作结果，还保留触发它的观测、这些观测有多新、覆盖了多少，以及它正在满足什么 application 或 scheduler intent。这样不同 memory policy 才能在同一组证据语义上比较，而不是各自把假设藏在 driver 里。
+
+这是一篇 adjacent-systems 报告，不计作 eBPF-centered。eBPF 或类似的可编程 instrumentation 可以补充 host/runtime 侧证据，[bpftime 的 GPU 工作](https://eunomia.dev/bpftime/documents/gpu/)也能作为实验入口，但这里的核心问题并不依赖 eBPF。
+
+## Unified Memory 统一了地址，但没有固定页面住在哪里
+
+CUDA Unified Memory 让 CPU 和 GPU 可以访问同一份 allocation，具体 backing page 由 runtime 决定放在 host 还是 device。当前 [CUDA Programming Guide](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html) 对 `cudaMemAdviseSetPreferredLocation` 的表述很明确：它是 performance hint，不是 residency guarantee。`cudaMemPrefetchAsync` 可以请求把某段数据提前迁到指定 processor 附近，之后新的访问或其他 hint 仍然可能把它移走。
+
+当前 [CUDA Runtime API](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html) 还有一个很值得注意的细节。默认情况下，driver 检测到 host/device 之间持续 thrashing 时，可能最终把页面固定在 host memory；但如果应用把 GPU 设成 preferred location，这个 preference 可以覆盖原来的 thrash resolution，让页面继续来回迁移。也就是说，应用表达的是“倾向”，这个倾向会改变 policy，却没有形成一个“运行时必须满足并反馈结果”的 placement contract。
+
+Linux HMM 的底层也同样是动态的。当前 [Linux HMM 文档](https://docs.kernel.org/mm/hmm.html) 通过 `migrate_vma_*()` 支持 system memory 与 device-private memory 之间迁移。driver 可以决定一个 range 里的哪些 page 实际迁移，还要处理 race、无法迁移的页面以及 device mapping 更新。虚拟地址保持有效，并不意味着这些地址背后的 physical placement 不会变化。
+
+AMD 的 [HIP managed memory](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html) 也提供类似模型。在支持 HMM 和 recoverable page fault 的系统上，页面可以自动在 host 与 device 之间迁移；具体能力取决于 GPU architecture、kernel support 与 XNACK 配置。
+
+这些接口的共同点是：统一 addressability 相对容易，稳定 residency 并不是它们承诺的抽象。应用可以一直拿着同一个 pointer，底层却不断重新做 placement decision。
+
+## 最近的系统为什么都在给 memory manager 增加新证据
+
+Page fault 很适合证明“现在有人要这个页面”，却几乎不包含“接下来谁更值得留在 HBM”这种 future reuse 信息。
+
+ISCA 2026 的 [Observability-aided GPU Memory Oversubscription](https://www.csa.iisc.ac.in/~arkapravab/papers/ISCA26_ObservUVM.pdf) 直接展示了这个缺口。NVIDIA UVM 的 CPU-side driver 能看到访问 DRAM-resident page 产生的 fault，但一个 page 已经迁入 HBM 后，driver 通常没有直接办法继续观察 GPU 对它的访问。因此默认 eviction 顺序更接近“最近何时迁入”，而不是“最近是否真的被使用”，活跃页面也可能被赶走。论文把原本用于 PCIe access tracking 的 hardware access counter 改造成 HBM-resident region 的采样观测，并构建 ObservUVM，把 eviction/prefetch policy 放到 userspace。对 14 个应用的评估中，这组 observability-aided policy 相对 UVM baseline 报告了 34% 的 geometric-mean speedup。
+
+这里最值得记住的并不是 34% 本身，而是额外观测会改变“该赶走谁”的答案。单靠 fault stream 根本没有这部分信息。
+
+其他系统补的是不同层次的证据。MICRO 2024 的 [SUV](https://www.csa.iisc.ac.in/~arkapravab/papers/MICRO24_SUV.pdf) 把 compiler 推断出的 access semantics 与 runtime 信息结合起来，判断哪些 object 或 object region 更值得占用有限 HBM，以及何时应该主动 prefetch。HPCA 2025 的 [OASIS](https://yueqiwang42.github.io/assets/pdf/papers/OASIS_HPCA25.pdf) 进一步发现，同一个 multi-GPU 应用里，不同 object、甚至同一个 object 的不同 phase，最合适的 page-management policy 都可能不同，因此它把对象与 phase 行为带入 migration/duplication 的选择。
+
+HPCA 2026 的 [ARIADNE](https://doi.org/10.1109/HPCA68181.2026.11408564) 仍然保持 UVM 对应用透明的抽象，但在 runtime 里计算 Sharing Degree，pipeline fault handling，并根据实时 access pattern 在 GPU memory 与 zero-copy 之间动态放置 region。它的 [artifact](https://zenodo.org/records/17830000) 也公开了 driver-level 实现。
+
+[MSched](https://arxiv.org/abs/2512.24637) 又走得更远。它不把每个 fault 当成独立的意外，而是让 GPU scheduler 和 memory manager 协同。kernel launch 信息加上已知的 scheduling timeline 可以预测未来 working set，在 task context switch 前主动准备内存。论文在其 multi-task oversubscription workload 上报告了远高于 demand paging 的性能。
+
+这些系统对“最好的证据是什么”没有统一答案，但对问题本身已经很一致：fault 只描述眼前 demand。要把页面放得更好，运行时还得知道 resident page 是否活跃、object 是什么、程序处于哪个 phase，或者接下来哪个 task 会运行。
+
+站内此前的 [page-level eBPF memory attribution](https://eunomia.dev/research/page-level-ebpf-memory-attribution/) 关注的是另一件事：怎样把 page-level cost 重新连回造成它的 application object。即使这个 attribution 已经完全正确，GPU memory manager 仍然要回答下一步哪个页面更应该留在 HBM。
+
+## 更多 observability 本身也有成本
+
+“多收一点信息”并不天然正确。ObservUVM 之所以做 sampling，就是因为在 HBM 的极高带宽下完整跟踪每一次访问不现实。NVIDIA [Nsight Systems](https://docs.nvidia.com/nsight-systems/UserGuide/index.html) 可以采集 Unified Memory CPU/GPU page fault，但文档明确提醒，相关 fault tracing 在测试中可能带来最高 70% 的 overhead。
+
+Static information 有另一类失效方式。compiler 能理解的代码可以给出很精确的 pattern，但 closed-source library、data-dependent indexing 和 runtime phase change 都可能让预测失真。Object-aware policy 需要跨 allocator/library 稳定识别对象。Scheduler knowledge 在受控 multi-task runtime 里很强，但面对来自独立 process 或外部 service 的 work 时未必完整。
+
+所以 production design 不能简单变成“把所有信号都收齐”。真正需要的是让 runtime 知道每一种 evidence 能支持什么结论，以及它什么时候已经 stale、只覆盖 sample、缺失，或者与另一种证据矛盾。
+
+## 现有研究还缺什么
+
+### 不同 placement evidence 没有共同语义
+
+GPU fault 表示某个 address 在 non-resident 状态下被 demand。Access-counter notification 表示一个 sampled region 的 activity 达到了阈值。Static analysis 根据 code structure 预测未来访问。Object-aware system 把行为绑定到 logical allocation。Task scheduler 则可能直接知道一个 process 什么时候会再次拿到 GPU。
+
+这些信息最后都可能影响同一次 eviction，却没有统一的 evidence model。结果是 policy 很难横向比较，也很难组合，除非把某个系统的特定假设直接写进另一个系统。
+
+一个有区分度的实验是：给几种 policy 完全相同的 workload 与 fixed observability budget，然后要求每次 migration 都只能引用“决策发生前已经可见”的证据。如果两个 policy 最终 throughput 一样，但其中一个经常使用过期或互相冲突的 evidence，这个差异应该直接被 benchmark 看见。
+
+### Placement hint 没有告诉上层“意图到底有没有被满足”
+
+CUDA 把 memory advice 定义成 hint 是合理的，它让 driver 保留实现自由。但 production control plane 因此缺了一层。应用可以请求 preferred location，也可以发起 prefetch，却没有一个 portable service-level object 能表达：“这 8 GB region 在这次 inference phase 内优先留在 GPU；除非 memory pressure 超过 X，否则不要驱逐；如果做不到，请明确告诉我原因。”
+
+这里不是要把每个 `cudaMemAdvise` 都升级成硬保证，而是需要一个可选的上层 contract，把 desired placement、允许怎样降级，以及 runtime 实际满足到什么程度记录下来。
+
+测试可以用两类数据做：一类对 tail latency 很敏感，一类可以安全 spill。在固定 memory pressure 下，contract-aware runtime 应该保持这个优先级，或者明确报告无法满足；hint-only baseline 则可能静默地破坏它。
+
+### 现在的 evaluation 很少直接测“这次 decision 做得对不对”
+
+GPU memory paper 通常比较 application runtime、page-fault count、migration traffic 或 throughput，这些指标都合理，但不能说明 policy 是不是因为正确证据做出了正确决定。
+
+一个 policy 可能刚好撞对了某种 access pattern；也可能通过 aggressive prefetch 降低 fault，却把 PCIe bandwidth 用光，在共享链路上伤害另一个 workload。更强的 benchmark 需要知道 future reuse 的 ground truth，还要固定 evidence budget，才能测 decision regret，而不是只看最终 runtime。
+
+### 跨 vendor 的 portability 到 policy 这一层就变得模糊
+
+CUDA UVM、HIP managed memory 和 Linux HMM 都支持某种 shared addressing 与 migration，但它们暴露的 hardware signal、fault 行为、coherence mode 和 policy hook 并不相同。Portable runtime 不能只是把 vendor event 换个名字，就假设语义相同。
+
+因此更合适的抽象不是“全平台统一 eviction algorithm”，而是一小组稳定概念：evidence、placement intent、action 和 uncertainty。具体 adapter 应该保留 vendor-specific fact，而不是把差异抹掉。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 让每一次 placement decision 自带证据
+
+**Gap。** 现在的 memory manager 可以利用 fault、access sampling、object semantics 或 scheduling prediction，但某一次 placement action 为什么发生，通常被藏在具体 driver/policy 代码里。
+
+**Mechanism。** 给每个 managed virtual region 分配 lifetime-scoped region ID 和 generation。只要 runtime 改变 placement，就输出一个紧凑 decision record：
+
+```text
+region_generation
+virtual_range
+action = migrate | evict | prefetch | remote-map | replicate | keep
+evidence = [fault, sampled_access, object_phase, kernel_prediction, schedule]
+evidence_age
+coverage_or_sampling_rate
+pressure_state
+policy_generation
+confidence
+```
+
+这里不把不同 evidence 当成同等强度。Fault 可以准确证明一次 access；sampled access 只给概率性 hotness；scheduler prediction 有过期时间；compiler claim 可能识别 region，却漏掉 data-dependent access。Schema 需要保留这些差异。
+
+高频路径不必保存每条完整日志。driver 可以按 policy generation 聚合，只保留异常、高成本或会改变 eviction outcome 的 exemplar。这样 operator 可以回答“为什么这个 page 被移走”，又不用长期打开 full memory-access tracing。
+
+**与已有工作的差别。** ObservUVM 已经把 mechanism 和 policy 分开，并提供 sampled access evidence；SUV、OASIS、MSched 分别增加更高层语义。这里要标准化的是 evidence-to-decision boundary，而不是再发明一个新的 eviction heuristic。
+
+**Artifact。** 一个 trace schema、CUDA/HIP/HMM adapter，以及 `why-moved <region>` 查询工具。现有 [bpftime GPU runtime](https://github.com/eunomia-bpf/bpftime) 可以用它做 instrumentation 实验，但 schema 本身不依赖 bpftime。
+
+**Evaluation。** 在 oversubscribed scientific kernel、CUDA Graph workload、DNN/LLM inference 和 mixed multi-process workload 上比较 fault-only、sampled-access、compiler/object-informed 与 schedule-aware policy。测量 record overhead、无法解释的 decision 比例、stale-evidence rate，以及 postmortem query 能否还原真实 migration 原因。
+
+**Academic value。** 把 GPU memory observability 与 placement policy 之间原本隐式的边界变成可比较的系统对象。
+
+**Production value。** Operator 可以区分“应用就是超过了 HBM”与“policy 把仍然 hot 的 region 赶走了”，而不必采集所有 memory access。
+
+**Failure condition。** 如果 decision record 对 diagnosis 和 policy comparison 都没有比现有 fault/migration trace 多提供有效信息，就不值得保留这层 metadata。
+
+### 2. 把 placement intent 与实际 compliance 一起暴露出来
+
+**Gap。** 现有 advice API 能表达 preference，却很难让更高层 scheduler 知道 runtime 是否真的满足了某个 phase 的内存优先级。
+
+**Mechanism。** 在 vendor-specific advice 上增加一个可选 runtime object。一个 region generation 可以声明：
+
+- 希望驻留在哪些位置，例如 GPU 0 HBM 或 host DRAM；
+- 哪些 access mode 可以 remote-map，而不必 migration；
+- migration deadline 或 phase boundary；
+- 相对其他 region generation 的 eviction priority；
+- 最大允许 remote-access 或 migration budget；
+- 与 kernel、graph、request 或 scheduler epoch 绑定的 expiry condition。
+
+Memory manager 再把这些 intent 映射到 CUDA advice、HIP advice、HMM migration 或自己的 policy。如果因为 capacity、topology、coherence 或更高优先级 region 无法满足，就记录 degraded state 与原因，而不是把 hint 发出去后默认它已经成功。
+
+Generation 很重要。同一块 tensor buffer 或 virtual range 可能在下一阶段被复用，旧的 placement intent 应该随 logical lifetime 失效，而不是永远黏在一个 address 上。
+
+**与已有工作的差别。** CUDA/HIP 已经有 placement/prefetch hint；MSched 引入 scheduler knowledge；OASIS 把 policy 绑定 object 与 phase。这里新增的是跨这些机制都能表达的 requested outcome 与 observed compliance。
+
+**Artifact。** 先基于 NVIDIA UVM 实现 userspace controller 和小型 region-intent API，再做 HIP/HMM compatibility prototype。controller 同时保留普通 best-effort hint 和“做不到就报告 degradation”的模式，不要求现有硬件突然提供新的 correctness guarantee。
+
+**Evaluation。** 构造不同 latency sensitivity 的 paired region，在 110%、150% 和 250% HBM subscription 下运行，并加入 multi-GPU peer access、CPU/GPU ping-pong、phase change 与 concurrent jobs。与 plain UVM 和 static advice 比较 intent satisfaction、migration bytes、remote-access bytes、tail kernel delay、throughput 与 control overhead。
+
+**Academic value。** 研究 memory placement 能不能从 fault 的隐式副作用提升为显式 resource contract。
+
+**Production value。** Inference/training runtime 可以表达 KV-cache working set、communication buffer 或下一批 imminent data 比 cold model state 更值得占 HBM，同时在压力太大时拿到真实失败原因。
+
+**Failure condition。** 如果 static advice 在 phase-changing 与 multi-tenant workload 上也能达到同样的 tail latency 和 migration cost，这层 contract 就没有必要。
+
+### 3. 用 counterexample benchmark 直接测试 placement evidence 的价值
+
+**Gap。** 现有 evaluation 能看出最终性能差异，却很少刻意制造“表面观测相同、正确 decision 不同”的情况。
+
+**Mechanism。** 构造 paired workload，保持一种可见 signal 近似不变，同时改变真正最优的 placement：
+
+| Pair | 保持相似的观测 | 改变最优动作的隐藏事实 |
+| --- | --- | --- |
+| repeated faults | fault stream | 一个页面马上会复用，另一个已经 dead |
+| equal access counts | sampled hotness | 一个 region 的访问即将发生，另一个很久以后才用 |
+| same allocation size | object metadata | 一个 phase 只访问 5%，另一个访问 95% |
+| same current residency | HBM state | 一个 task 马上被 schedule out |
+| same preferred location | advice | 一个 job 有严格 latency budget，另一个可以 spill |
+
+Harness 自己知道 future reference 与 task order，因此能在同样的 HBM/PCIe 约束下计算 oracle placement。然后逐层开放 evidence：fault-only、sampled access、object/phase semantics，最后才给 scheduler knowledge。
+
+**与已有工作的差别。** ARIADNE、ObservUVM、SUV、OASIS、MSched 已经证明了不同 policy mechanism 可以工作。这个 benchmark 不再只比较谁跑得快，而是隔离“每增加一种 evidence，到底减少了多少错误 decision”，并故意让隐藏假设暴露出来。
+
+**Artifact。** 开源 trace corpus、可 replay 的 oversubscription workload、oracle solver 与 evaluator。第一版支持 NVIDIA UVM，同时保持 vendor-neutral trace format，后续可以加入 HIP/HMM。
+
+**Evaluation。** 核心指标包括 application runtime、fault stall time、migration/remote-access bytes、useful-prefetch ratio、相对 oracle 的 decision regret、false-confidence rate 和 observability overhead。每种 policy 都必须拿到完全相同的 memory、link 与 evidence budget。
+
+**Academic value。** 它回答一个更一般的 systems 问题：在线 resource manager 至少需要增加多少信息，才能真正改善 placement decision？
+
+**Production value。** Runtime 团队可以用自己的 workload 判断某个 profiler、compiler analysis 或 scheduler integration 是否值得，而不是因为别人的 paper 有 speedup 就直接把整套机制搬进来。
+
+**Failure condition。** 如果额外 evidence 相对 fault-only policy 几乎不能降低 regret 或 end-to-end cost，那么更简单的 UVM 行为应该继续作为默认方案。
+
+## 哪些结果会改变这个判断？
+
+现有证据只支持一个相对窄的结论：在 HBM oversubscription 下，GPU memory placement 会从 demand fault 之外的信息中获益，而近期系统分别从几个互不兼容的层次获得这些信息。它并不能证明应该用一个 universal placement policy 或一种 universal signal 替代 vendor UVM heuristic。
+
+有三类结果会明显削弱本文的方向。第一，如果用当前 driver 和 hardware 重新做大规模 reproduction 后发现默认 UVM 已经接近各种 specialized policy，增加 contract 的价值会很小。第二，如果 sampled HBM observability、compiler semantics 与 scheduler knowledge 实际只服务完全不重叠的 workload，统一 evidence contract 的复用价值也会很低。第三，如果暴露 decision metadata 与 control path 的成本比它减少的 migration 还高，这个抽象就不该进入生产路径。
+
+所以最值得先做的实验不是再写一个独立 eviction heuristic，而是做 fixed-budget comparison：让同一个 placement controller 逐级获得更丰富的 evidence，然后直接测这些信息到底有多少次改变了真正影响性能与 QoS 的 decision。
+
+## 参考资料
+
+- NVIDIA：[CUDA Programming Guide: Unified Memory](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html)，CUDA 13.x 文档，访问于 2026-08-29。
+- NVIDIA：[CUDA Runtime API: Memory Management](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html)，访问于 2026-08-29。
+- NVIDIA：[Nsight Systems User Guide](https://docs.nvidia.com/nsight-systems/UserGuide/index.html)，Unified Memory page-fault tracing，访问于 2026-08-29。
+- Linux kernel documentation：[Heterogeneous Memory Management](https://docs.kernel.org/mm/hmm.html)，访问于 2026-08-29。
+- AMD：[HIP Unified Memory Management](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html)，访问于 2026-08-29。
+- Pratheek B, Khushit Shah, Arkaprava Basu：[Observability-aided GPU Memory Oversubscription](https://www.csa.iisc.ac.in/~arkapravab/papers/ISCA26_ObservUVM.pdf)，ISCA 2026。
+- Hyunkyun Shin, Seongtae Bang, Hyungwon Park, Daehoon Kim：[ARIADNE: Adaptive UVM Management for Efficient GPU Memory Oversubscription](https://doi.org/10.1109/HPCA68181.2026.11408564)，HPCA 2026；[Artifact](https://zenodo.org/records/17830000)。
+- Yueqi Wang et al.：[OASIS: Object-Aware Page Management for Multi-GPU Systems](https://yueqiwang42.github.io/assets/pdf/papers/OASIS_HPCA25.pdf)，HPCA 2025。
+- Pratheek B, Guilherme Cox, Jan Vesely, Arkaprava Basu：[SUV: Static Analysis Guided Unified Virtual Memory](https://www.csa.iisc.ac.in/~arkapravab/papers/MICRO24_SUV.pdf)，MICRO 2024。
+- Weihang Shen, Yinqiu Chen, Rong Chen, Haibo Chen：[MSched: GPU Multitasking via Proactive Memory Scheduling](https://arxiv.org/abs/2512.24637)，arXiv:2512.24637，2026。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can a GPU Runtime Place Memory Well With Only Page Faults?](https://eunomia.dev/research/gpu-memory-placement-evidence/)
+
+GPU memory oversubscription turns every migration and eviction into a policy decision. This report compares fault, sampled-access, object/phase, and scheduling evidence, then develops evidence-carrying placement records, placement intent with observable compliance, and a counterexample benchmark that measures decision regret under a fixed observability budget.
+
 ### [Can eBPF Keep Policy Identity Across an L7 Proxy Handoff?](https://eunomia.dev/research/ebpf-l7-proxy-policy-identity/)
 
 An L7 proxy terminates one policy-bound connection and emits or reuses another, so socket identity can stop representing the principal that caused an upstream request. This report develops generation-scoped handoff capabilities, policy-safe multiplexing, and a benchmark for authorization-lineage violations across fast and slow paths.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [GPU 运行时只看页故障，能把内存放对地方吗？](https://eunomia.dev/zh/research/gpu-memory-placement-evidence/)
+
+GPU 显存超配会把 migration 和 eviction 都变成 policy decision。本文比较 fault、采样访问、object/phase 与 scheduling evidence，并提出携带证据的 placement record、可观测 compliance 的 placement intent，以及固定观测预算下测量 decision regret 的 counterexample benchmark。
+
 ### [eBPF 在 L7 代理交接时还能保住策略身份吗？](https://eunomia.dev/zh/research/ebpf-l7-proxy-policy-identity/)
 
 L7 proxy 会终止一条带策略身份的连接，再创建或复用新的上游连接，因此 socket identity 可能不再代表真正触发请求的 principal。本文提出 generation-scoped handoff capability、policy-safe multiplexing，以及检测 fast/slow path authorization-lineage violation 的 benchmark。


### PR DESCRIPTION
## Summary

- publish one new bilingual Daily Report on GPU memory placement under Unified Memory oversubscription
- compare page-fault, sampled-access, object/phase, and scheduling evidence, then develop evidence-carrying placement records, placement intent with observable compliance, and a fixed-budget decision-regret benchmark
- refresh the August 29 Google/live-site operating record and reconcile the previous daily closeout
- correct the rolling newest-ten arithmetic from the stale 7 eBPF / 0 Agent / 3 adjacent record to the actual 8 / 0 / 2 archive state
- make no separate technical SEO implementation change because the current evidence does not establish a concrete crawl, canonical, hreflang, structured-data, rendering, or deployment defect

## Data coverage

- Drive folder rechecked August 29; newest weekly set remains 2026-08-17..23
- GSC finalized rows through August 22; the complete 7-day and 28-day comparisons remain unavailable because required source rows/history are missing
- finalized GA4 organic landing-page aggregate remains 2026-08-17..23
- Cloudflare remains disabled by repository configuration
- fresh public-safe site collection observed homepage/robots/sitemap HTTP 200 and 710 sitemap entries

## Report classification

Series: **GPU and Heterogeneous Runtime Systems**  
Class: **adjacent systems**

The report does not count as eBPF-centered because eBPF-like instrumentation is optional to the central memory-placement mechanism. The incoming adjacent report displaces one of the two August 20 adjacent reports, so the rolling newest-ten mix remains 8 eBPF / 0 pure Agent / 2 adjacent. An adjacent report on the next normal run would displace the remaining August 20 adjacent report and still leave 8 / 0 / 2; a second consecutive adjacent report after that would rotate the August 21 eBPF report out and restore 7 / 0 / 3. Prefer genuinely adjacent GPU/runtime questions over the next two normal runs when the quality gates permit; do not repair the ratio through classification or by publishing extra reports.

## Validation

- authoritative repository CI
- complete final diff and generated-output self-review
- exact squash-commit production deployment
- public English and Chinese route verification after deployment
