### PR TITLE
Daily: define native operation trust boundaries for eBPF

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,7 +1,6 @@
 # Human-only blockers
 
-Only unresolved external conditions belong here. The daily ChatGPT scheduler is
-already configured and enabled; it is not a blocker.
+Only unresolved external conditions belong here. The daily ChatGPT scheduler is already configured and enabled; it is not a blocker.
 
 ## Cloudflare analytics is not configured
 
@@ -12,33 +11,16 @@ already configured and enabled; it is not a blocker.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder was
-directly rechecked on `2026-09-05`. No export newer than the source-native
-`2026-08-24..30` weekly set is present.
+Google Drive access is verified and is not a blocker. The configured folder was directly rechecked on `2026-09-07` and now contains a fresh `2026-08-31..09-06` weekly source set.
 
-For Search Console, the newest date export contains rows for `2026-08-24..29` and
-no row for `2026-08-30`. Every row actually present in that six-day slice is
-finalized evidence under the configured lag. Those six rows sum to **436 clicks
-and 55,594 impressions**, with aggregate CTR about **0.784%** and
-impression-weighted average position about **10.73**.
+For Search Console, date rows are present for `2026-08-31..09-05`; `2026-09-06` is absent. Under the configured three-day lag, rows through September 4 are treated as finalized and September 5 as partial. Finalized `2026-08-31..09-04` contains **368 clicks / 53,341 impressions / ~0.690% aggregate CTR / ~7.45 impression-weighted average position**.
 
-The equal-duration `2026-08-17..22` slice has 477 clicks, 59,798 impressions,
-~0.798% CTR, and ~9.56 weighted position. The comparison is useful but is not a
-complete seven-day trend because the preceding weekly export omits `2026-08-23`
-and the current export omits `2026-08-30`. Other historical gaps also prevent the
-required complete 28-day comparison. Missing rows are never converted to zero.
+The equal-duration finalized `2026-08-24..28` slice contains **398 clicks / 48,044 impressions / ~0.828% CTR / ~10.04 weighted position**. Relative to it, current clicks are about **7.5% lower**, impressions **11.0% higher**, CTR about **0.139 percentage points lower**, and weighted position about **2.59 positions better**.
 
-The GA4 organic landing-page aggregate for `2026-08-24..30` is fully finalized.
-It contains **1,007 sessions** at about **45.88% session-weighted engagement**.
-The preceding finalized `2026-08-17..23` aggregate contains 984 sessions at about
-49.29% engagement. Sessions are about **2.3% higher** week over week while
-engagement is about **3.41 percentage points lower**.
+This remains a source-history constraint rather than a collection failure. Missing `2026-08-30` and absent `2026-09-06` prevent the required complete latest-seven versus previous-seven comparison, and older gaps still prevent a complete 28-day comparison. Missing rows are never converted to zero.
 
-These constraints never justify skipping the daily operation. Each run must use
-the available Google evidence, live-site evidence, public GitHub evidence, and
-public primary-source evidence; missing or partial coverage must never be
-converted into zero. Every run must still publish one new Daily Report under the
-current repository contract.
+A new GA4 organic landing-page aggregate for `2026-08-31..09-06` is present, but the weekly file has no date dimension and includes dates inside the finalization lag, so it is treated as partial. The latest fully finalized GA4 aggregate remains `2026-08-24..30`: **1,007 sessions** at about **45.88% session-weighted engagement**, versus 984 sessions at about 49.29% for `2026-08-17..23`.
 
-Remove or narrow a blocker in the next daily pull request after the external
-condition is verified as resolved.
+These constraints never justify skipping the daily operation. Each run must use the available Google evidence, live-site evidence, public GitHub evidence, and public primary-source evidence; missing or partial coverage must never be converted into zero. Every run must still publish one new Daily Report under the current repository contract.
+
+Remove or narrow a blocker in the next daily pull request after the external condition is verified as resolved.

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -494,6 +494,18 @@ cross-JIT benchmark that measures semantic equality, specialization coverage,
 fallback reasons, cross-target performance regret, proof/selection overhead, and
 trusted-code growth.
 
+The `2026-09-07` report advances a third boundary after implementation selection:
+who must be trusted when verifier-visible BPF semantics are delegated to native
+code. Linux kfuncs show that verifier-enforced argument, ownership, RCU,
+sleepability, and destructive-call contracts can coexist with an implementation
+that still requires kernel review. Kops makes the native-emission TCB trade-off
+explicit and demonstrates proof-linked native operations as well as a larger-TCB
+whole-program native replacement. The report separates semantic authority from
+implementation authority and develops independently checked native-operation
+certificates, runtime effect envelopes for partially verified delegation, and a
+TCB mutation benchmark whose primary oracle is escaped semantic divergence from
+the verifier-approved BPF program.
+
 ### Published progress
 
 1. `2026-09-05`: `/research/ebpf-runtime-profile-specialization/` asks when a
@@ -512,22 +524,32 @@ trusted-code growth.
    fallback, and evaluates portability across JIT backends and kernel versions.
    It is eBPF-centered because BPF ISA conformance, verifier-visible proof
    sequences, JIT capability, and native lowering are the object of the contract.
+3. `2026-09-07`: `/research/ebpf-native-operation-trust-boundary/` asks why a
+   selected native implementation should be allowed to exercise the same
+   authority as verifier-approved BPF semantics without making its entire
+   optimizer/backend toolchain trusted. It proposes independently checkable
+   operation certificates, explicit effect envelopes and bounded differential
+   canaries, plus an adversarial TCB-mutation benchmark. It is eBPF-centered
+   because the verifier boundary, BPF semantic witness, native JIT lowering, and
+   delegated execution authority are the central object of the contract.
 
 Before the September 5 publication, the newest ten contained **5 eBPF-centered /
 0 pure Agent / 5 adjacent systems**. The September 5 eBPF-centered report rotated
-the `2026-08-25` eBPF-centered report out, so the mix remained **5 / 0 / 5**.
-Before the September 6 publication the mix is therefore still **5 / 0 / 5**. The
-incoming eBPF-centered report rotates the `2026-08-26` eBPF-centered report out,
-so after publication the mix again remains **5 / 0 / 5**. No classification was
-changed to obtain that result.
+an eBPF-centered report out, so the mix remained **5 / 0 / 5**. The September 6
+report likewise kept the mix at **5 / 0 / 5**. Before the September 7 publication
+the mix is still **5 / 0 / 5**; the incoming eBPF-centered report rotates the
+`2026-08-27` eBPF-centered complete-mediation report out, so after publication
+the mix again remains **5 / 0 / 5**. No classification was changed to obtain that
+result.
 
 A later report should not repeat "verifier accepted is not equivalent", stale
 profile invalidation, architecture capability negotiation, proof-linked portable
-fallback, or cross-JIT portability measurement with a different optimizer
-example. Distinct remaining boundaries include delegated native operations and
-their trust/TCB boundary, safe delegation of higher-level operations to
-hardware-specific implementations, and debugging/provenance mechanisms that can
-explain which native implementation and optimization decision actually executed.
+fallback, cross-JIT portability measurement, or today's delegated-native trust
+and TCB thesis with a different optimizer example. Distinct remaining boundaries
+include safe delegation of higher-level operations with explicit semantic/effect
+contracts and debugging/provenance mechanisms that can explain which native
+implementation, certificate, specialization generation, and optimization decision
+actually executed.
 
 ## Queued series — Agent Systems (limited)
 

--- a/.github/seo-data/daily/2026-09-07.md
+++ b/.github/seo-data/daily/2026-09-07.md
@@ -1,0 +1,142 @@
+# SEO operations — 2026-09-07
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Baseline default-branch commit: `e091531a375c458ed34c973a5861b75ebf9b3473`
+- Delivery branch: `daily/2026-09-07-ebpf-native-operation-trust`
+- Run type: mandatory data analysis, technical SEO/GEO audit, and exactly one new bilingual Daily Report
+- Technical SEO outcome: no separate implementation change. Fresh source-native data and current repository/public evidence do not establish a crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, persistent-performance, or deployment defect that warrants an unrelated change.
+- Mandatory publication: one new bilingual eBPF-centered Daily Report on delegated native-operation trust.
+
+Cloudflare remains disabled by repository configuration. Missing or incomplete source coverage is unavailable or partial, never zero.
+
+### Prior-run reconciliation
+
+The September 6 delivery is complete. PR `#189`, **Daily: define portable architecture specialization for eBPF**, squash-merged as `e091531a375c458ed34c973a5861b75ebf9b3473`. Its final PR-head checks were green; exact-merge `Validate SEO Operations` run `34140327427` and `Deploy Static App` run `34140327505` completed successfully. Production static export `fe48a46224768cd0270280f8c4fd0d559bfd366f` is explicitly built for the squash commit. PR `#189` contains exactly one compact top-level Daily closeout comment.
+
+## Data window
+
+The configured Drive folder `eunomia.dev SEO Weekly CSV` was directly rechecked on `2026-09-07`. A fresh weekly source set for `2026-08-31..2026-09-06` is now present.
+
+- Search Console date rows are present for `2026-08-31..2026-09-05`; `2026-09-06` is absent.
+- Under the configured three-day lag, this run treats rows through `2026-09-04` as finalized and `2026-09-05` as partial/fresh.
+- The new GA4 weekly aggregate covers `2026-08-31..2026-09-06`, but because it has no date dimension and includes days inside the finalization lag, it is treated as partial rather than compared as a finalized week.
+- The latest fully finalized GA4 weekly organic landing-page aggregate therefore remains `2026-08-24..2026-08-30`.
+- A complete latest-seven-day Search Console comparison is still unavailable because `2026-08-30` is missing from the previous export and `2026-09-06` is absent from the new one.
+- Older gaps still prevent the required complete 28-day versus preceding comparable period comparison.
+- Cloudflare remains disabled.
+
+## Evidence collected
+
+### Google Search Console
+
+The latest finalized equal-duration slice `2026-08-31..2026-09-04` contains **368 clicks / 53,341 impressions / ~0.690% aggregate CTR / ~7.45 impression-weighted average position**.
+
+The preceding five finalized source days `2026-08-24..2026-08-28` contain **398 clicks / 48,044 impressions / ~0.828% aggregate CTR / ~10.04 weighted position**. Relative to that equal-duration slice, clicks are about **7.5% lower**, impressions about **11.0% higher**, aggregate CTR about **0.139 percentage points lower**, while weighted average position is about **2.59 positions better**.
+
+This is explicitly a five-day source-native comparison, not the configured complete seven-day trend. Missing `2026-08-30` and `2026-09-06` are not synthesized as zero.
+
+The current page export shows established tutorials and project pages still dominate clicks. Daily Report routes have small per-route volumes; the new weekly page export does not provide a date-by-page dimension, so it cannot establish a causal metadata, title, navigation, or topic intervention.
+
+### Google Analytics 4
+
+A new `2026-08-31..2026-09-06` organic landing-page export is present, generated on September 7. It is treated as **partial** because the weekly aggregate has no date dimension and includes dates inside the configured finalization lag. It is not used as a finalized week-over-week comparison.
+
+The latest fully finalized aggregate remains `2026-08-24..30`: **1,007 organic landing-page sessions** at about **45.88% session-weighted engagement**, versus **984 sessions** at about **49.29% engagement** for `2026-08-17..23`. The finalized comparison remains about **+2.3% sessions** and **-3.41 percentage points engagement**.
+
+### Cloudflare
+
+Cloudflare analytics remains disabled by repository configuration. No traffic, cache, bot, country, or status-code conclusion is inferred from absent Cloudflare data.
+
+### Public site and repository evidence
+
+Current repository generation already covers robots, sitemap, canonical, reciprocal language alternates, Article structured data, and the Daily Report navigation/index paths. The September 6 report completed exact-SHA GitHub Pages deployment and generated-artifact verification. No fresh evidence establishes a separate technical SEO defect today.
+
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. The durable repository plan requires a consuming-contract migration before moving the pointer, so no pointer-only upgrade is made.
+
+### Rolling Daily Report mix before topic selection
+
+The ten actually published reports immediately before today's publication contain:
+
+- eBPF-centered: **5 of 10**
+- pure Agent-centered: **0 of 10**
+- adjacent systems: **5 of 10**
+
+Today's selected report is **eBPF-centered**. It enters above the September 6 report while the August 27 eBPF-centered complete-mediation report leaves the newest-ten window, so the resulting mix remains **5 eBPF / 0 pure Agent / 5 adjacent**. No classification is changed to obtain that result.
+
+### Research evidence and topic selection
+
+Active series: **eBPF Optimization and Execution Specialization**.
+
+Selected report:
+
+- English: **Can eBPF Delegate Native Operations Without Growing Its Trust Boundary?**
+- Chinese: **eBPF 把操作交给原生代码后，怎样控制可信边界？**
+- Route: `/research/ebpf-native-operation-trust-boundary/`
+- Classification: **eBPF-centered**
+
+The selected boundary is trust after native delegation. Linux verifier documentation shows that BPF instructions are symbolically checked and function calls are constrained through verifier-known prototypes. Current kfunc documentation shows a rich boundary contract for trusted arguments, ownership, RCU, sleepability, nullability, and destructive calls while still requiring maintainers to review whether the underlying kernel implementation is safe. Kops makes the optimization trust trade-off explicit: verifier-visible BPF proof sequences can coexist with native emits; Lean proofs relate the evaluated native implementations to those sequences; whole-program native replacement provides more speed in its evaluation at the cost of a larger TCB. Linux JIT hardening and JIT-code inspection controls provide additional evidence that generated native code is security-sensitive.
+
+The unresolved mechanism is therefore not architecture eligibility or fallback, which September 6 already covered. It is how a selected native implementation receives the same authority as verifier-approved semantics without forcing the kernel to trust every optimizer, backend, or generator that produced it.
+
+A debugging/provenance report was considered but not selected. It remains distinct and useful, but the current evidence supports a stronger trust-boundary question with a direct fault oracle: whether native execution can produce an observable state the verifier-approved semantic program could not produce.
+
+### Technical SEO / GEO decision
+
+No separate technical SEO implementation change is justified today. Fresh GSC evidence has higher impressions but lower CTR in an equal-duration five-day slice while average position improves; that mixed signal is not a diagnosis of one metadata or crawl defect. GA4's new week is partial. Existing generated SEO primitives and the prior exact deployment remain intact. The report-coupled English and Chinese index additions are the only search-facing changes in scope.
+
+## Work performed
+
+The branch is scoped to one publication plus directly coupled operating-state changes:
+
+- added `docs/research/ebpf-native-operation-trust-boundary.md`;
+- added `docs/research/ebpf-native-operation-trust-boundary.zh.md`;
+- prepended the English and Chinese Daily Report indexes;
+- added this September 7 operating record;
+- refreshed `site.md`, `status.md`, `plan.md`, `block.md`, and `content-series.md` for the new Google export coverage, prior-run reconciliation, active-series progress, and rolling mix;
+- made no unrelated technical SEO implementation change;
+- kept the SEO skill submodule pinned under the existing consuming-contract migration rule.
+
+The report develops three testable directions:
+
+1. native-operation packages with verifier-visible semantic witnesses, explicit effect summaries, implementation hashes, and independently checkable certificates;
+2. runtime effect envelopes and bounded differential canaries for delegated operations that cannot yet receive complete proofs;
+3. a TCB mutation benchmark whose primary correctness metric is escaped semantic violation rather than verifier acceptance or crash rate.
+
+## Validation and self-review
+
+The authoritative PR checks are `Validate SEO Operations` and `Deploy Static App`. Missing, queued, skipped, cancelled, or failed checks are not success. Any validation or review issue must be fixed on this same branch and rechecked.
+
+Before merge, the complete final PR diff, changed-file set, English and Chinese report prose, references, metadata, internal links, series classification, and generated output must be reviewed after final head checks reach terminal success.
+
+The report review must confirm a concrete reader failure scenario, current primary evidence, explicit `Where current work is still weak` / `现有研究还缺什么`, three developed and evaluable directions, an observable semantic-divergence oracle, and `What would change this conclusion?` / `哪些结果会改变这个判断？`.
+
+## Delivery
+
+Delivery branch: `daily/2026-09-07-ebpf-native-operation-trust`.
+
+One non-draft pull request against `main` will contain this operating record, the bilingual report, index updates, and directly coupled operating-state refreshes. After terminal green checks and one complete clean final self-review, it must be squash-merged.
+
+Production acceptance then requires the exact squash commit to complete `Deploy Static App`, followed by verification of:
+
+- `https://eunomia.dev/research/ebpf-native-operation-trust-boundary/`
+- `https://eunomia.dev/zh/research/ebpf-native-operation-trust-boundary/`
+
+Both routes must expose the intended content, Daily Report navigation, locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` hreflang, Article JSON-LD, intended internal links, the explicit current-work gap, all three developed research directions, and the reader-facing conclusion boundary. The production sitemap must contain both routes and language alternates.
+
+Exactly one compact top-level closeout comment on the merged PR will record the verified merge, CI, exact production deployment, data coverage, series/classification, topic mix, and remaining uncertainty. No second closeout pull request will be created.
+
+## Decisions and follow-ups
+
+- Publish the native-operation trust-boundary report as **eBPF-centered** and make it the third report in **eBPF Optimization and Execution Specialization**.
+- After publication, the newest-ten mix remains **5 eBPF-centered / 0 pure Agent / 5 adjacent systems**.
+- Do not repeat verifier-versus-equivalence, stale-profile invalidation, architecture capability negotiation, multi-backend fallback, cross-JIT portability, or today's trust/TCB thesis in the next report.
+- Distinct next boundaries include safe high-level operation delegation with explicit semantic/effect contracts and debugging/provenance that explains which specialized implementation actually executed.
+- Keep complete GSC 7-day and 28-day comparisons unavailable until source history becomes contiguous; never fill missing dates with zero.
+- Treat the new GA4 `2026-08-31..09-06` weekly aggregate as partial under the configured lag; do not compare it as a finalized week.
+- Keep Cloudflare explicit as unavailable until repository configuration enables a supported read-only route.
+- Keep the shared SEO skill pointer unchanged until the consuming contract migration required by `plan.md` is completed.
+- Closeout facts remain pending until the exact squash deployment and bilingual production verification are complete.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -2,17 +2,11 @@
 
 ## Purpose
 
-Make eunomia.dev a reliable canonical source for eBPF, systems infrastructure,
-observability, profiling, networking, security, runtimes, and heterogeneous
-systems research. AI-agent infrastructure is a deliberately smaller adjacent
-topic rather than the center of the publication program.
+Make eunomia.dev a reliable canonical source for eBPF, systems infrastructure, observability, profiling, networking, security, runtimes, and heterogeneous systems research. AI-agent infrastructure is a deliberately smaller adjacent topic rather than the center of the publication program.
 
-Optimize for technically useful discovery and citation by people and software
-agents without creating shallow, repetitive, or trend-driven content.
+Optimize for technically useful discovery and citation by people and software agents without creating shallow, repetitive, or trend-driven content.
 
-`DAILY_TASK.md` is the authoritative operating entrypoint. It combines daily data
-analysis, technical SEO/GEO, and one mandatory new Daily Report. This file stores
-durable goals and constraints, not duplicated scheduler instructions.
+`DAILY_TASK.md` is the authoritative operating entrypoint. It combines daily data analysis, technical SEO/GEO, and one mandatory new Daily Report. This file stores durable goals and constraints, not duplicated scheduler instructions.
 
 ## Success signals
 
@@ -34,31 +28,26 @@ durable goals and constraints, not duplicated scheduler instructions.
 - Every scheduled run must add exactly one new bilingual Daily Report. A weak candidate is replaced by another approved question rather than published or converted into a no-report day.
 - Technical SEO changes remain evidence-driven and may be skipped on a given day; the Daily Report may not be skipped.
 - Keep the rolling topic mix compliant and classify by the report's actual central mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the daily pull request incoherent; put unrelated durable SEO work in this plan for a focused follow-up.
 - Required and expected CI must pass before a clean final automated self-review and squash merge.
 - Every daily report is a public change, so the exact squash commit must deploy successfully and both language pages must be verified.
 - Do not create a second closeout pull request. Put the verified closeout in one compact comment on the merged daily pull request, then refresh `status.md` in the next run.
 - `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
 - `.agents/skills/eunomia-research-report` owns Daily Report research, quality, writing, and publication gates.
 
-Short-term fixes and remediation backlogs belong in GitHub issues. Durable priorities that can guide a later daily run belong below.
-
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically from the actually published archive. Before the `2026-09-06` publication the newest ten contain **5 eBPF-centered / 0 pure Agent / 5 adjacent systems**. The architecture-specialization report is genuinely eBPF-centered because portable BPF semantics, JIT capability, proof-linked native implementations, and fallback are the central mechanism. It rotates the `2026-08-26` eBPF-centered report out, so the newest-ten mix remains **5 / 0 / 5** after publication. Never repair the ratio through classification or by publishing an extra report.
-2. **eBPF Optimization and Execution Specialization** is the active series. The September 5 report established verifier-safety versus optimizer-equivalence and the lifetime of profile-derived assumptions. The September 6 report advances a distinct second boundary: architecture-specific native fast paths must expose target eligibility, preserve one portable semantic witness, and fall back deterministically when a machine/JIT capability is unavailable. It develops a two-level capability manifest, proof-linked multi-backend operation packages, and a cross-JIT portability benchmark.
-3. Keep later optimization-series reports materially distinct from those first two boundaries. Good remaining candidates include delegated native operations and their trust/TCB boundary, safe delegation of higher-level operations to hardware-specific implementations, and debugging/provenance that explains the actual native implementation and optimization decision executed. Do not repackage verifier-safety-versus-equivalence, stale-profile invalidation, capability negotiation, or cross-JIT fallback with another optimizer name.
-4. Treat **eBPF Networking and Security** as complete at its normal six-report boundary after the `2026-08-28` proxy handoff report. Return only when fresh evidence supports a mechanism beyond policy composition, zero-copy ownership, temporal state correctness, revocation, complete mediation, or proxy identity continuity.
-5. Treat **GPU and Heterogeneous Runtime Systems** as complete at its normal six-report post-activation boundary after `2026-09-04`. Do not continue with a seventh report merely because another GPU paper exists. Its covered boundaries are memory-placement evidence, instrumentation non-interference, candidate-conditioned allocatability, membership/generation continuity, semantic observability after megakernel fusion, and application-consistent checkpoint/restore.
-6. Use all verified weekly Search Console and GA4 Drive export sets in every run. As of `2026-09-06`, no source set newer than `2026-08-24..30` is present. Its Search Console date rows remain verified through `2026-08-29`, with `2026-08-30` absent.
-7. Record the current Search Console `2026-08-24..29` slice as **436 clicks / 55,594 impressions / ~0.784% CTR / ~10.73 impression-weighted position**. The equal-duration `2026-08-17..22` slice is **477 / 59,798 / ~0.798% / ~9.56**. Current clicks are ~8.6% lower, impressions ~7.0% lower, CTR ~0.013 percentage points lower, and position ~1.17 worse. Label this as a six-day source-native comparison, not a complete seven-day trend.
-8. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them. The prior weekly export omits `2026-08-23`, the current set omits `2026-08-30`, and other older gaps prevent a complete preceding 28-day source window. Missing rows are never zero.
-9. Weekly GSC page aggregates may prioritize inspection but must not be used for page-level causal claims without date-by-page evidence. Daily Report pages show 6 clicks / 1,017 impressions in the current weekly page export versus 5 / 744 previously, but volume is still too small to justify a title, navigation, or metadata change by itself.
-10. Treat the GA4 `2026-08-24..30` organic landing-page aggregate as fully finalized. It contains 1,007 sessions at about 45.88% session-weighted engagement. The preceding finalized `2026-08-17..23` aggregate contains 984 sessions at about 49.29% engagement. Sessions are about **2.3% higher** week over week while engagement is about **3.41 percentage points lower**.
-11. Use finalized date-by-page or date-by-query evidence before attributing search movement to one page, report, title, or topic family. Weekly page/query aggregates without a date dimension are prioritization evidence, not causal attribution.
-12. The independent crawler/search view discovers the September 5 runtime-profile-specialization report as of `2026-09-06`, after previously confirming the September 4 checkpoint report and September 3 megakernel report. Treat this as supplementary retrievability evidence. Exact-SHA Pages deployment and generated production artifacts remain the stronger publication acceptance evidence.
-13. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and technical SEO questions that require richer source-native evidence rather than as reasons to steer Daily Report topics.
-14. Add Cloudflare coverage only when a supported read-only route is enabled in repository configuration.
-15. Use search behavior, GitHub activity, primary research, kernel changes, and production evidence to order questions inside approved eBPF and adjacent systems series.
-16. Revisit a dedicated public hub for a series only after at least three strong reports and report-level acquisition or navigation evidence show that it would improve retrieval beyond the existing Daily Report index.
-17. Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule to a newer upstream layout. Upstream `main` is newer at `f42128a3f05c73cf10c786a2711c488bb3a14839`, but upstream movement alone is not evidence that a pointer-only bump is safe.
+1. Preserve the rolling ten-report mix mechanically from the published archive. Before the `2026-09-07` publication the newest ten contain **5 eBPF-centered / 0 pure Agent / 5 adjacent systems**. Today's report is genuinely eBPF-centered and rotates the `2026-08-27` eBPF-centered report out, so the window remains **5 / 0 / 5** after publication.
+2. **eBPF Optimization and Execution Specialization** is the active series. September 5 established verifier safety versus optimizer equivalence and profile-assumption lifetime. September 6 established architecture-specific implementation eligibility, a portable semantic witness, deterministic fallback, and cross-JIT portability evidence. September 7 advances the separate native-operation trust/TCB boundary: the selected implementation must be independently bound to verifier-approved semantics instead of making every optimizer/backend trusted.
+3. Keep later optimization-series reports materially distinct. Good next candidates include safe delegation of higher-level operations with explicit semantic/effect contracts, and debugging/provenance that explains the exact specialized implementation, certificate, optimizer generation, and decision that executed. Do not repackage stale-profile invalidation, architecture capability negotiation, portable fallback, cross-JIT portability, or today's trust/TCB thesis with a new optimizer name.
+4. Treat **eBPF Networking and Security** as complete at its six-report boundary after `2026-08-28`; return only for a mechanism beyond policy composition, zero-copy ownership, temporal state correctness, revocation, complete mediation, or proxy identity continuity.
+5. Treat **GPU and Heterogeneous Runtime Systems** as complete at its six-report post-activation boundary after `2026-09-04`; do not continue merely because another GPU paper exists.
+6. Use all verified weekly Search Console and GA4 Drive export sets in every run. As of `2026-09-07`, a new `2026-08-31..09-06` set is present. GSC rows exist through `2026-09-05`; rows through September 4 are treated as finalized under the configured three-day lag, September 5 as partial, and September 6 is absent.
+7. Record finalized GSC `2026-08-31..09-04` as **368 clicks / 53,341 impressions / ~0.690% CTR / ~7.45 impression-weighted position**. Equal-duration `2026-08-24..28` is **398 / 48,044 / ~0.828% / ~10.04**. Current clicks are ~7.5% lower, impressions ~11.0% higher, CTR ~0.139 percentage points lower, and position ~2.59 positions better. Label this as a five-day source-native comparison, not a complete seven-day trend.
+8. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous. Missing `2026-08-30`, absent `2026-09-06`, and older gaps are never converted to zero.
+9. The new GA4 `2026-08-31..09-06` weekly landing-page aggregate is partial under the configured lag because it has no date dimension. Do not compare it as a finalized week. The latest fully finalized aggregate remains `2026-08-24..30`: 1,007 sessions at ~45.88% engagement versus 984 at ~49.29% for `2026-08-17..23`.
+10. Weekly GSC page/query aggregates may prioritize inspection but must not support page-level causal claims without date-resolved evidence. Use finalized date-by-page or date-by-query evidence before attributing movement to one report, title, metadata change, or topic family.
+11. Exact-SHA Pages deployment and generated production artifacts remain stronger publication acceptance evidence than crawler discovery alone.
+12. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement or technical SEO questions requiring richer source-native evidence rather than reasons to steer Daily Report topics.
+13. Add Cloudflare coverage only when a supported read-only route is enabled in repository configuration.
+14. Revisit a dedicated public series hub only after at least three strong reports and report-level acquisition/navigation evidence show retrieval benefit beyond the existing Daily Report index.
+15. Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule to a newer upstream layout. Upstream movement alone is not evidence that a pointer-only bump is safe.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -31,20 +31,19 @@
 - Google Drive folder name: `eunomia.dev SEO Weekly CSV`
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
-- Verified raw export window: `2026-07-27` through `2026-08-30`
-- Search Console newest verified row: `2026-08-29`; finalized rows are used through `2026-08-29`; `2026-08-30` is absent
+- Verified raw export window: `2026-07-27` through `2026-09-06`
+- Search Console newest verified row: `2026-09-05`; finalized rows are used through `2026-09-04`; `2026-09-06` is absent
 - Latest fully finalized GA4 aggregate: `2026-08-24` through `2026-08-30`
+- Newest GA4 aggregate: `2026-08-31` through `2026-09-06`, partial under the configured lag because the export has no date dimension
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
-The configured folder was directly reverified on `2026-09-05`. It contains weekly Google export sets for `2026-07-27..08-02`, `2026-08-03..09`, `2026-08-10..16`, `2026-08-17..23`, and `2026-08-24..30`. The newest set remains the current source-native export material; no later weekly set was observed. Missing rows are not converted to zero.
+The configured folder was directly reverified on `2026-09-07`. It now contains a fresh `2026-08-31..09-06` weekly export set in addition to the earlier weekly sets. Missing rows are never converted to zero.
 
-For Search Console, the newest source-native date export contains rows for `2026-08-24..29`; `2026-08-30` is absent. Every row actually present in that six-day slice is finalized evidence under the configured lag. The `2026-08-24..29` slice contains 436 clicks / 55,594 impressions, about 0.784% aggregate CTR, and impression-weighted average position about 10.73.
+For Search Console, finalized `2026-08-31..09-04` rows contain **368 clicks / 53,341 impressions / ~0.690% aggregate CTR / ~7.45 impression-weighted average position**. The equal-duration finalized `2026-08-24..28` slice contains **398 / 48,044 / ~0.828% / ~10.04**. Relative to that slice, clicks are about **7.5% lower**, impressions **11.0% higher**, CTR about **0.139 percentage points lower**, and weighted average position about **2.59 positions better**.
 
-The equal-duration source-native `2026-08-17..22` slice contains 477 clicks / 59,798 impressions / about 0.798% CTR / about 9.56 impression-weighted position. Relative to that six-day slice, the current `2026-08-24..29` slice has about 8.6% fewer clicks, 7.0% fewer impressions, CTR about 0.013 percentage points lower, and average position about 1.17 positions worse. This is explicitly not a complete seven-day comparison.
+This is a five-day source-native comparison, not the configured complete seven-day trend. `2026-08-30` is missing from the previous export and `2026-09-06` is absent from the new one; older gaps also prevent a complete preceding 28-day source window.
 
-A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because verified source rows are not contiguous across the required windows: the preceding weekly export omits `2026-08-23` and the newest set omits `2026-08-30`; older gaps also prevent a complete preceding 28-day source window. Missing rows are not converted to zero.
-
-The GA4 `2026-08-24..30` organic landing-page aggregate is fully finalized and contains 1,007 sessions at about 45.88% session-weighted engagement. The preceding finalized `2026-08-17..23` aggregate contains 984 organic landing-page sessions at about 49.29% engagement, including 118 `(not set)` sessions. Week over week, sessions are about 2.3% higher while engagement is about 3.41 percentage points lower. The earlier `2026-08-10..16` aggregate contains 970 sessions at about 44.95% engagement. These weekly aggregates have no date dimension, so they do not support daily or within-week causal attribution.
+The GA4 `2026-08-24..30` organic landing-page aggregate remains the latest fully finalized weekly aggregate: **1,007 sessions** at about **45.88% session-weighted engagement** versus **984 sessions** at about **49.29% engagement** for `2026-08-17..23`. The new `2026-08-31..09-06` aggregate is partial under the lag and is not used as a finalized week-over-week comparison.
 
 Public repository and live-site data supplement these exports but do not replace their source-native meanings.
 
@@ -60,7 +59,7 @@ Public repository and live-site data supplement these exports but do not replace
 - Public GitHub repository evidence enabled: yes
 - Public web and primary-source evidence enabled: yes
 
-Fresh public search discovery on `2026-09-05` exposes the `2026-09-04` checkpoint-recovery Daily Report and the `2026-09-03` eBPF megakernel report. The independent crawler uncertainty recorded at the September 4 closeout is therefore resolved for those routes. This discovery evidence supplements, rather than replaces, exact-SHA deployment and generated-output verification.
+Public discovery is supplementary retrievability evidence. Exact-SHA deployment and generated production artifacts remain the publication acceptance boundary.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -6,125 +6,64 @@
 - Technical SEO subtask: `.github/seo-data/daily-task.md`
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
-- Verified raw Google export window: through `2026-08-30`
-- Search Console newest verified row: `2026-08-29`; `2026-08-30` is absent
+- Verified raw Google export window: through `2026-09-06`
+- Search Console newest verified row: `2026-09-05`; finalized rows used through `2026-09-04`; `2026-09-06` absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
-- Latest completed daily record before the current run: `2026-09-05`
-- Last completed Daily Report pull request: `#187`
-- Last verified Daily Report squash commit: `e5a521a9fb7e3787be57084b58d8b3ed2687c3e3`
-- Last verified production publication from a Daily Report run: static export commit `72d9f79f2b7b6fc6a8bc7ebe14dcc484d25743bd`
-- Current daily branch: `daily/2026-09-06-ebpf-portable-architecture-specialization`
-- Current daily pull request: `#189`
-- Current branch base: `7c16962c9a1971e2ef87afa06e5f0ec36e0ecd8e`
+- Newest GA4 weekly aggregate: `2026-08-31` through `2026-09-06`, partial under the configured lag
+- Latest completed daily record before the current run: `2026-09-06`
+- Last completed Daily Report pull request: `#189`
+- Last verified Daily Report squash commit: `e091531a375c458ed34c973a5861b75ebf9b3473`
+- Last verified production publication from a Daily Report run: static export commit `fe48a46224768cd0270280f8c4fd0d559bfd366f`
+- Current daily branch: `daily/2026-09-07-ebpf-native-operation-trust`
+- Current branch base: `e091531a375c458ed34c973a5861b75ebf9b3473`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#187` is independently reconciled from GitHub. It squash-merged as
-`e5a521a9fb7e3787be57084b58d8b3ed2687c3e3`; exact-merge `Validate SEO
-Operations` run `33977190232` and exact-merge `Deploy Static App` run
-`33977190225` both completed successfully. The deployment produced static export
-`72d9f79f2b7b6fc6a8bc7ebe14dcc484d25743bd`, explicitly built for that squash
-commit. The merged PR contains exactly one top-level Daily closeout comment.
-
-The September 5 runtime-profile-specialization report is freshly discoverable in
-a public crawler/search snapshot on `2026-09-06`. Exact deployment and generated
-artifacts remain the publication acceptance boundary; crawler discovery is only
-supplementary retrievability evidence.
+PR `#189` is fully reconciled. It squash-merged as `e091531a375c458ed34c973a5861b75ebf9b3473`; exact-merge `Validate SEO Operations` run `34140327427` and `Deploy Static App` run `34140327505` succeeded. Production static export `fe48a46224768cd0270280f8c4fd0d559bfd366f` is explicitly built for that squash commit, and the merged PR contains exactly one top-level Daily closeout comment.
 
 ## Current Daily Report mix
 
-Before today's publication, the newest ten actually published reports contain:
+Before today's publication, the newest ten actually published reports contain **5 eBPF-centered / 0 pure Agent / 5 adjacent systems**.
 
-- eBPF-centered: **5 of 10**
-- pure Agent-centered: **0 of 10**
-- adjacent systems: **5 of 10**
+Today's selected `/research/ebpf-native-operation-trust-boundary/` report is **eBPF-centered**. It asks how verifier-approved BPF semantics can be delegated to native implementations without making every optimizer, backend, and generator part of the trusted computing base. The incoming eBPF report rotates the `2026-08-27` eBPF-centered complete-mediation report out of the newest-ten window, so after publication the mix remains **5 / 0 / 5** without changing any existing classification.
 
-Today's selected `/research/ebpf-portable-architecture-specialization/` report is
-**eBPF-centered**. Its central mechanism is a portability contract between
-portable BPF semantics, architecture-specific JIT capabilities, proof-linked
-native implementations, and deterministic fallback. eBPF is essential rather
-than optional instrumentation.
-
-The incoming eBPF report rotates the `2026-08-26` eBPF-centered authorization
-revocation report out of the newest-ten window, so after publication the mix
-remains **5 / 0 / 5**. This stays at the lower edge of the configured normal
-5–7 eBPF band without changing any existing classification.
-
-**eBPF Optimization and Execution Specialization** remains the active series.
-The September 5 report established verifier safety versus optimizer equivalence
-and profile-assumption lifetime. Today's report advances a separate second
-boundary: architecture-specific fast paths need explicit target eligibility,
-portable semantic witnesses, and safe fallback across JIT backends.
+**eBPF Optimization and Execution Specialization** remains the active series. September 5 covered optimizer equivalence and profile-assumption lifetime; September 6 covered architecture eligibility, portable semantic witnesses, and deterministic fallback; September 7 advances the separate trust/TCB boundary after a native implementation has already been selected.
 
 ## Current signals
 
 ### Google Search Console
 
-The exact configured Drive folder was rechecked on `2026-09-06`; no weekly source
-set newer than `2026-08-24..30` is present. Search Console rows remain verified
-through `2026-08-29`, with `2026-08-30` absent.
+The configured Drive folder was rechecked on `2026-09-07` and now contains a fresh `2026-08-31..09-06` set. Date rows are present through `2026-09-05`; under the configured three-day lag, rows through `2026-09-04` are treated as finalized and September 5 as partial.
 
-The source-native `2026-08-24..29` six-day slice contains **436 clicks / 55,594
-impressions / ~0.784% aggregate CTR / ~10.73 impression-weighted average
-position**. The equal-duration `2026-08-17..22` slice contains **477 / 59,798 /
-~0.798% / ~9.56**. Current clicks are about **8.6% lower**, impressions about
-**7.0% lower**, CTR about **0.013 percentage points lower**, and average position
-about **1.17 positions worse**.
+Finalized `2026-08-31..09-04` contains **368 clicks / 53,341 impressions / ~0.690% CTR / ~7.45 impression-weighted position**. Equal-duration `2026-08-24..28` contains **398 / 48,044 / ~0.828% / ~10.04**. Current clicks are about **7.5% lower**, impressions about **11.0% higher**, CTR about **0.139 percentage points lower**, and weighted position about **2.59 positions better**.
 
-This is not a complete seven-day trend. The preceding weekly export omits
-`2026-08-23`, the current set omits `2026-08-30`, and older gaps prevent a
-complete preceding 28-day source window. Missing rows are never interpreted as
-zero.
-
-Weekly page aggregates show Daily Report routes at **6 clicks / 1,017
-impressions** versus **5 / 744** in the preceding weekly page export. The exports
-lack a date-by-page dimension and the volume remains too small for a causal
-metadata, navigation, or topic conclusion.
+This is not a complete seven-day trend. Missing `2026-08-30` and `2026-09-06` prevent the configured complete short comparison, and older gaps prevent a complete 28-day comparison. Missing dates remain missing rather than zero.
 
 ### Google Analytics 4
 
-The finalized `2026-08-24..30` organic landing-page aggregate contains **1,007
-sessions** at about **45.88% session-weighted engagement**. The preceding
-finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29%
-engagement**.
+The new `2026-08-31..09-06` landing-page aggregate is present but is **partial** under the configured lag and lacks a date dimension. It is not compared as a finalized week.
 
-Sessions are about **2.3% higher** week over week while engagement is about
-**3.41 percentage points lower**. Weekly landing-page exports have no date
-dimension, so they cannot support within-week causal attribution to one report or
-page change.
+The latest fully finalized aggregate remains `2026-08-24..30`: **1,007 organic landing-page sessions** at about **45.88% session-weighted engagement**, versus **984 sessions** at about **49.29%** for `2026-08-17..23`. The finalized change remains about **+2.3% sessions** and **-3.41 percentage points engagement**.
 
 ### Public technical evidence
 
-The production robots file currently allows crawling and points at the canonical
-sitemap. The generated sitemap continues to expose canonical English/Chinese
-alternates, and public search discovery now exposes the September 5 English
-Daily Report. No current evidence establishes a crawl, robots, sitemap,
-canonical, hreflang, structured-data, redirect, broken-link, rendering,
-accessibility, persistent-performance, or deployment defect that justifies a
-separate technical SEO implementation change today.
+No current evidence establishes a crawl, robots, sitemap, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that justifies a separate technical SEO implementation change today. Report-coupled EN/ZH publication and index updates are the only search-facing change in scope.
 
-Cloudflare remains disabled by repository configuration, so no
-Cloudflare-grounded traffic, cache, bot, country, or status-code conclusion is
-made.
+Cloudflare remains disabled by repository configuration, so no Cloudflare-grounded conclusion is made.
 
 ## Current technical baseline
 
-The repository generates sitemap, robots, canonical, `hreflang`, Open Graph,
-structured data, legacy redirect stubs, and static audit artifacts. Production
-deploys through `Deploy Static App`.
+The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and static audit artifacts. Production deploys through `Deploy Static App`.
 
-The SEO skill submodule remains pinned at
-`516e9e2dcf012506a677a749049d64c5914643e9`. Its upstream `main` is newer at
-`f42128a3f05c73cf10c786a2711c488bb3a14839`, but the durable plan requires the
-consuming SEO contract to be migrated before the pointer moves. Upstream movement
-alone is not sufficient evidence for a pointer-only update.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. A newer upstream pointer is not adopted until the consuming SEO contract migration required by `plan.md` is completed.
 
 ## Current focus
 
-1. Complete PR `#189` through expected CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and exactly one merged-PR closeout comment.
-2. Advance **eBPF Optimization and Execution Specialization** with the architecture-portability boundary: one portable semantic witness, explicit native implementation eligibility, proof-linked multi-backend fast paths, and deterministic fallback.
-3. Keep the next question materially distinct. Delegated native-operation trust/TCB, safe high-level operation delegation, and machine-code debugging/provenance remain candidates; do not repeat today's capability negotiation or cross-JIT fallback thesis.
-4. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
-5. Keep Cloudflare evidence unavailable until a supported read-only path is enabled in repository configuration.
-6. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
+1. Complete today's single daily PR through authoritative CI, full final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, and exactly one top-level merged-PR closeout comment.
+2. Publish the third **eBPF Optimization and Execution Specialization** report on native-operation trust/TCB, with independent certificates, effect envelopes, and a semantic-divergence mutation benchmark.
+3. Keep later reports distinct from profile invalidation, architecture capability/fallback, cross-JIT portability, and today's native trust thesis. Safe higher-level delegation and specialized-code debugging/provenance remain candidates.
+4. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
+5. Keep the newest GA4 week partial until its dates are outside the finalization lag or a date-resolved export supports finalized comparison.
+6. Keep Cloudflare evidence unavailable until repository configuration enables a supported read-only path.
+7. Keep the shared SEO skill pointer unchanged until the consuming-contract migration is completed.
 
 Detailed run history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/docs/research/ebpf-native-operation-trust-boundary.md
+++ b/docs/research/ebpf-native-operation-trust-boundary.md
@@ -1,0 +1,156 @@
+---
+date: 2026-09-07
+title: "Can eBPF Delegate Native Operations Without Growing Its Trust Boundary?"
+description: "Native eBPF operations can bypass verifier-visible bytecode and expand the trusted computing base. This report defines proof-linked delegation and fault tests."
+tags:
+  - Daily Report
+  - eBPF
+  - JIT
+  - Program Verification
+  - Systems Security
+  - Compilers
+research_question: "How can eBPF delegate a verified semantic operation to native code without making every optimizer, backend, and native implementation part of the trusted computing base?"
+source_cutoff: 2026-09-07
+status: daily-report
+---
+
+# Can eBPF Delegate Native Operations Without Growing Its Trust Boundary?
+
+Suppose an eBPF optimizer recognizes a sequence that can execute as one native CPU instruction. The portable BPF sequence passes the verifier, the target machine supports the fast path, and the loader selects the right implementation. There is still one question left: **what proves that the native code actually does only what the verified BPF sequence was allowed to do?**
+
+This matters because the verifier reasons about BPF instructions and verifier-described calls, not arbitrary machine instructions inserted later by an optimizer. Once a specialization mechanism can replace verifier-visible work with native code, a bug in that replacement can become a kernel bug even when the original BPF program was safe.
+
+This report argues for a narrow design rule: **native delegation should carry a verifier-visible semantic witness and a separately checkable implementation certificate, so adding an optimization does not automatically add its compiler and generator to the trusted computing base.**
+
+<!-- more -->
+
+The previous report on [architecture-specific eBPF specialization](https://eunomia.dev/research/ebpf-portable-architecture-specialization/) asked which native implementation is eligible on a machine and what happens when no fast path exists. That is a portability problem. Here, assume the eligible implementation has already been selected correctly. The problem is whether selecting it silently enlarges the set of code whose correctness the kernel must trust.
+
+The earlier report on [runtime profile-guided specialization](https://eunomia.dev/research/ebpf-runtime-profile-specialization/) asks whether an optimization is still semantically justified when workload assumptions change. Here the assumptions may be timeless. A wrong native implementation can violate semantics on the very first execution.
+
+## The verifier can police a call boundary without proving the callee
+
+Linux already has a useful example in BPF kernel functions, or kfuncs. A kfunc exposes a kernel function to BPF programs. The current Linux documentation makes two properties explicit.
+
+First, the verifier can enforce a rich calling contract. Pointer arguments are trusted by default, BTF types constrain what may be passed, and flags such as `KF_ACQUIRE`, `KF_RELEASE`, `KF_RET_NULL`, `KF_SLEEPABLE`, `KF_RCU`, and `KF_DESTRUCTIVE` tell the verifier about lifetime, nullability, execution context, and unusually dangerous effects. For example, `KF_ACQUIRE` makes the verifier prove that a returned reference is eventually released or transferred into supported map state.
+
+Second, the implementation behind that boundary remains ordinary kernel code. Linux says an existing kernel function can be registered directly as a kfunc, while maintainers must still review the context in which BPF can invoke it and whether doing so is safe. The verifier guarantees valid arguments and tracks declared properties, but those declarations are not a proof of the function body.
+
+That split is productive. The verifier does not need to interpret all of Linux to check every BPF program. But it also exposes the trust question for optimizer-defined native operations: a precise call-site contract can keep BPF safe only if the delegated implementation respects the contract it advertises.
+
+The same distinction appears in the general verifier documentation. The verifier symbolically executes BPF instructions and checks function-call argument constraints. After a call, it updates register state according to the function prototype. This is an interface-level proof boundary, not a machine-code equivalence proof for the callee.
+
+## Kops makes the extra trusted code visible
+
+[Kops](https://arxiv.org/abs/2606.24213) is a useful case because it is explicit about the trade-off. A Kops operation has a proof sequence made from ordinary eBPF instructions and a native emit used by an architecture-specific JIT path. The ordinary sequence remains verifier-visible. The native emit is the per-operation code that must be trusted to implement the same semantics.
+
+For its hardware-idiom operations, Kops uses Lean 4 proofs to establish equivalence between a native emit and its BPF proof sequence. The paper reports up to 24% speedup on microbenchmarks and up to 12% on production applications. It also demonstrates whole-program native replacement, which reaches 2.358x in its evaluation but explicitly comes with a larger trusted computing base.
+
+That result sharpens the engineering choice. Faster native delegation is not one mechanism with one fixed safety cost. The trust cost depends on how much verifier-visible semantics remain and how much native code is accepted on faith.
+
+Linux's JIT controls point in the same direction from another angle. The kernel can enable JIT hardening to mitigate JIT spraying, and it provides privileged mechanisms for inspecting generated JIT code. Those controls do not prove semantic equivalence, but they show that generated native code is already treated as a security-sensitive execution artifact rather than an irrelevant implementation detail.
+
+## The missing contract is between semantic authority and implementation authority
+
+It helps to separate two questions that are often collapsed.
+
+A **semantic authority** says what an operation is allowed to do. For a native BPF operation, that could be an ordinary BPF proof sequence plus an explicit effect summary: which registers are inputs and outputs, which context or map memory may be touched, whether helpers or kfuncs may be called, and whether the operation can sleep, allocate, acquire references, or produce externally visible effects.
+
+An **implementation authority** says why this particular native body may stand in for that semantic operation. It should bind a concrete implementation hash to the semantic witness and to evidence that can be checked independently of the optimizer that generated it.
+
+A minimal package could look like this:
+
+```text
+semantic_op = rotate64_v1
+proof_seq_hash = sha256(portable_bpf_sequence)
+effects = {read: r1,r2; write: r0; memory: none; calls: none}
+
+native_impl_hash = sha256(machine_code)
+target = x86_64
+certificate = proof-or-translation-validation-result
+checker_version = v3
+```
+
+The exact representation is not the point. The important property is separation of duties. A userspace optimizer may search aggressively, a backend may generate machine code, and a small checker may decide whether the result is authorized. If the optimizer is wrong, the checker should reject the implementation rather than turn the optimizer into part of kernel safety.
+
+This is different from the capability manifest in the previous report. Capability negotiation answers, "May this implementation run here?" A trust contract answers, "Why is this implementation allowed to have the same authority as the verified semantic operation?"
+
+## Where current work is still weak
+
+### Kfunc-style contracts describe boundary obligations, not implementation equivalence
+
+Linux kfunc metadata is increasingly expressive about pointer trust, ownership, RCU state, sleepability, and destructive behavior. That helps the verifier reject unsafe calls. It still relies on kernel review and implementation correctness behind the boundary.
+
+For stable in-tree kernel functions, that may be the right engineering trade-off. It scales less comfortably to a model where userspace optimizers or third-party modules can introduce many machine-specific operations. Review-only trust grows roughly with every new implementation and backend.
+
+The missing evidence is whether a compact semantic/effect contract plus an independent checker can catch implementation mistakes that call-site typing cannot. A fault-injection study should mutate native bodies while leaving their advertised kfunc-like signature unchanged.
+
+### Proof-linked operations still need a deployable checker boundary
+
+Kops demonstrates that native emits can be related to verifier-visible proof sequences, and its Lean proofs are strong evidence for the evaluated operations. A production extension mechanism still has to decide what is checked at build time, load time, kernel integration time, or not at all.
+
+If every proof must be trusted because it came from a particular compiler pipeline, the trusted base has merely moved. If a tiny proof checker or translation validator can independently reject a malformed implementation, the generator can stay outside the trusted base.
+
+The missing benchmark is not another speed comparison. It is trusted-code growth versus escaped semantic bugs as the operation library and architecture matrix scale.
+
+### Whole-program native replacement changes the failure radius
+
+Replacing a small arithmetic idiom with one native instruction and replacing an entire BPF program with native code are both "native specialization," but their failure modes are not comparable. A small operation may have no memory effects. A whole program can touch packet or context memory, call helpers, update maps, and branch through many states.
+
+A useful trust model therefore needs an effect envelope, not only an equivalence label. If the checker cannot prove the full implementation, the runtime should at least know which classes of effects the native body is permitted to exercise and fail closed when it exceeds that envelope.
+
+## Promising directions with academic and production value
+
+### 1. Make native operations carry independently checkable certificates
+
+The first artifact should define a small certification interface for delegated BPF operations.
+
+Each operation carries a verifier-visible proof sequence, a stable semantic identity, an explicit effect summary, the native implementation, and a certificate checked by code that is substantially smaller than the optimizer or native generator. The certificate could be a proof object for a restricted operation language, translation-validation evidence, or another representation whose checker can be audited independently.
+
+The strongest baseline is not "no optimization." Compare against ordinary BPF/JIT execution, review-only native modules, and native operations whose generator is fully trusted. Measure accepted optimization coverage, checker time, code size, speedup, and trusted source lines or trusted components. Then inject wrong register results, clobbered callee-saved state, unauthorized memory writes, missing side effects, and backend-specific corner cases.
+
+The academic question is whether the trust of an extensible JIT can scale with a small checker rather than with every optimizer/backend implementation. The production value is the ability to accept third-party or rapidly evolving native optimizations without treating their entire toolchain as kernel-trusted code.
+
+The idea loses if the certificate/checker becomes almost as complex as the optimizer or if nearly all useful operations require semantics too broad for compact checking.
+
+### 2. Enforce a runtime effect envelope around partially verified delegation
+
+Some useful native operations may be too complex for a complete proof. A second design can still reduce their failure radius.
+
+Give each operation an effect envelope derived from verifier-visible semantics: permitted register outputs, memory regions, helper/kfunc call classes, reference-lifetime changes, and control-flow return behavior. The JIT or runtime inserts cheap guards only where native code could cross that envelope. High-risk operations can additionally run differential canaries against the portable BPF form during deployment or after a kernel/JIT update.
+
+This is not a portability fallback mechanism. The target is already capable of running the native operation. The mechanism asks whether a buggy implementation can escape the authority it was delegated. On a violated guard or differential mismatch, the runtime disables that implementation generation and records the failure.
+
+Evaluate with deliberately malformed native operations and realistic hardware idioms. Measure semantic escapes, detection latency, guard overhead, false positives, and the percentage of operations that can be contained without full proof. Compare full proof, effect-only containment, shadow execution, and review-only trust.
+
+The production user is an operator running an extensible re-JIT or BPF runtime across frequent kernel and optimizer updates. The design is not worthwhile if effect guards cost more than the native optimization saves or if most important semantic failures occur entirely inside the declared envelope.
+
+### 3. Build a TCB mutation benchmark for eBPF specialization
+
+Current optimization evaluation naturally emphasizes verifier acceptance, code size, and runtime. A trust-boundary benchmark should make the optimizer fail on purpose.
+
+Start from a corpus of verifier-accepted BPF programs and certified native operations. Generate controlled mutations: wrong arithmetic flags, stale architecture assumptions, register clobbers, unauthorized loads/stores, missing reference releases, extra helper calls, incorrect exceptional cases, and malicious certificates. Run them under several trust designs: stock BPF/JIT, kfunc-style typed boundary, review-only native delegation, proof-linked delegation, and proof-linked delegation plus effect containment.
+
+The primary metric is **escaped semantic violation**, not crash rate. A mutation fails the system if native execution produces an observable state that the verifier-approved semantic program could not produce. Secondary metrics include trusted-code growth per new operation/backend, certification latency, optimization coverage, runtime overhead, and debugging evidence after rejection.
+
+Such a benchmark would let systems papers make a stronger claim than "our extension is safe by construction." It would show which faults the construction actually excludes and where trust still accumulates. In production, the same corpus can become regression tests for new JIT backends and operation libraries.
+
+The benchmark is less useful if independent implementations almost never expose failures beyond what normal kernel testing already catches. That outcome would itself argue for simpler review-and-test processes rather than a new certification layer.
+
+## What would change this conclusion?
+
+The need for a separate native-operation trust contract becomes much weaker if profitable specialization can remain entirely in verifier-visible BPF. EPSO and other BPF-level optimizers show why that simpler design is attractive: optimized bytecode can still pass through the existing verifier and stock JIT. If native operations add little performance beyond such rewrites, moving the trust boundary is unnecessary.
+
+The conclusion also weakens if native delegation remains a tiny, stable, in-tree mechanism maintained like other kernel code. Linux already relies on review for kfunc implementations and JIT backends. If an optimization interface exposes only a handful of mature operations and never becomes a third-party extension surface, the existing kernel trust model may be sufficient.
+
+Finally, an empirical mutation study could show that a small checker adds little protection. If almost every realistic implementation fault is already caught by compiler validation, architecture tests, verifier-side contracts, and ordinary kernel review, certificate complexity would not pay for itself.
+
+But an extensible optimizer changes the scaling assumption. Kfuncs show that the verifier can enforce precise obligations at a trusted call boundary. Kops shows that native operations can retain verifier-visible semantic witnesses and that larger native replacement buys more speed at the cost of a larger TCB. **The next abstraction should make that cost explicit and checkable: delegate authority to a native implementation only when independent evidence binds it to the semantics the verifier approved.**
+
+## References
+
+- Linux kernel documentation. [eBPF verifier](https://www.kernel.org/doc/html/latest/bpf/verifier.html), accessed 2026-09-07.
+- Linux kernel documentation. [BPF Kernel Functions (kfuncs)](https://www.kernel.org/doc/html/latest/bpf/kfuncs.html), accessed 2026-09-07.
+- Linux kernel documentation. [Documentation for /proc/sys/net/](https://kernel.org/doc/html/latest/admin-guide/sysctl/net.html), accessed 2026-09-07.
+- Yusheng Zheng et al. [Kops: Safely Extending the eBPF Compilation Pipeline with Native Operations](https://arxiv.org/abs/2606.24213), 2026.
+- Qian Zhu et al. [EPSO: A Caching-Based Efficient Superoptimizer for BPF Bytecode](https://arxiv.org/abs/2511.15589), 2025.

--- a/docs/research/ebpf-native-operation-trust-boundary.zh.md
+++ b/docs/research/ebpf-native-operation-trust-boundary.zh.md
@@ -1,0 +1,156 @@
+---
+date: 2026-09-07
+title: "eBPF 把操作交给原生代码后，怎样控制可信边界？"
+description: "eBPF 原生操作可能绕过 verifier 可见的字节码，并扩大可信计算基。本文分析怎样用语义证明、独立检查和故障测试控制这种委托。"
+tags:
+  - Daily Report
+  - eBPF
+  - JIT
+  - 程序验证
+  - 系统安全
+  - 编译器
+research_question: "eBPF 怎样把已经验证的语义操作委托给原生代码，同时避免把每个优化器、后端和原生实现都纳入可信计算基？"
+source_cutoff: 2026-09-07
+status: daily-report
+---
+
+# eBPF 把操作交给原生代码后，怎样控制可信边界？
+
+假设一个 eBPF 优化器发现，原本需要多条 BPF 指令完成的操作，在某种 CPU 上可以用一条原生指令实现。原来的 BPF 序列已经通过 verifier，目标机器也支持这个快路径，loader 还正确选中了对应实现。此时仍然少了一个问题：**谁来证明这段原生代码只做了那份 BPF 程序被允许做的事情？**
+
+这个问题不能靠 verifier 自动解决。verifier 分析的是 BPF 指令，以及它已知语义的函数调用；优化器之后插入的任意机器码并不在这套分析里。一旦 specialization 允许用原生代码替换 verifier 看过的逻辑，原生实现里的一个错误就可能变成内核错误，即使最初的 BPF 程序完全安全。
+
+本文的判断是：**原生委托应该同时携带 verifier 可见的语义依据，以及可以独立检查的实现证据。这样，新增一个优化不必自动把它的优化器和代码生成器一起放进可信计算基。**
+
+<!-- more -->
+
+上一篇关于[特定架构 eBPF 优化可移植性](https://eunomia.dev/zh/research/ebpf-portable-architecture-specialization/)的报告讨论的是：某个原生实现能不能在这台机器上使用，如果不能应该怎样安全退回 portable BPF。那是 capability 和 portability 问题。本文假设目标实现已经正确选出来，只追问它获得与原始 BPF 相同执行权限的理由是否可信。
+
+更早一篇关于[运行时画像驱动 eBPF specialization](https://eunomia.dev/zh/research/ebpf-runtime-profile-specialization/)的报告讨论 workload assumption 会不会过期。本文的错误不需要等 workload 改变才出现。一段实现错误的 native emit 第一次执行就可能偏离原始语义。
+
+## Verifier 可以约束调用边界，却不会自动证明被调用函数
+
+Linux 的 BPF kernel function，也就是 kfunc，是一个很好的现成例子。kfunc 把内核函数暴露给 BPF 程序。当前 Linux 文档明确体现出两个层次。
+
+第一层是 verifier 可以检查相当丰富的调用契约。指针参数默认需要可信，BTF 类型限制可以传入什么对象，而 `KF_ACQUIRE`、`KF_RELEASE`、`KF_RET_NULL`、`KF_SLEEPABLE`、`KF_RCU` 和 `KF_DESTRUCTIVE` 等标记告诉 verifier 资源生命周期、空指针、执行上下文和危险 effect 应该怎样处理。例如，一个 `KF_ACQUIRE` kfunc 返回引用以后，verifier 会继续检查这份引用最终是否被释放，或者被转移进支持的 map 状态。
+
+第二层是调用边界后面的实现仍然是普通内核代码。Linux 文档说明，已有内核函数可以直接注册成 kfunc，但维护者仍然需要审查 BPF 在什么上下文调用它，以及这样做是否安全。verifier 能保证参数有效，并追踪已经声明的属性；这些声明本身并不会证明函数体实现正确。
+
+这种划分本身很合理。否则 verifier 为了验证一个 BPF 程序，就得理解整个 Linux 内核。但是，当 userspace optimizer 或第三方模块可以不断加入新的机器相关操作时，这个划分也把 trust 问题暴露得很清楚：边界契约只有在委托实现真的遵守契约时才有效。
+
+通用的 [eBPF verifier 文档](https://www.kernel.org/doc/html/latest/bpf/verifier.html)也体现同样的关系。verifier 对 BPF 指令做符号执行，对函数调用检查参数约束，并在调用后按照函数原型更新寄存器状态。这是一条 interface-level proof boundary，而不是对 callee 机器码做语义等价证明。
+
+## Kops 把新增的可信代码明确暴露出来
+
+[Kops](https://arxiv.org/abs/2606.24213) 很适合分析这个问题，因为它直接讨论了这笔 trade-off。每个 Kops operation 都有两种表示：一份由普通 eBPF 指令组成、可以交给现有 verifier 检查的 proof sequence；以及一份架构相关 JIT 可以使用的 native emit。普通序列仍然处于 verifier 的语义世界里，native emit 则是每个 operation 新增的可信实现。
+
+对于文中实现的硬件 idiom，Kops 使用 Lean 4 证明 native emit 与 BPF proof sequence 等价。论文报告在 microbenchmark 上最高 24% 的加速，在生产应用上最高 12%。它还演示了 whole-program native replacement，在评测中达到 2.358x，但论文也明确指出这会换来更大的 trusted computing base（TCB）。
+
+这使工程选择变得更具体。原生委托不是只有“快或者不快”一个维度。它留下多少 verifier 可见语义、又把多少机器码放进必须信任的范围，直接决定了安全成本。
+
+Linux 对 BPF JIT 的控制也从另一个角度说明原生代码是安全敏感对象。内核提供 JIT hardening 来降低 JIT spraying 风险，也提供面向特权用户的 JIT 代码观察机制。这些措施不证明语义等价，但它们说明最终机器码并不是一个可以忽略的实现细节。
+
+## 真正缺少的是语义权限与实现权限之间的契约
+
+这里最好把两个经常混在一起的问题分开。
+
+**语义权限**定义一个 operation 被允许做什么。对原生 BPF operation 来说，它可以由一份普通 BPF proof sequence 加上一份明确的 effect summary 表示：哪些寄存器是输入和输出，可以读写哪些 context 或 map memory，是否允许调用 helper/kfunc，是否可能 sleep、分配资源、取得引用或者产生外部可见 effect。
+
+**实现权限**则回答：为什么这一段具体机器码可以代替上面的语义操作。它应该把一个确定的实现 hash 与语义依据绑定，再附上可以由独立 checker 验证的证据，而不是只相信生成它的 optimizer。
+
+一个最小的表示可能类似：
+
+```text
+semantic_op = rotate64_v1
+proof_seq_hash = sha256(portable_bpf_sequence)
+effects = {read: r1,r2; write: r0; memory: none; calls: none}
+
+native_impl_hash = sha256(machine_code)
+target = x86_64
+certificate = proof-or-translation-validation-result
+checker_version = v3
+```
+
+具体字段并不是本文要提前冻结的 ABI。关键在于职责分离：userspace optimizer 可以大胆搜索优化，backend 可以生成机器码，而一个远小于 optimizer 的 checker 决定产物是否能获得执行权限。如果 optimizer 出错，应该是 checker 拒绝它，而不是因此把整个 optimizer 变成内核安全的一部分。
+
+这与上一篇的 capability manifest 不同。capability negotiation 回答“这个实现能不能在这台机器上运行”；trust contract 回答“为什么这份实现可以获得与 verifier 已批准语义相同的权限”。
+
+## 现有研究还缺什么
+
+### kfunc 式契约能约束边界，却不能证明实现等价
+
+Linux kfunc 的 metadata 已经可以表达 pointer trust、ownership、RCU 状态、sleepability 和 destructive behavior。verifier 因此可以拒绝许多不安全调用。但边界后面仍然依赖内核代码审查和实现本身正确。
+
+对于少量、稳定、in-tree 的 kernel function，这可能就是合理的工程取舍。但如果将来 userspace optimizer 或第三方模块可以加入大量 machine-specific operation，单靠 review 的可信范围会随着 operation 数量和 backend 数量一起扩大。
+
+这里缺的不是更多类型标记，而是一项故障实验：保持 kfunc-like signature 和声明 effect 完全不变，只故意修改 native body，看看 compact semantic/effect contract 加独立 checker 能捕获多少 call-site typing 捕获不了的错误。
+
+### proof-linked operation 仍然需要可部署的 checker boundary
+
+Kops 已经说明 native emit 可以与 verifier 可见的 proof sequence 建立形式关系，Lean 证明也为文中评测的 operation 提供了强证据。生产扩展机制还必须决定：什么在 build time 检查，什么在 load time 检查，什么在进入 kernel 时检查，以及哪些东西最终仍然只能信任。
+
+如果系统因为“proof 是某个 compiler pipeline 生成的”就直接信任 proof，那么可信范围只是搬了位置。相反，如果一个很小的 proof checker 或 translation validator 能独立拒绝错误实现，生成器就可以留在 TCB 外面。
+
+真正需要测的是 operation library 和 architecture matrix 扩大时，trusted-code growth 与 escaped semantic bug 怎样变化，而不是再做一次单纯的 speedup benchmark。
+
+### whole-program native replacement 会扩大一次错误的影响范围
+
+把一个算术 idiom 替换成一条机器指令，与把完整 BPF 程序替换成 native code 都可以叫 native specialization，但它们的 failure radius 完全不同。小 operation 可能根本不碰内存；完整程序则可能读写 packet/context、调用 helper、更新 map，并经过很多控制流状态。
+
+因此 trust model 不能只有一个“equivalent”标签，还需要 effect envelope。如果系统暂时无法完整证明实现，至少应该知道 native body 获准使用哪些类别的 effect，并在越界时 fail closed。
+
+## 兼具学术价值与生产价值的方向
+
+### 1. 让每个 native operation 携带可独立检查的证书
+
+第一个 artifact 可以是一套小型 delegated BPF operation certification interface。
+
+每个 operation 携带 verifier 可见的 proof sequence、稳定 semantic identity、明确 effect summary、native implementation，以及由一个明显小于 optimizer/code generator 的 checker 验证的 certificate。证书可以是受限 operation language 上的 proof object，也可以是 translation-validation evidence；关键是 checker 本身能够独立审计。
+
+最强 baseline 不应该只是“不开优化”。应该同时比较 stock BPF/JIT、只靠人工 review 的 native module，以及把整个 generator 当成 trusted component 的 native operation。评测 acceptance coverage、checker latency、代码体积、speedup，以及新增 operation/backend 带来的 trusted source lines 或 trusted component 数量。然后主动注入错误：算错寄存器结果、破坏 callee-saved state、越权内存写、漏掉 side effect、架构 corner case。
+
+学术问题是：可扩展 JIT 的可信范围能否只随着一个小 checker 增长，而不是随着所有 optimizer/backend 实现增长。生产价值则是让快速演化、甚至第三方提供的 native optimization 不必整套进入 kernel trust boundary。
+
+如果 certificate/checker 最后复杂到接近 optimizer 本身，或者绝大多数有价值的 operation 都无法用紧凑语义检查，这个方向就不值得。
+
+### 2. 给无法完整证明的委托加 runtime effect envelope
+
+有些 native operation 可能太复杂，完整证明成本很高。第二个方向仍然可以把故障范围收紧。
+
+从 verifier 可见语义生成 effect envelope，限定它能输出哪些寄存器、访问哪些内存区域、调用哪类 helper/kfunc、怎样改变 reference lifetime，以及如何返回控制流。JIT 或 runtime 只在 native code 有机会越过这些边界的位置插入便宜 guard。高风险 operation 在部署初期或者 kernel/JIT 更新后，还可以用 portable BPF 版本做小比例 differential canary。
+
+这里不是在解决跨架构 fallback。目标机器已经有能力执行这个 native operation。机制要解决的是：实现有 bug 时，它能不能逃出自己被委托的权限。一旦 guard 违规或 differential result 不一致，runtime 就禁用这一代 implementation，并保留明确的失败记录。
+
+评测可以故意制造坏的 native operation，比较 full proof、effect-only containment、shadow execution 和 review-only trust。主要指标包括 semantic escape 数量、检测延迟、guard overhead、false positive，以及多少 operation 能在没有 full proof 的情况下被有效限制。
+
+生产用户是频繁升级 kernel 和 optimizer、同时允许 extensible re-JIT 的 operator。如果 guard 成本比优化本身省下的时间还高，或者大多数真正语义错误都发生在已声明 envelope 内，这个方向就失去价值。
+
+### 3. 做一个专门攻击 TCB 的 eBPF specialization benchmark
+
+现在的 optimization evaluation 自然会测 verifier acceptance、code size 和 runtime。trust-boundary benchmark 应该反过来，主动让 optimizer 出错。
+
+从 verifier 已接受的 BPF 程序与正常 native operation 开始，系统化生成受控 mutation：错误 arithmetic flag、过期架构假设、register clobber、越权 load/store、漏掉 reference release、多余 helper call、异常 case 错误，以及恶意 certificate。然后分别在 stock BPF/JIT、kfunc-style typed boundary、review-only native delegation、proof-linked delegation，以及 proof-linked + effect containment 下运行。
+
+第一指标应该是 **escaped semantic violation**，而不是 crash rate。只要 native 执行产生了 verifier-approved semantic program 不可能产生的可观测状态，就算系统没有守住边界。第二指标再看每增加一个 operation/backend 带来的 trusted-code growth、certification latency、optimization coverage、runtime overhead，以及拒绝后能留下多少 debugging evidence。
+
+这样的 benchmark 能让系统论文不只写“safe by construction”，而是展示 construction 实际挡住哪些错误、trust 还在哪里累积。生产环境也可以把同一套 mutation corpus 用作新 JIT backend 或 operation library 的回归测试。
+
+如果独立实现几乎从不暴露普通 kernel testing 发现不了的错误，这项 benchmark 也会给出有价值的反结论：继续依赖更简单的 review-and-test 流程，而不是增加新的 certification layer。
+
+## 哪些结果会改变这个判断？
+
+如果有价值的 specialization 基本都能留在 verifier 可见的 BPF 世界里，那么单独设计 native-operation trust contract 的必要性会大幅下降。EPSO 一类 BPF-level optimizer 正说明了这种简单路径为什么有吸引力：优化后的 bytecode 仍然能走已有 verifier 和 stock JIT。如果 native operation 对这些 rewrite 的额外收益很小，就没有必要移动 trust boundary。
+
+如果 native delegation 最终只包含很少量、长期稳定、完全 in-tree 的 mechanism，这个结论也会变弱。Linux 本来就依赖 code review 来信任 kfunc implementation 和 JIT backend。如果扩展接口始终不会变成第三方 operation surface，现有 kernel trust model 可能已经足够。
+
+最后，一项真实 mutation study 也可能证明 small checker 没有带来多少额外保护。如果绝大多数 realistic implementation fault 已经会被 compiler validation、architecture tests、verifier-side contract 和普通内核 review 捕获，那么 certificate complexity 就不划算。
+
+但 extensible optimizer 改变了规模假设。kfunc 说明 verifier 可以在 trusted call boundary 上强制很多精确义务；Kops 则说明 native operation 可以继续保留 verifier-visible semantic witness，并且更大的 native replacement 会用更大的 TCB 换速度。**下一步值得做的抽象，是把这笔 trust 成本变得显式、可检查：只有当独立证据把 native implementation 与 verifier 已批准语义绑定起来时，才把对应权限委托给它。**
+
+## 参考资料
+
+- Linux kernel documentation. [eBPF verifier](https://www.kernel.org/doc/html/latest/bpf/verifier.html)，访问于 2026-09-07。
+- Linux kernel documentation. [BPF Kernel Functions (kfuncs)](https://www.kernel.org/doc/html/latest/bpf/kfuncs.html)，访问于 2026-09-07。
+- Linux kernel documentation. [Documentation for /proc/sys/net/](https://kernel.org/doc/html/latest/admin-guide/sysctl/net.html)，访问于 2026-09-07。
+- Yusheng Zheng et al. [Kops: Safely Extending the eBPF Compilation Pipeline with Native Operations](https://arxiv.org/abs/2606.24213), 2026.
+- Qian Zhu et al. [EPSO: A Caching-Based Efficient Superoptimizer for BPF Bytecode](https://arxiv.org/abs/2511.15589), 2025.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Can eBPF Delegate Native Operations Without Growing Its Trust Boundary?](https://eunomia.dev/research/ebpf-native-operation-trust-boundary/)
+
+A verifier-approved BPF sequence can still become unsafe if an optimizer replaces it with native code whose implementation is simply trusted. This report separates semantic authority from implementation authority and develops independently checked operation certificates, runtime effect envelopes, and a mutation benchmark whose primary metric is escaped semantic divergence.
+
 ### [Can Architecture-Specific eBPF Optimization Stay Portable?](https://eunomia.dev/research/ebpf-portable-architecture-specialization/)
 
 BPF bytecode can stay portable while JIT backends use different machine instructions, but optimizer-added native fast paths need a clearer deployment contract. This report develops two-level capability negotiation, proof-linked multi-backend operation packages, and a cross-JIT benchmark that treats safe fallback and performance portability as first-class outcomes.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [eBPF 把操作交给原生代码后，怎样控制可信边界？](https://eunomia.dev/zh/research/ebpf-native-operation-trust-boundary/)
+
+一段通过 verifier 的 BPF 语义，如果被 optimizer 换成只靠信任的 native code，仍然可能越过原来的安全边界。本文把 semantic authority 与 implementation authority 分开，提出可独立检查的 operation certificate、runtime effect envelope，以及以 escaped semantic violation 为主指标的 mutation benchmark。
+
 ### [eBPF 针对特定架构做优化后，还能保持可移植吗？](https://eunomia.dev/zh/research/ebpf-portable-architecture-specialization/)
 
 同一份 BPF bytecode 可以跨架构加载，但 optimizer 自己加入的 native fast path 需要更明确的 deployment contract。本文提出两层 capability negotiation、一个 semantic operation 搭配多个 proof-linked backend，以及把安全 fallback 和 performance portability 一起测量的 cross-JIT benchmark。


### PR DESCRIPTION
## Summary

- publish the 2026-09-07 bilingual Daily Report on delegated native-operation trust and TCB growth
- update the English/Chinese Daily Report indexes and active-series roadmap
- refresh Google source coverage and operating state from the new 2026-08-31..09-06 export set
- make no unrelated technical SEO implementation change because current evidence does not establish a concrete defect

## Report boundary

This is distinct from the September 6 architecture-portability report. It assumes an eligible native implementation has already been selected and asks why that implementation may exercise the same authority as verifier-approved BPF semantics without making every optimizer/backend trusted.

The report develops independently checked native-operation certificates, runtime effect envelopes for partially verified delegation, and a TCB mutation benchmark whose primary correctness oracle is escaped semantic divergence.

## Data handling

GSC finalized rows are used through 2026-09-04 under the configured three-day lag. Missing 2026-08-30 and absent 2026-09-06 prevent a complete seven-day comparison; older gaps prevent the required complete 28-day comparison. The new GA4 2026-08-31..09-06 weekly aggregate is treated as partial because it has no date dimension and includes dates inside the lag. Missing coverage is not converted to zero.

## Validation

Authoritative expected checks are `Validate SEO Operations` and `Deploy Static App`. Merge only after terminal green checks and a complete final diff/generated-output self-review.