### PR TITLE
Daily: define evidence for eBPF optimization promotion

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -12,15 +12,15 @@ already configured and enabled; it is not a blocker.
 
 ## Current data-history constraint
 
-Google Drive access is verified and is not a blocker. The configured folder was directly rechecked on `2026-09-07` and now contains the `2026-08-31..09-06` weekly source set.
+Google Drive access is verified and is not a blocker. The configured folder was directly rechecked on `2026-09-11`; no weekly source set newer than `2026-08-31..09-06` is present.
 
-For Search Console, the newest date export contains rows for `2026-08-31..09-05` and no row for `2026-09-06`. Under the configured three-day finalization lag, the newest finalized contiguous slice is `2026-08-31..09-04`. Those five rows sum to **368 clicks and 53,341 impressions**, with aggregate CTR about **0.690%** and impression-weighted average position about **7.45**.
+For Search Console, the newest date export contains rows for `2026-08-31..09-05` and no row for `2026-09-06`. Under the configured three-day finalization lag, all currently observed rows through September 5 are finalized. The finalized six-day `2026-08-31..09-05` slice contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**.
 
-The equal-duration finalized `2026-08-24..28` slice contains **398 clicks / 48,044 impressions / ~0.828% CTR / ~10.04 weighted position**. Relative to that slice, the current five days have about **7.5% fewer clicks**, **11.0% more impressions**, CTR about **0.139 percentage points lower**, and weighted average position about **2.59 positions better**. This is useful source-native evidence but is not a complete seven-day trend.
+The equal-duration finalized `2026-08-24..29` slice contains **436 clicks / 55,594 impressions / ~0.784% CTR / ~10.73 weighted position**. Relative to that slice, the current six days have about **11.0% fewer clicks**, **9.5% more impressions**, CTR about **0.147 percentage points lower**, and weighted average position about **3.38 positions better**. This is useful source-native evidence but is not a complete seven-day trend.
 
-A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the previous weekly export omits `2026-08-30`. Older history includes the previously recorded `2026-08-23` gap and other incompleteness, so the required complete 28-day versus preceding-comparable-period comparison is also unavailable. Missing rows are never converted to zero.
+A complete latest-seven-days versus previous-seven-days comparison remains unavailable because the newest weekly export omits `2026-09-06` and the preceding weekly export omits `2026-08-30`. Older history includes the recorded `2026-08-23` gap and other incompleteness, so the required complete 28-day versus preceding-comparable-period comparison is also unavailable. Missing rows are never converted to zero.
 
-The new GA4 organic landing-page aggregate for `2026-08-31..09-06` contains **913 sessions** at about **47.54% session-weighted engagement**, but it includes dates inside the configured finalization lag and has no date dimension. It is therefore partial. The latest fully finalized weekly aggregate remains `2026-08-24..30` at **1,007 sessions** and about **45.88% engagement**.
+The newer frozen GA4 organic landing-page aggregate for `2026-08-31..09-06` contains **913 sessions** at about **47.54% session-weighted engagement**, but it was produced while lagged dates were present and has no date dimension for safe finalized subsetting. It therefore remains partial. The latest fully finalized weekly aggregate remains `2026-08-24..30` at **1,007 sessions** and about **45.88% engagement**.
 
 These constraints never justify skipping the daily operation. Each run must use the available Google evidence, live-site evidence, public GitHub evidence, and public primary-source evidence; missing or partial coverage must never be converted into zero. Every run must still publish one new Daily Report under the current repository contract.
 

--- a/.github/seo-data/content-series.md
+++ b/.github/seo-data/content-series.md
@@ -1,9 +1,9 @@
 # Daily Report content series
 
 This file is the authoritative thematic roadmap for scheduled Daily Report work.
-Daily Report is eBPF-first and series-driven. The goal is to build durable
-technical ownership around eBPF and adjacent systems topics rather than publish
-unrelated daily news.
+Daily Report is eBPF-first and series-driven. The goal is durable technical
+ownership around eBPF and adjacent systems topics rather than unrelated daily
+news.
 
 ## Editorial mix
 
@@ -14,627 +14,254 @@ Reports:
   measurement substrate, comparison point, or systems boundary.
 - **Pure AI-agent topics are capped at 1–2 of 10.** Agent topics that primarily
   study eBPF instrumentation, policy enforcement, profiling, or runtime
-  mechanisms count as eBPF-centered when eBPF is essential to the technical
-  question rather than a decorative mention.
-- The remaining reports may cover directly adjacent systems areas such as Linux
-  kernels, observability, profiling, networking, security, runtimes, GPU and
-  heterogeneous systems, distributed systems, compilers, or storage.
-- Until the archive reaches 10 reports, apply the same proportions to the
-  available set as closely as possible.
-
-Record the rolling mix in the daily operating record before selecting a topic.
-Do not manipulate classification to satisfy the ratio; classify by the report's
-actual central technical question.
+  mechanisms count as eBPF-centered only when eBPF is essential to the question.
+- Remaining reports may cover directly adjacent Linux, observability, profiling,
+  networking, security, runtime, GPU, distributed-systems, compiler, or storage
+  questions.
+- Record the rolling mix before topic selection. Never relabel old reports or add
+  an extra report merely to repair the ratio.
 
 ## Daily publication rule
 
-Every scheduled daily run must publish **one new Daily Report page**. `no-report`
-is not an allowed completion outcome.
+Every scheduled daily run publishes **exactly one new bilingual Daily Report**.
+`no-report` is not an allowed normal completion outcome. A weak first candidate
+must be rejected and replaced with another approved question rather than padded
+with weak evidence.
 
-This is a publication requirement, not permission to lower the quality bar. If
-the first candidate fails the evidence, gap, novelty, or usefulness gates, reject
-that candidate and continue research on another question in the approved roadmap
-until one passes. Prefer changing the question over padding weak evidence or
-inventing novelty.
-
-A daily report must still provide:
-
-- a concrete reader problem;
-- primary-source evidence;
-- a non-trivial gap or unresolved mechanism;
-- a reasoned technical conclusion;
-- a small number of implementable research directions with academic and
-  production value;
-- a discriminating evaluation or evidence that would change the conclusion;
-- a thesis that does not duplicate an existing report.
+Every report must provide a concrete reader problem, primary-source evidence, a
+non-trivial unresolved mechanism, a reasoned conclusion, a small number of
+implementable research directions, a discriminating evaluation, and evidence
+that would change the conclusion. The thesis must not duplicate an existing
+report.
 
 ## Series rules
 
-- Keep one **active series** for normal daily publication. A series normally
-  contains 4–6 substantial reports that build on one another.
-- Search inside the active series first. Each new report must answer a distinct
-  question and materially advance the series argument.
-- Reuse valid evidence maps, unresolved questions, experiments, terminology, and
-  counterexamples from earlier reports, but never copy the thesis with a new
-  example.
-- If the active series cannot yield a publishable report on a given day, move to
-  another approved eBPF or adjacent-systems series for that run rather than
-  publishing weak material.
+- Keep one active series for normal publication. A series normally contains 4–6
+  substantial reports that build on one another.
+- Search the active series first when the rolling mix permits it. Each report
+  must answer a distinct question.
+- If the active series cannot yield a publishable report or the mix temporarily
+  blocks its classification, use a technically strong approved detour rather
+  than violate the quality or mix gates.
 - A material external development may justify an out-of-series report when it
-  has durable systems consequences and still respects the rolling topic mix.
-- Search Console, GA4, GitHub activity, reader pathways, and technical releases
-  can influence ordering inside the roadmap, but short-lived popularity does not
-  override the editorial mix or technical quality standard.
-- After a series has at least three strong reports, consider a public series hub
-  and stronger internal linking. Do not create thin hub pages in advance.
+  has durable systems consequences.
+- After a series has at least three strong reports, consider stronger internal
+  linking or a public hub only when acquisition/navigation evidence supports it.
+
+## Completed series — eBPF Runtime, Extensibility, and Composition
+
+Working question: **What mechanisms are missing if eBPF is treated as a
+programmable runtime substrate rather than only a kernel observability feature?**
+
+This series reached its normal six-report boundary on `2026-08-17`:
+
+1. `2026-08-08` — `/research/userspace-ebpf-runtime-contract/`: first-class
+   userspace eBPF attachment, capability, state, lifetime, and attribution.
+2. `2026-08-09` — `/research/ebpf-hook-composition-contract/`: effect visibility,
+   outcome resolution, shared-state ownership, and versioned hook composition.
+3. `2026-08-10` — `/research/stateful-ebpf-transactional-upgrade/`: prepare /
+   migrate / commit / retire upgrade generations for programs, links, maps,
+   pinned state, controller recovery, and rollback.
+4. `2026-08-12` — `/research/async-ebpf-causal-profiler/`: typed lifetime-aware
+   causal handoff edges across `io_uring`, workqueues, runtimes, and application
+   resources.
+5. `2026-08-15` — `/research/io-uring-bpf-programmability/`: cBPF admission
+   versus eBPF `io_uring_bpf_ops`, capability, policy generation, provenance,
+   and resource ownership.
+6. `2026-08-17` — `/research/heterogeneous-ebpf-execution-placement/`: target
+   manifests and generation-scoped state ownership across kernel, userspace,
+   NIC/DPU, and GPU-side execution.
+
+Return only when fresh evidence supports a mechanism beyond these boundaries.
+
+## Completed series — eBPF Observability and Profiling
+
+Working question: **Which important performance and correctness questions remain
+unanswerable with today's eBPF observability stack?**
+
+The series reached six reports on `2026-08-22`:
+
+1. `2026-08-18` — `/research/page-level-ebpf-memory-attribution/`: allocation,
+   residency, page lifecycle, and sampled-memory provenance.
+2. `2026-08-19` — `/research/profiler-sampling-bias/`: adjacent-systems sampling
+   aliasing, skid, uncertainty, and selective instrumentation.
+3. `2026-08-20` — `/research/gpu-kernel-launch-latency/`: adjacent host/runtime/
+   queue/dependency/device launch-delay attribution.
+4. `2026-08-20` — `/research/gpu-host-device-causality/`: adjacent host/device
+   causal identity and dependency-aware critical paths.
+5. `2026-08-21` — `/research/ebpf-application-resource-semantics/`: versioned
+   resource-semantics manifests and confidence under software evolution.
+6. `2026-08-22` — `/research/ebpf-diagnostic-telemetry-compression/`: diagnostic
+   contracts, bounded exemplars, coverage, and equal-budget diagnosis retention.
+
+Do not add a seventh report merely by renaming one of these boundaries.
 
 ## Completed series — eBPF Networking and Security
 
 Working question: **Where are eBPF networking and security mechanisms still
 missing deployable abstractions or correctness guarantees?**
 
-This series became active after the `2026-08-22` report completed the normal
-six-report boundary for eBPF Observability and Profiling and reached its own
-normal six-report boundary on `2026-08-28`.
+This series became active after Observability and Profiling and reached six
+reports on `2026-08-28`:
 
-The roadmap initially preferred transactional policy updates across programs,
-maps, links, and userspace control planes. Fresh novelty review on `2026-08-23`
-rejected that candidate because `/research/stateful-ebpf-transactional-upgrade/`
-already develops a prepare / migrate / commit / retire generation protocol across
-programs, links, maps, pinned state, controller recovery, and rollback. Repeating
-the same update transaction with a networking example would not materially
-advance the archive.
+1. `2026-08-23` — `/research/ebpf-network-policy-composition/`: authority-aware
+   composition and generation-stable verdict provenance.
+2. `2026-08-24` — `/research/ebpf-zero-copy-buffer-ownership/`: generation-scoped
+   packet-buffer leases and policy-linked handoff witnesses.
+3. `2026-08-25` — `/research/ebpf-stateful-policy-verification/`: temporal policy
+   contracts for persistent map-backed security state.
+4. `2026-08-26` — `/research/ebpf-authorization-revocation/`: scoped revocation
+   epochs and a measurable bound on stale authorization.
+5. `2026-08-27` — `/research/ebpf-complete-mediation-offload/`: path coverage and
+   generation-continuous policy enforcement across host/offload/fallback.
+6. `2026-08-28` — `/research/ebpf-l7-proxy-policy-identity/`: policy/principal
+   identity continuity across proxy termination, pooling, retry, and fallback.
 
-The `2026-08-23` report starts the series with a distinct security-policy
-question: how additive Kubernetes `NetworkPolicy`, tiered `ClusterNetworkPolicy`,
-and Cilium L3-L7 policy can compose for multiple owners without losing authority,
-delegation, or source-policy provenance after the result is compiled into an
-eBPF datapath. It develops an authority-aware composition IR, generation-stable
-verdict witnesses, and a counterexample-driven multi-tenant policy benchmark.
-
-The `2026-08-24` report advances a second, materially different boundary. AF_XDP,
-io_uring ZC Rx, page_pool, and DPDK all recycle packet memory through native
-ownership protocols, while BPF policy decisions, NIC steering, and userspace
-processing can cross those boundaries. The report develops a generation-scoped
-buffer capability, policy-linked handoff witnesses, and a cross-path zero-copy
-fault benchmark. It is distinct from the earlier io_uring programmability report:
-the missing property is buffer lease ownership and provenance across APIs, not
-BPF execution control inside the ring.
-
-The `2026-08-25` report advances a third boundary: the Linux verifier can prove
-that each loaded BPF program executes safely while the security policy encoded in
-persistent map state still follows an invalid temporal trace. Production policy
-state can be shared across hooks, CPUs, programs, and userspace and can change
-under eviction, map pressure, revocation, restart, or stale control-plane writes.
-The report develops a small temporal policy contract, verifier-cooperative runtime
-transition guards, and an adversarial state-fault benchmark. This is distinct
-from verifier-error diagnosis, transactional upgrade, and policy composition:
-the target property is legal runtime state transition after safe bytecode has
-already been admitted.
-
-The `2026-08-26` report narrows one consequence of persistent state into an
-incident-response property. A policy or identity can be revoked while an old
-allow still survives in connection tracking, authentication caches, socket-local
-storage, or another derived datapath object. The report asks for a measurable
-upper bound on that stale authority rather than another general state-machine
-contract. It develops scoped revocation epochs, a cross-layer completion barrier,
-and a benchmark whose primary outcome is the last stale allow after a revoke.
-
-The `2026-08-27` report advances a fifth boundary by narrowing heterogeneous
-execution placement into a complete-mediation property. Linux representors and
-XDP offload expose host slow paths and device fast paths that can change under
-misses, updates, and faults. The report asks whether every reachable
-policy-relevant packet path still crosses an enforcement point for the current
-policy generation. It develops a path-coverage plan, generation-continuous
-offload/fallback, and a benchmark whose primary outcome is policy escape rather
-than offload throughput.
-
-A broad cross-boundary information-flow candidate was considered again on
-`2026-08-28` but not selected. Existing ActPlane and Eunomia material already
-covers process/file/network effect labels and layered enforcement, so a broad
-version has higher thesis-overlap risk than a narrower cross-boundary property.
-A second candidate limited to fast-path versus proxy allow/deny equivalence was
-also rejected because it overlaps complete mediation and placement without
-capturing what identity the accepted request carries.
-
-The `2026-08-28` report closes the series with a sixth distinct boundary: an L7
-proxy can terminate a policy-bound downstream connection and emit or reuse a new
-upstream socket, so every intended enforcement point can still be present while
-the request loses the principal and policy generation that justified it. The
-report develops generation-scoped handoff capabilities, policy-safe
-multiplexing, and an authorization-lineage benchmark across kernel fast paths
-and proxy slow paths.
-
-### Published progress
-
-1. `2026-08-23`: `/research/ebpf-network-policy-composition/` separates
-   policy-language semantics from BPF hook composition and update transactions.
-   It asks how several legitimate policy owners can produce one effective
-   network verdict while keeping the deciding owner, tier, delegation path, and
-   source rule inspectable across policy generations. The report is
-   eBPF-centered because the proposed provenance contract is evaluated against
-   the realized BPF policy datapath, not only against Kubernetes objects.
-2. `2026-08-24`: `/research/ebpf-zero-copy-buffer-ownership/` separates
-   allocator-specific lifetime rules from a cross-path ownership contract. It
-   asks how packet-buffer leases can preserve owner, DMA reachability, recycle
-   generation, and BPF policy provenance across AF_XDP, io_uring ZC Rx, DPDK,
-   userspace eBPF, and NIC handoffs. It is eBPF-centered because policy identity
-   and BPF/user-runtime transitions are part of the correctness contract rather
-   than optional instrumentation.
-3. `2026-08-25`: `/research/ebpf-stateful-policy-verification/` separates
-   per-program verifier safety from temporal correctness of persistent security
-   state. It asks how map-backed policy states can restrict legal transitions,
-   transition authority, generations, expiry, capacity failure, and userspace
-   writes without forcing the Linux verifier to model unbounded event history.
-   It is eBPF-centered because BPF maps, hooks, verifier boundaries, and in-kernel
-   transition enforcement are the central mechanism rather than optional probes.
-4. `2026-08-26`: `/research/ebpf-authorization-revocation/` separates policy
-   rollout from revocation effectiveness. It asks how a previously admitted
-   authorization can be made unusable within a measurable bound across conntrack,
-   auth maps, socket-local state, endpoint policy, and userspace-managed state.
-   It is eBPF-centered because the proposed epoch checks and completion barrier
-   are evaluated on persistent BPF datapath state and hot-path policy reuse.
-5. `2026-08-27`: `/research/ebpf-complete-mediation-offload/` separates backend
-   placement from global security coverage. It asks how host software, SmartNIC
-   fast paths, representor fallback, and DPU/offload execution can preserve one
-   current enforcement point for every reachable policy-relevant packet path.
-   It is eBPF-centered because BPF/XDP attachment, offload capability, policy
-   generations, and cross-backend verdict continuity are the core mechanism.
-6. `2026-08-28`: `/research/ebpf-l7-proxy-policy-identity/` separates path
-   coverage from authorization identity continuity across a semantic proxy
-   boundary. It asks how the original principal, policy generation, and
-   authorization provenance survive proxy termination, connection pooling,
-   multiplexing, retry, and fast/slow-path fallback. It is eBPF-centered because
-   the handoff starts and ends at BPF policy boundaries and the proposed
-   capability/lineage contract is evaluated against the realized BPF datapath.
-
-Future work should return to this series only when fresh evidence supports a
-mechanism beyond these six boundaries. In particular, do not repeat policy
-composition, zero-copy ownership, temporal state verification, revocation,
-complete mediation, or proxy identity continuity with a different product
-example alone.
-
-A direct recount on `2026-08-29` corrected the previous rolling-window arithmetic.
-Immediately before the August 29 publication, the newest ten contain **8
-eBPF-centered / 0 pure Agent / 2 adjacent systems**, not `7 / 0 / 3`. This is an
-operating-record correction only; no report classification changed.
-
-## Completed series — eBPF Observability and Profiling
-
-Historical roadmap state: **Active series — eBPF Observability and Profiling**
-through the `2026-08-22` report. The series is completed after that publication;
-Networking and Security became the active series for the next normal run.
-
-Working question: **Which important performance and correctness questions remain
-unanswerable with today's eBPF observability stack?**
-
-The `2026-08-18` report started this series with **page-level memory attribution**:
-how to distinguish allocation from pages that were actually touched, faulted,
-reclaimed, migrated, or responsible for sampled memory cost while preserving
-provenance across `mmap`, `brk`, allocator, runtime, and process boundaries.
-
-The `2026-08-19` report was a deliberate **adjacent profiling detour** on sampling
-bias. Its central mechanism is general profiler measurement design, not eBPF, so
-it is classified as adjacent systems.
-
-The first `2026-08-20` report was a second adjacent profiling detour required by
-the rolling-window arithmetic. It asks whether a late CUDA kernel start came from
-host scheduling, runtime/command-buffer work, a dependency, or device
-availability. CUPTI and Nsight Systems are the primary mechanisms; Linux/eBPF
-host tracing can be an optional evidence source but is not essential, so this
-report is adjacent systems rather than eBPF-centered.
-
-The second `2026-08-20` report follows the same adjacent-systems boundary from a
-causality angle. It asks how host API work, runtime handoffs, CUDA Graph replay,
-and device execution can retain a trustworthy causal identity. CUPTI/CUDA
-dependency semantics are central while eBPF is one possible host observer.
-
-The `2026-08-21` report returns to an eBPF-essential question: how dynamic probes
-can observe application-defined pools, queues, caches, and credits without
-silently turning stale program semantics into confident diagnoses. It develops a
-versioned semantics manifest, runtime semantic validation, and a mutation
-benchmark for software evolution.
-
-The `2026-08-22` report closes the series with another eBPF-essential question:
-how always-on collectors can reduce high-rate telemetry before export without
-silently deleting the evidence required for diagnosis. It develops a compiled
-diagnostic contract, bounded state-transition exemplars, coverage-carrying
-summaries, and an equal-budget diagnosis-retention benchmark.
-
-### Published progress
-
-1. `2026-08-18`: `/research/page-level-ebpf-memory-attribution/` separates
-   allocation intent, residency, working-set evidence, page lifecycle, and
-   sampled memory cost, then develops a lifetime-aware provenance ledger,
-   access-weighted attribution with explicit confidence, and a ground-truth
-   benchmark spanning reserve-versus-touch, COW, THP, reclaim, refault, and NUMA
-   migration.
-2. `2026-08-19`: `/research/profiler-sampling-bias/` asks when sampling itself is
-   untrustworthy. It compares randomized sampling history, current Linux perf
-   interfaces and kernel profile-collection guidance, and OSDI 2026 Blink, then
-   develops a sampling-schedule contract with aliasing diagnostics, independent
-   profile epochs with uncertainty and rank stability, and uncertainty-triggered
-   selective instrumentation. Because the mechanism applies to profilers in
-   general and does not require eBPF, this report is adjacent systems rather than
-   eBPF-centered.
-3. `2026-08-20`: `/research/gpu-kernel-launch-latency/` separates CUDA API time,
-   command-buffer queue/submission, dependency readiness, device availability,
-   and kernel execution. It develops an explicit launch-state ledger, a
-   cross-domain launch identity that survives host handoffs and graph replay, and
-   a ground-truth launch-delay attribution benchmark. The central question is GPU
-   profiling, so it is adjacent systems.
-4. `2026-08-20`: `/research/gpu-host-device-causality/` develops
-   generation-scoped host/device causal identity, dependency-aware critical-path
-   reasoning, explicit unknown/loss states, and a ground-truth causality
-   benchmark. CUPTI/CUDA dependency semantics are essential while eBPF is one
-   possible host observer, so this report is adjacent systems.
-5. `2026-08-21`: `/research/ebpf-application-resource-semantics/` asks how eBPF
-   can dynamically observe application-defined resources without hard-coding
-   stale semantics. It develops a versioned resource-semantics manifest compiled
-   into eBPF attachments, runtime semantic validation with explicit confidence
-   loss, and a software-mutation benchmark. Dynamic no-rebuild instrumentation
-   and independent cross-layer validation are central, so this report is
-   eBPF-centered.
-6. `2026-08-22`: `/research/ebpf-diagnostic-telemetry-compression/` asks how an
-   always-on eBPF collector can reduce telemetry volume before export while
-   preserving later root-cause diagnosis. It develops a diagnostic-contract
-   compiler for BPF retention plans, state-transition exemplars, explicit
-   coverage accounting, and an equal-budget incident benchmark. Source-side BPF
-   aggregation and exemplar retention are central, so this report is
-   eBPF-centered.
-
-Before and after the August 22 publication, the newest ten contain **7
-eBPF-centered / 0 pure Agent / 3 adjacent systems**. The incoming eBPF-centered
-report ages an eBPF-centered report out of the rolling ten.
-
-A related unresolved question remains: online confidence and adaptive collection
-when trace loss, missing probes, or stale schemas make the current representation
-uncertain. It is intentionally not a seventh report in this series. The August 22
-report first defines what a compact representation promises to preserve; adaptive
-fidelity can be revisited later when fresh evidence supports a distinct mechanism.
-
-## Completed series — eBPF Runtime, Extensibility, and Composition
-
-Working question: **What mechanisms are still missing if eBPF is treated as a
-programmable runtime substrate rather than only a kernel observability feature?**
-
-This series connected kernel and userspace execution, composition, state,
-upgrade, safety, asynchronous attribution, programmable I/O, and heterogeneous
-execution placement. It reached the normal six-report series boundary on
-`2026-08-17` and is no longer the default topic source for scheduled publication.
-
-### Published progress
-
-1. `2026-08-08`: `/research/userspace-ebpf-runtime-contract/` established that
-   first-class userspace eBPF needs explicit attachment, capability, state,
-   lifetime, and attribution contracts above ISA compatibility.
-2. `2026-08-09`: `/research/ebpf-hook-composition-contract/` narrowed the
-   multi-program problem beyond dispatch and ordering to effect visibility,
-   outcome resolution, shared-state ownership, and versioned hook composition.
-3. `2026-08-10`: `/research/stateful-ebpf-transactional-upgrade/` separated
-   object-level replacement from application-level upgrade and developed an
-   explicit prepare / migrate / commit / retire generation protocol for programs,
-   links, maps, pinned state, controller recovery, and rollback.
-4. `2026-08-12`: `/research/async-ebpf-causal-profiler/` separated thread
-   execution from logical-work causality and developed typed, lifetime-aware
-   handoff edges, an edge-versus-context measurement budget, and a ground-truth
-   causal-attribution benchmark across `io_uring`, workqueues, runtime tasks, and
-   application-defined resources.
-5. `2026-08-15`: `/research/io-uring-bpf-programmability/` separated the current
-   per-opcode cBPF admission path from the eBPF `io_uring_bpf_ops`
-   execution-control path, then developed a typed capability contract, versioned
-   ring policy generations, explicit provenance, and a comparative
-   control-boundary benchmark.
-6. `2026-08-17`: `/research/heterogeneous-ebpf-execution-placement/` separated
-   backend compatibility from execution placement and developed a target
-   manifest, generation-scoped state ownership, and a ground-truth
-   placement/provenance benchmark across kernel, userspace, NIC/DPU, and
-   GPU-side targets.
-
-The Daily Report index already exposes the sequence. Report-level acquisition and
-navigation evidence is still too young to justify a dedicated public series hub.
-Revisit that decision only when evidence shows a retrieval benefit.
+Return only with a mechanism beyond policy composition, zero-copy ownership,
+temporal state correctness, revocation, complete mediation, or proxy identity.
 
 ## Completed series — GPU and Heterogeneous Runtime Systems
 
 Working question: **What runtime and observability abstractions are missing at
 CPU/GPU and host/device boundaries?**
 
-The two August 20 reports are focused adjacent-systems contributions to this
-roadmap, but they predate activation and do not count as progress in the normal
-sequence. They establish two boundaries that should not simply be repeated:
-kernel launch-latency attribution and host/device causal tracing.
+The August 20 launch and causality reports predate activation and remain adjacent
+background boundaries. The active sequence reached its six-report boundary on
+`2026-09-04`:
 
-The series became active after the `2026-08-28` Networking and Security report
-reached that series' normal six-report boundary. It reached its own six-report
-post-activation boundary on `2026-09-04`.
+1. `2026-08-29` — `/research/gpu-memory-placement-evidence/`: evidence-carrying
+   placement under HBM oversubscription.
+2. `2026-08-30` — `/research/gpu-instrumentation-safety-contract/`: probe-effect
+   manifests, resource budgets, and explicit observation coverage.
+3. `2026-08-31` — `/research/gpu-utilization-allocatability/`: candidate-specific
+   admission rather than retrospective utilization.
+4. `2026-09-02` — `/research/gpu-membership-generation-continuity/`: application
+   state generation continuity across communicator membership changes.
+5. `2026-09-03` — `/research/ebpf-gpu-megakernel-observability/`: semantic task
+   hooks and coverage-carrying device-side eBPF aggregation.
+6. `2026-09-04` — `/research/gpu-checkpoint-recovery-consistency/`: application-
+   consistent recovery cuts across CPU, GPU, communication, and external effects.
 
-The `2026-08-29` report asks what evidence a GPU runtime needs before migrating,
-evicting, prefetching, replicating, or remotely mapping Unified Memory pages
-under HBM oversubscription. It develops evidence-carrying placement decisions,
-placement intent with observable compliance, and a counterexample benchmark that
-measures decision regret while progressively revealing richer evidence. It is
-adjacent systems because eBPF is optional instrumentation rather than the central
-mechanism.
+Return only with a mechanism beyond these six boundaries.
 
-The `2026-08-30` report asks what contract a dynamic GPU instrumentation runtime
-needs before an inserted device-side probe can be treated as a faithful observer.
-It develops a verified probe-effect manifest, resource-budgeted instrumentation
-with explicit coverage, and a counterexample benchmark for observer-induced
-failures. It is adjacent systems because the property applies across NVBit,
-GTPin, vendor profiling interfaces, native instrumentation, and eBPF-like device
-monitors.
-
-The `2026-08-31` report separates retrospective GPU activity from
-**allocatability**, the counterfactual question of whether a particular incoming
-workload can safely co-reside now. It develops an allocatability certificate,
-bounded two-stage admission, and paired counterexamples that hold headline
-utilization or occupancy similar while changing the true co-residency result. It
-is adjacent systems because eBPF is not required by the admission mechanism.
-
-The `2026-09-02` report separates communicator liveness from application-state
-generation consistency. It develops a generation-scoped reconfiguration
-certificate, ownership-aware state reconstruction, and a membership-transition
-counterexample benchmark whose oracle is semantic consistency rather than
-recovery latency. It is adjacent systems because eBPF/GPU instrumentation is
-optional evidence and fault-injection machinery.
-
-The `2026-09-03` report returns the series to an eBPF-essential mechanism.
-Megakernel compilers deliberately fuse many operator and dependency boundaries
-into one persistent GPU kernel, so an external kernel timeline or PC sample no
-longer automatically identifies the logical task or request generation. It
-develops a versioned semantic task-hook ABI, coverage-carrying on-device eBPF
-aggregation, and a counterexample benchmark that holds the outer megakernel
-similar while changing the internal task-level cause. It is eBPF-centered
-because the device-side eBPF runtime is central to the proposed monitor.
-
-The `2026-09-04` report closes the series with a sixth distinct boundary:
-transparent GPU checkpoint/restore can reconstruct CUDA and process state while
-the resulting image still crosses application epochs among CPU state, GPU state,
-peer communication, persistent-kernel state, and externally visible effects. It
-develops a machine-checkable recovery-cut certificate, narrow semantic
-quiescence/effect-fence adapters, and an adversarial benchmark whose oracle is
-whether recovery corresponds to an allowed application prefix plus legitimate
-replay. It is adjacent systems because the consistency mechanism does not require
-eBPF.
-
-### Published progress
-
-1. `2026-08-29`: `/research/gpu-memory-placement-evidence/` separates address
-   validity and demand faults from the evidence needed to make a placement
-   decision under oversubscription. It proposes an evidence-to-decision contract
-   and fixed-budget evaluation. It is adjacent systems.
-2. `2026-08-30`: `/research/gpu-instrumentation-safety-contract/` separates
-   logical probe-state preservation from whole-execution non-interference. It
-   develops a probe-effect manifest, explicit resource budgets and observation
-   coverage, and adversarial cases around occupancy, timing, synchronization,
-   control behavior, and unsupported sites. It is adjacent systems.
-3. `2026-08-31`: `/research/gpu-utilization-allocatability/` separates observed
-   utilization from candidate-conditioned admission. It distinguishes hard fit,
-   interference risk, and unknown evidence, then proposes an inspectable
-   allocatability certificate, a bounded online interference probe, and a
-   spare-capacity counterexample benchmark. It is adjacent systems.
-4. `2026-09-02`: `/research/gpu-membership-generation-continuity/` separates
-   communicator liveness from application-state generation consistency. It binds
-   member incarnations, a committed application frontier, old-generation
-   quiescence/rollback evidence, state manifests, and ownership maps into an
-   activation contract, then tests stale completions, rank reuse, partial state
-   transfer, and repartitioning as semantic counterexamples. It is adjacent
-   systems.
-5. `2026-09-03`: `/research/ebpf-gpu-megakernel-observability/` separates
-   persistent-kernel identity and PC identity from compiler/runtime logical task
-   identity. It proposes a versioned semantic task-hook ABI, a device-side eBPF
-   program type for late-bound bounded aggregation with explicit coverage, and a
-   fault-injection benchmark comparing low-level evidence, compiler-native task
-   profiling, and semantic eBPF hooks. It is eBPF-centered.
-6. `2026-09-04`: `/research/gpu-checkpoint-recovery-consistency/` separates
-   process/GPU restorable state from an application-consistent recovery cut. It
-   proposes a recovery-cut certificate, semantic quiescence and external-effect
-   fences, and an adversarial benchmark for duplicate effects, missing commits,
-   mixed epochs, pointer errors, communication deadlocks, and unsupported
-   recovery coverage. It is adjacent systems.
-
-Before the September 4 publication, the newest ten contain **6 eBPF-centered / 0
-pure Agent / 4 adjacent systems**. The incoming adjacent report rotates the
-`2026-08-24` eBPF-centered report out, so after publication the mix becomes **5 /
-0 / 5**, still inside the normal 5–7 eBPF target band.
-
-Future work should return to this GPU/runtime series only when fresh evidence
-supports a mechanism beyond these six boundaries. Do not repeat memory placement,
-instrumentation non-interference, allocatability, membership/generation
-continuity, launch/host-device causality, megakernel semantic observability, or
-checkpoint recovery-cut consistency with a different product example alone.
-
-## Active series — eBPF Optimization and Execution Specialization
+## Completed series — eBPF Optimization and Execution Specialization
 
 Working question: **How can eBPF programs and runtimes specialize to hardware and
 workload behavior without silently changing verifier-approved semantics,
-portability, debuggability, or the system's trusted boundary?**
+portability, debuggability, trust, or the validity of the performance claim?**
 
-This series became active after the GPU/runtime series reached its normal
-six-report boundary on `2026-09-04`. The rolling mix was then **5 / 0 / 5**, so a
-genuinely eBPF-centered question remains preferred while the normal evidence and
-novelty gates still apply.
+This series became active after the GPU/runtime series closed and reaches its
+normal six-report boundary with the `2026-09-11` publication.
+
+The six boundaries are intentionally different:
+
+1. `2026-09-05` — `/research/ebpf-runtime-profile-specialization/` separates
+   verifier acceptance, optimizer semantic equivalence, profile assumptions, and
+   guarded invalidation/deoptimization.
+2. `2026-09-06` — `/research/ebpf-portable-architecture-specialization/` separates
+   portable BPF semantics from architecture-specific implementation eligibility,
+   proof-linked native emits, and deterministic fallback.
+3. `2026-09-07` — `/research/ebpf-specialization-debug-provenance/` makes the
+   exact specialization generation, assumptions, transforms, JIT image, and
+   activation interval durable for postmortem attribution.
+4. `2026-09-09` — `/research/ebpf-native-operation-trust-boundary/` makes the
+   delegated native-code TCB, effect scope, assurance evidence, and artifact
+   identity explicit rather than treating verifier success as a blanket trust bit.
+5. `2026-09-10` — `/research/ebpf-cross-backend-operation-semantics/` asks whether
+   eligible and trusted host, native, NIC, and DPU implementations refine one
+   observable state-transition contract under concurrency, failures, and handoff.
+6. `2026-09-11` — `/research/ebpf-optimization-evidence-contract/` separates
+   semantic admissibility from performance generalization and production
+   promotion. Kops, BPF CI/veristat, and the current bpf-bench corpus show why one
+   instruction win, verifier statistic, application result, or tuned search set
+   cannot serve as a universal performance oracle. The report develops scoped
+   evidence envelopes, frozen holdout/counterexample evaluation for adaptive
+   optimizers, and profitability-aware promotion/rollback gates.
+
+### Rolling mix at closure
+
+Before September 10 the newest ten contained **5 eBPF-centered / 0 pure Agent /
+5 adjacent systems**. The September 10 eBPF-centered report rotated the August
+29 adjacent GPU memory-placement report out, producing **6 / 0 / 4**.
+
+Before September 11 the mix is therefore **6 / 0 / 4**. The September 11
+optimization-evidence report is eBPF-centered and rotates the August 30 adjacent
+GPU-instrumentation report out. After publication the newest ten contain **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. No classification changes
+were made to obtain that result.
+
+The series is closed. Future reports must not repackage verifier/equivalence,
+profile invalidation, architecture capability/fallback, execution provenance,
+native-operation trust accounting, cross-backend state-transition semantics, or
+performance-evidence/promotion scope with a different optimizer example.
+
+## Active series — eBPF Deployment Compatibility and Lifecycle
+
+Working question: **How can one eBPF application remain loadable, semantically
+correct, and operationally explainable across real kernel, distribution,
+backport, toolchain, and BPF-interface evolution?**
+
+This roadmap becomes active after the optimization series reaches six reports on
+`2026-09-11`. It is deliberately about deployment compatibility across evolving
+systems, not architecture-specific code generation and not application-level
+transactional upgrade.
 
 Candidate boundaries include:
 
-- profile-guided or workload-guided BPF re-JIT that can prove semantic
-  equivalence while changing machine code or helper lowering;
-- specialization contracts that make architecture-specific assumptions explicit
-  rather than hiding them behind one nominal BPF program;
-- delegated native operations whose trusted computing base, effects, proof or
-  validation evidence, and implementation identity can be made explicit;
-- safe delegation of high-level operations to kernel, NIC, DPU, or other
-  hardware-specific implementations without repeating the completed execution-
-  placement thesis;
-- optimization evidence that distinguishes a portable semantic contract from
-  one lucky microbenchmark or one JIT backend.
+- real-kernel and distribution/backport feature evidence versus kernel-version
+  heuristics for deciding which BPF features are actually available;
+- verifier-acceptance and behavior drift across kernels/toolchains, including how
+  a deployment records and diagnoses “same object, different verifier outcome”;
+- CO-RE relocation compatibility versus semantic compatibility of helpers, maps,
+  kfuncs, program types, and attachment behavior;
+- version/capability negotiation for kfunc, `struct_ops`, iterator, and other
+  rapidly evolving BPF-facing interfaces;
+- pinned-map and persistent-state lifecycle when kernel capabilities, BTF, or
+  object layouts evolve across host upgrades;
+- reproducible capability and artifact manifests across distributions so a
+  loader can explain why a program chose, rejected, or downgraded one path.
 
-The `2026-09-05` report establishes the first boundary. It separates kernel
-verifier safety from optimizer equivalence and from the lifetime of profile-based
-assumptions. K2 and EPSO show that semantics-preserving BPF rewrites can carry
-explicit equivalence checking; Kops shows proof-structured hardware
-specialization; the public BpfReJIT design shows how configuration and workload
-facts can drive a userspace re-JIT while every candidate still returns through
-the stock verifier/JIT. The report develops an optimization-equivalence
-certificate, guarded specialization dependencies with bounded deoptimization,
-and a phase-shift/rare-path benchmark whose correctness oracle is observable
-divergence from the portable source program.
+Novelty guards:
 
-The `2026-09-06` report advances a separate second boundary: architecture-specific
-native optimization can preserve one portable BPF semantic artifact only if the
-implementation eligibility and fallback are explicit. RFC 9669 conformance groups
-show that capability discovery is already part of BPF interoperability; current
-Linux JIT hooks expose backend-dependent capabilities; and Kops shows that a
-verifier-visible ordinary-BPF proof sequence can coexist with per-architecture
-native emits whose implementation coverage differs by target. The report develops
-a two-level semantic/implementation capability manifest, a multi-backend
-proof-linked operation package with deterministic portable fallback, and a
-cross-JIT benchmark that measures semantic equality, specialization coverage,
-fallback reasons, cross-target performance regret, proof/selection overhead, and
-trusted-code growth.
+- do not repeat September 6 architecture-specific specialization and fallback;
+- do not repeat the August 10 application-level transactional-upgrade protocol;
+- do not repeat the August 8 userspace-runtime capability/lifetime contract;
+- require current primary evidence from Linux/BPF tooling, distributions, CI, or
+  production compatibility systems before selecting a boundary.
 
-The `2026-09-07` report advances a third boundary: a dynamically specialized BPF
-program can be semantically valid and portable yet still become impossible to
-explain after several re-JIT and deoptimization generations. Linux already
-exposes program IDs, BPF tags, translated bytecode, JIT images, BTF line
-information, and load/runtime metadata; the missing property is a durable chain
-that joins an incident observation to the exact specialization generation,
-optimizer assumptions and transforms, verifier/JIT context, active native image,
-and activation/retirement interval. The report develops content-addressed
-execution receipts, generation-aware sample attribution with an explicit unknown
-state, and an adversarial re-JIT forensic benchmark that unloads the faulty
-generation before analysis.
-
-The `2026-09-09` report advances a fourth boundary: after the runtime chooses a
-native implementation and can identify the exact generation that executed, the
-correctness argument still depends on code outside the verifier-visible BPF
-program. Linux kfuncs encode caller-side ownership, pointer, sleepability, and
-other constraints while trusting the kernel function body; Jitterbug shows that
-JIT translation itself can contain semantic bugs; Kops makes the trade-off
-explicit by pairing verifier-checked proof sequences with native emits and by
-showing that larger native replacement increases the TCB. The report develops a
-verifier-linked native-operation effect contract, evidence-carrying trust tiers,
-and an adversarial trust-budget benchmark that measures escaped faults,
-validation cost, performance, and trusted-code growth together.
-
-The `2026-09-10` report advances a fifth boundary: several implementations can be
-eligible, identifiable, and individually trusted while still disagreeing on the
-observable meaning of one stateful operation. Linux BPF map types already expose
-atomicity, per-CPU state, eviction, locking, and failure semantics, while the
-kernel's offload path dispatches map operations through device-specific
-implementations. The report therefore moves above single-call result equality and
-defines cross-backend equivalence over state transitions, concurrency histories,
-visibility, failures, and handoff. It develops a backend-independent operation
-transition contract, executable reference/history conformance, and a mixed-
-backend continuity benchmark that treats semantic divergence as the primary
-failure rather than a throughput loss.
-
-### Published progress
-
-1. `2026-09-05`: `/research/ebpf-runtime-profile-specialization/` asks when a
-   workload- or deployment-guided BPF rewrite is still justified as the same
-   program. It distinguishes unconditional profile hints, conditional semantic
-   assumptions, verifier acceptance, and optimizer equivalence; proposes a
-   generation-scoped certificate and invalidation registry; and evaluates
-   correctness under adversarial profile staleness before treating speedup as a
-   win. It is eBPF-centered because BPF bytecode semantics, verifier/JIT
-   acceptance, BPF effects, and link generations are the object of the contract.
-2. `2026-09-06`: `/research/ebpf-portable-architecture-specialization/` asks how
-   architecture-specific BPF fast paths can remain optional implementations of
-   one portable semantic operation instead of becoming an implicit machine ABI.
-   It separates BPF semantic capability from native implementation eligibility,
-   packages per-architecture emits around a shared proof sequence and explicit
-   fallback, and evaluates portability across JIT backends and kernel versions.
-   It is eBPF-centered because BPF ISA conformance, verifier-visible proof
-   sequences, JIT capability, and native lowering are the object of the contract.
-3. `2026-09-07`: `/research/ebpf-specialization-debug-provenance/` asks how a
-   postmortem can prove which dynamically specialized BPF generation and JIT
-   image actually executed after the runtime has already replaced or unloaded
-   it. It separates source/BTF mapping from optimization history, proposes a
-   durable execution receipt plus generation interval map, and evaluates exact
-   attribution, explicit unknown handling, replay, storage/runtime overhead, and
-   operator time-to-root-cause under adversarial re-JIT churn. It is
-   eBPF-centered because BPF generation identity, verifier/JIT artifacts, link
-   activation, and specialized instruction images are the core objects of the
-   provenance contract.
-4. `2026-09-09`: `/research/ebpf-native-operation-trust-boundary/` asks how a
-   verifier-safe BPF operation can delegate execution to native code without
-   turning the whole implementation path into an opaque `verified` bit. It
-   separates verifier-visible caller obligations from native implementation
-   effects and identity, proposes version-bound operation contracts and assurance
-   tiers, and evaluates semantic fault escape under a fixed trust/performance
-   budget. It is eBPF-centered because BPF verifier semantics, JIT/kfunc/native
-   delegation, and proof-linked BPF fallback are the core trust boundary.
-5. `2026-09-10`: `/research/ebpf-cross-backend-operation-semantics/` asks whether
-   host, native, NIC, and DPU implementations of one higher-level BPF operation
-   preserve the same observable state machine. It separates capability and trust
-   from state-transition equivalence, defines explicit atomicity, visibility,
-   failure, retry, and ownership semantics, and evaluates concurrent histories
-   across backend handoff and injected faults. It is eBPF-centered because BPF
-   map semantics, offload dispatch, and BPF-facing operation continuity are the
-   core objects of the contract.
-
-Before the September 5 publication, the newest ten contained **5 eBPF-centered /
-0 pure Agent / 5 adjacent systems**. The September 5 eBPF-centered report rotated
-the `2026-08-25` eBPF-centered report out, so the mix remained **5 / 0 / 5**.
-Before the September 6 publication the mix was therefore still **5 / 0 / 5**;
-the incoming eBPF-centered report rotated the `2026-08-26` eBPF-centered report
-out, so the mix again remained **5 / 0 / 5**. Before the September 7 publication
-the mix was still **5 / 0 / 5**; the incoming eBPF-centered report rotated the
-`2026-08-27` eBPF-centered report out, so after publication the newest ten
-remained **5 / 0 / 5**. Before the September 9 publication the mix was again **5 /
-0 / 5**; the incoming eBPF-centered report rotated the `2026-08-28` eBPF-centered
-proxy-identity report out, so after publication the newest ten still contained
-**5 eBPF-centered / 0 pure Agent / 5 adjacent systems**. Before the September 10
-publication the mix is therefore **5 / 0 / 5**; today's eBPF-centered report
-rotates the `2026-08-29` adjacent GPU memory-placement report out, so after
-publication the newest ten contain **6 eBPF-centered / 0 pure Agent / 4 adjacent
-systems**. No classification was changed to obtain that result.
-
-A later report should not repeat verifier acceptance versus semantic equivalence,
-stale-profile invalidation, architecture capability negotiation, proof-linked
-portable fallback, cross-JIT portability measurement, execution receipts,
-generation-aware sample attribution, re-JIT forensic provenance, native-operation
-trust/TCB accounting, or cross-backend state-transition equivalence with a
-different optimizer example. With five strong reports, one additional
-series-closing question is allowed only if fresh evidence exposes a genuinely
-separate optimization boundary; otherwise close the series and activate another
-approved eBPF-centered roadmap.
+The newest-ten mix after September 11 sits at the allowed maximum of **7
+eBPF-centered / 0 pure Agent / 3 adjacent systems**. Therefore the next scheduled
+run must not mechanically publish another eBPF-centered report if doing so would
+push the rolling window above 7. When the active series is temporarily blocked by
+that arithmetic, select a strong approved adjacent-systems detour (or, if it
+passes the quality bar, a limited pure-Agent systems question) and record the
+detour. Resume this active series as soon as the rolling window permits it.
 
 ## Queued series — Agent Systems (limited)
 
-Pure Agent systems work is intentionally a minority topic. Use this series only
-for questions with unusually strong systems consequences that are not better
-framed through eBPF, Linux, runtime, observability, or security mechanisms.
-
-Existing anchors:
+Pure Agent systems work remains intentionally a minority topic. Existing anchors:
 
 - `/research/agent-trace-evidence-budget/`
 - `/research/parallel-agent-effect-serializability/`
 
-Neither pure-Agent report remains inside the newest ten after the August 28
-publication. Pure-Agent publication is allowed by the cap but is not required;
-prefer the technically stronger question after applying the evidence, novelty,
-and editorial-mix gates.
-
-Future Agent reports should preferentially connect back to eBPF or systems
-infrastructure, for example OS-level effect tracing, eBPF policy enforcement,
-sandbox escape visibility, syscall/tool causality, or runtime resource control.
+Pure-Agent publication is allowed by the cap but is never required. Prefer Agent
+questions with strong systems consequences, especially OS-level effect tracing,
+eBPF policy enforcement, sandbox visibility, syscall/tool causality, or runtime
+resource control.
 
 ## Choosing the next report
 
 Each daily run should:
 
-1. calculate the current rolling topic mix from the actually published index;
+1. calculate the actual rolling topic mix from the published index;
 2. start inside the active series when the mix permits it;
-3. research multiple candidate questions if necessary;
-4. reject candidates that do not pass the evidence and novelty gates;
-5. choose one question that both passes quality review and keeps the rolling mix
-   compliant;
-6. publish exactly one new Daily Report;
-7. record the chosen series, topic classification, rejected candidates when
-   useful, and why the report materially advances the roadmap.
+3. research multiple candidate questions when necessary;
+4. reject candidates that fail evidence, novelty, or usefulness gates;
+5. choose one question that preserves the editorial mix without relabeling old
+   reports;
+6. publish exactly one new bilingual Daily Report;
+7. record the chosen series, classification, useful rejected candidates, and why
+   the report materially advances the roadmap.
 
-A temporary out-of-series detour should be recorded in the daily operating record
-and in this file so the repository, not chat history, remains authoritative.
+Temporary detours must be recorded here or in the daily operating record so the
+repository, not chat history, remains authoritative.

--- a/.github/seo-data/daily/2026-09-11.md
+++ b/.github/seo-data/daily/2026-09-11.md
@@ -1,0 +1,143 @@
+# SEO operations — 2026-09-11
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Baseline default-branch commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
+- Delivery branch: `daily/2026-09-11-ebpf-optimization-evidence`
+- Delivery PR: pending at record creation
+- Run type: mandatory data analysis, technical SEO/GEO audit, and exactly one new bilingual Daily Report
+- Technical SEO outcome: no separate implementation change. Current analytics, repository health, deployment evidence, and public-safe technical evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants an unrelated site change.
+- Mandatory publication: one new bilingual eBPF-centered Daily Report on the evidence required before an eBPF optimization result is broad enough to promote beyond one benchmark or target.
+
+Cloudflare remains disabled by repository configuration. Missing coverage is unavailable, partial, stale, or absent rather than zero.
+
+### Prior-run reconciliation
+
+PR `#195`, **Daily: define cross-backend semantics for eBPF operations**, was the valid September 10 delivery and was squash-merged as `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2` after its PR-head checks were terminal-green. The exact merge commit's `Validate SEO Operations` run `34618891189` completed successfully. At the start of this run, exact-merge `Deploy Static App` run `34618891146` was still in progress in its static-export verification step; it is not treated as completed until that run reaches terminal success, the generated export is bound to the squash SHA, and the bilingual production pages and sitemap are verified. This run will finish that reconciliation before closing today's work.
+
+PR `#194` is an older duplicate September 10 attempt whose validation failed. It is not accepted as a completed daily delivery and will be closed as superseded by `#195` after the valid production reconciliation is complete.
+
+## Data window
+
+- The exact configured Google Drive folder `eunomia.dev SEO Weekly CSV` was directly rechecked on `2026-09-11`. No weekly source set newer than `2026-08-31..09-06` is present.
+- Search Console source rows in that set are present for `2026-08-31..09-05`; `2026-09-06` is absent.
+- Under the configured three-day lag, all currently observed Search Console rows through `2026-09-05` are finalized.
+- The GA4 organic landing-page aggregate for `2026-08-24..30` remains the latest fully finalized weekly aggregate.
+- The `2026-08-31..09-06` GA4 aggregate was exported while dates inside the finalization lag were present and has no date dimension, so it remains explicitly partial; no refreshed source set supersedes it today.
+- A complete latest-seven-day versus preceding-seven-day Search Console comparison remains unavailable because the newest weekly export omits `2026-09-06` and the prior weekly export omits `2026-08-30`.
+- Older source gaps, including the recorded `2026-08-23` gap, also prevent the required complete 28-day versus preceding-comparable-period Search Console comparison.
+- Missing rows are never synthesized as zero.
+- Cloudflare remains disabled.
+
+## Evidence collected
+
+### Google Search Console
+
+The newest finalized source-native `2026-08-31..09-05` six-day slice contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**.
+
+The equal-duration finalized `2026-08-24..29` slice contains **436 clicks / 55,594 impressions / ~0.784% CTR / ~10.73 weighted position**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted average position about **3.38 positions better**.
+
+The combination can have multiple explanations: broader query/page exposure can increase impressions and improve weighted position while a changed query mix, SERP presentation, or weaker click appeal lowers CTR. Aggregate data cannot distinguish those explanations. The next discriminating evidence is finalized date-by-query and date-by-page data over contiguous windows, not an immediate title or metadata rewrite.
+
+This is explicitly not a complete seven-day trend. Missing dates are not converted to zero.
+
+The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly page export. The export lacks a date-by-page dimension and the published report set grew between weeks. The movement can prioritize report-level inspection but cannot justify a causal title, topic, navigation, or metadata change.
+
+### Google Analytics 4
+
+The finalized `2026-08-24..30` organic landing-page aggregate remains **1,007 sessions** at about **45.88% session-weighted engagement**. The preceding finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29% engagement**.
+
+The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**, but remains partial because the frozen export was produced while lagged dates were present and has no date dimension. It is recorded for coverage, not presented as a finalized week-over-week decline or recovery.
+
+### Cloudflare
+
+Cloudflare analytics remains disabled by repository configuration. No traffic, cache, bot, country, or status-code conclusion is inferred from missing Cloudflare data.
+
+### Public site and repository evidence
+
+The latest repository-generated public-safe data brief observed on `2026-09-11` reports the canonical homepage at HTTP 200 in 233 ms, robots at HTTP 200, sitemap at HTTP 200, and 748 sitemap entries. It records 99 active non-fork repositories with 9,987 current stars, 1,305 forks, and 287 open issue/PR records across the observed public portfolio. These counters are project context and are not blended into a synthetic SEO score.
+
+Current source and public-safe evidence does not establish a concrete technical SEO defect that warrants an unrelated implementation change. The pinned SEO skill submodule remains unchanged because the durable plan requires the consuming contract to be migrated before moving the pointer.
+
+### Rolling Daily Report mix before topic selection
+
+The ten actually published reports immediately before today's publication contain:
+
+- eBPF-centered: **6 of 10**
+- pure Agent-centered: **0 of 10**
+- adjacent systems: **4 of 10**
+
+Today's selected report is **eBPF-centered**. It rotates the `2026-08-30` adjacent GPU-instrumentation report out of the newest ten, so the resulting window becomes **7 eBPF / 0 pure Agent / 3 adjacent systems**, the upper edge of the normal 5–7 eBPF target band. No classification is changed to obtain that result.
+
+### Research evidence and topic selection
+
+Active series before publication: **eBPF Optimization and Execution Specialization**.
+
+Selected report:
+
+- English: **When Is an eBPF Optimization Result Strong Enough to Ship?**
+- Chinese: **一个 eBPF 优化结果，到什么程度才值得上线？**
+- Route: `/research/ebpf-optimization-evidence-contract/`
+- Classification: **eBPF-centered**
+
+Fresh primary/current evidence supports a sixth, series-closing boundary that is distinct from the prior five. Kops reports different performance scales for isolated native-operation microbenchmarks and production applications on x86-64 and ARM64. Linux BPF CI uses `veristat` to catch verifier and verification-performance regressions on complex BPF programs, while `veristat` itself is a verifier/statistics comparison tool rather than an end-to-end application-performance oracle. The current public `bpf-bench` framework spans six production eBPF applications, 146 comparable program measurements, and 42 microbenchmark tasks; it explicitly records verifier, JIT, workload, application-lifecycle, and per-program runtime evidence and treats adaptive optimizers as untrusted to prevent reward-hacking shortcuts.
+
+The unresolved mechanism is therefore not semantic equivalence, architecture eligibility, provenance, trust, or state-transition equivalence. It is the scope and promotion strength of a performance claim after correctness has already passed. The report develops: (1) evidence envelopes that bind speedups to kernel/JIT/CPU/program/application/workload and an explicit claim scope; (2) frozen holdout plus adversarial counterexample suites for adaptive optimizers; and (3) profitability-aware deployment predicates with measured regression budgets and rollback.
+
+A candidate that revisited architecture-specific fast paths was rejected because it would repeat September 6 capability/fallback and September 9 trust arguments. A pure Agent report was also not selected despite being allowed by the cap because the active eBPF series had one evidence-backed closing boundary that materially advanced the sequence.
+
+With this sixth report, **eBPF Optimization and Execution Specialization** closes at its normal boundary. The next normal eBPF roadmap becomes **eBPF Deployment Compatibility and Lifecycle**, covering real-kernel/backport feature evidence, verifier drift, CO-RE relocation versus semantic compatibility, evolving kfunc/`struct_ops` interfaces, persistent state over host upgrades, and reproducible capability/artifact manifests. Because today's result leaves the newest-ten window at 7 eBPF reports and the next report to rotate out is adjacent, the next scheduled run must use a strong adjacent-systems detour or other quality-qualified non-eBPF-centered topic if another eBPF report would exceed the 7-of-10 cap.
+
+## Work performed
+
+The branch is scoped to one publication plus directly coupled operating-state changes:
+
+- added `docs/research/ebpf-optimization-evidence-contract.md`;
+- added `docs/research/ebpf-optimization-evidence-contract.zh.md`;
+- prepended the English and Chinese Daily Report indexes;
+- added this September 11 operating record;
+- refreshed `status.md`, `plan.md`, and `content-series.md` with current analytics coverage, prior-run reconciliation state, rolling mix, series closure, and the next compatibility roadmap;
+- made no unrelated technical SEO implementation change;
+- kept Cloudflare unavailable and missing analytics dates explicit rather than inventing zeros;
+- kept the SEO skill submodule pinned until its consuming-contract migration is complete.
+
+The report develops three testable directions:
+
+1. a structured evidence envelope with an explicit claim scope and a measurable `claim escape` failure mode;
+2. frozen development/holdout/counterexample suites whose primary outcomes include holdout reproduction, worst guarded regression, invalid-result rate, and adaptive-search overfit;
+3. profitability-aware promotion and rollback that is compared against global enablement and a simple static allowlist and is rejected if the allowlist performs equally well.
+
+## Validation and self-review
+
+The authoritative PR checks are `Validate SEO Operations` and `Deploy Static App`. Missing, queued, skipped, cancelled, or failed checks are not success. Any validation or review issue must be fixed on this same branch and rechecked.
+
+Before merge, the complete final PR diff, changed-file set, report metadata, English/Chinese prose, internal links, series classification, rolling-window arithmetic, and generated production output will be re-read. The branch must contain exactly one new report in two language files and no unrelated site change.
+
+After squash merge, the exact merge commit must pass production deployment. The generated and public English/Chinese pages must be checked for Daily Report navigation, locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` hreflang, Article JSON-LD, internal continuation links, explicit gap/directions/conclusion, and sitemap alternates before the run is closed.
+
+## Delivery
+
+- Branch: `daily/2026-09-11-ebpf-optimization-evidence`
+- Pull request: pending at record creation
+- PR-head validation: pending
+- PR-head static deployment check: pending
+- Squash merge: pending
+- Exact-merge production deployment: pending
+- Production bilingual verification: pending
+- Merged-PR closeout comment: pending
+
+The recurring operations schedule remains enabled and is not modified by repository delivery state.
+
+## Decisions and follow-ups
+
+1. Do not infer a seven-day or 28-day Search Console trend until contiguous source history exists.
+2. Do not treat the partial `2026-08-31..09-06` GA4 aggregate as a finalized week-over-week result without refreshed or date-dimensional source evidence.
+3. Do not make a title/metadata change from aggregate CTR movement alone; obtain finalized date-by-page/query evidence first.
+4. Close the optimization series after today's sixth distinct boundary and activate the deployment-compatibility roadmap.
+5. Respect the post-publication **7 / 0 / 3** rolling mix. The next run must not create an eighth eBPF-centered report while an adjacent report is the one rotating out.
+6. Keep Cloudflare unavailable until a supported read-only route is configured.
+7. Keep the SEO skill pointer unchanged until the consuming-contract migration is complete.
+8. Finish the September 10 exact production reconciliation before treating PR `#195` as fully closed, and close failed duplicate PR `#194` as superseded rather than merging it.

--- a/.github/seo-data/daily/2026-09-11.md
+++ b/.github/seo-data/daily/2026-09-11.md
@@ -7,7 +7,7 @@
 - Authoritative task: `DAILY_TASK.md`
 - Baseline default-branch commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
 - Delivery branch: `daily/2026-09-11-ebpf-optimization-evidence`
-- Delivery PR: pending at record creation
+- Delivery PR: `#196`
 - Run type: mandatory data analysis, technical SEO/GEO audit, and exactly one new bilingual Daily Report
 - Technical SEO outcome: no separate implementation change. Current analytics, repository health, deployment evidence, and public-safe technical evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants an unrelated site change.
 - Mandatory publication: one new bilingual eBPF-centered Daily Report on the evidence required before an eBPF optimization result is broad enough to promote beyond one benchmark or target.
@@ -16,9 +16,9 @@ Cloudflare remains disabled by repository configuration. Missing coverage is una
 
 ### Prior-run reconciliation
 
-PR `#195`, **Daily: define cross-backend semantics for eBPF operations**, was the valid September 10 delivery and was squash-merged as `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2` after its PR-head checks were terminal-green. The exact merge commit's `Validate SEO Operations` run `34618891189` completed successfully. At the start of this run, exact-merge `Deploy Static App` run `34618891146` was still in progress in its static-export verification step; it is not treated as completed until that run reaches terminal success, the generated export is bound to the squash SHA, and the bilingual production pages and sitemap are verified. This run will finish that reconciliation before closing today's work.
+PR `#195`, **Daily: define cross-backend semantics for eBPF operations**, was the valid September 10 delivery and was squash-merged as `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`. Exact-merge `Validate SEO Operations` run `34618891189` and `Deploy Static App` run `34618891146` both completed successfully. The deployment produced static export `b9bab3bfd4897272ca6264d66c450ad5236feb2a`, explicitly bound by commit message to the squash SHA. The generated English and Chinese report artifacts and sitemap were verified for locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` alternates, Article JSON-LD, Daily Report navigation, and both sitemap routes. One compact merged-PR closeout comment was added.
 
-PR `#194` is an older duplicate September 10 attempt whose validation failed. It is not accepted as a completed daily delivery and will be closed as superseded by `#195` after the valid production reconciliation is complete.
+PR `#194` was an older failed duplicate September 10 attempt. It was closed as superseded by `#195` and was not merged.
 
 ## Data window
 
@@ -100,6 +100,7 @@ The branch is scoped to one publication plus directly coupled operating-state ch
 - prepended the English and Chinese Daily Report indexes;
 - added this September 11 operating record;
 - refreshed `status.md`, `plan.md`, and `content-series.md` with current analytics coverage, prior-run reconciliation state, rolling mix, series closure, and the next compatibility roadmap;
+- addressed review findings in both report languages by adding the required slug and primary-keyword H2, making academic and production value explicit for each direction, adding a concrete holdout failure condition, defining a sample/window/confidence/cooldown rollback protocol with false-rollback/flapping evaluation, and removing an unused reference;
 - made no unrelated technical SEO implementation change;
 - kept Cloudflare unavailable and missing analytics dates explicit rather than inventing zeros;
 - kept the SEO skill submodule pinned until its consuming-contract migration is complete.
@@ -121,9 +122,9 @@ After squash merge, the exact merge commit must pass production deployment. The 
 ## Delivery
 
 - Branch: `daily/2026-09-11-ebpf-optimization-evidence`
-- Pull request: pending at record creation
-- PR-head validation: pending
-- PR-head static deployment check: pending
+- Pull request: `#196`
+- PR-head validation: pending terminal result
+- PR-head static deployment check: pending terminal result
 - Squash merge: pending
 - Exact-merge production deployment: pending
 - Production bilingual verification: pending
@@ -140,4 +141,4 @@ The recurring operations schedule remains enabled and is not modified by reposit
 5. Respect the post-publication **7 / 0 / 3** rolling mix. The next run must not create an eighth eBPF-centered report while an adjacent report is the one rotating out.
 6. Keep Cloudflare unavailable until a supported read-only route is configured.
 7. Keep the SEO skill pointer unchanged until the consuming-contract migration is complete.
-8. Finish the September 10 exact production reconciliation before treating PR `#195` as fully closed, and close failed duplicate PR `#194` as superseded rather than merging it.
+8. September 10 is reconciled: `#195` deployed and verified successfully, and failed duplicate `#194` is closed as superseded.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -4,61 +4,124 @@
 
 Make eunomia.dev a reliable canonical source for eBPF, systems infrastructure,
 observability, profiling, networking, security, runtimes, and heterogeneous
-systems research. AI-agent infrastructure is a deliberately smaller adjacent
-topic rather than the center of the publication program.
+systems research. AI-agent infrastructure remains a smaller adjacent topic rather
+than the center of the publication program.
 
-Optimize for technically useful discovery and citation by people and software
-agents without creating shallow, repetitive, or trend-driven content.
-
-`DAILY_TASK.md` is the authoritative operating entrypoint. It combines daily data
-analysis, technical SEO/GEO, and one mandatory new Daily Report. This file stores
-durable goals and constraints, not duplicated scheduler instructions.
+Optimize for technically useful discovery and citation without creating shallow,
+repetitive, or trend-driven content. `DAILY_TASK.md` is the authoritative
+operating entrypoint; this file stores durable goals and constraints.
 
 ## Success signals
 
-- Search Console clicks, impressions, CTR, query/page movement, and canonical/indexing state; preserve each metric's source-native meaning.
-- Public-safe GA4 acquisition, engaged-session, landing-page, referral, and configured outcome signals, used to distinguish discovery from useful on-site follow-through.
-- Cloudflare traffic, bot, status-code, and cache evidence once a supported read-only route is available.
-- Stable crawlability, canonical ownership, language alternates, structured data, internal links, rendering, and production verification enforced by repository checks and live inspection.
-- Qualified movement from relevant technical pages to public repositories, papers, tutorials, and demos, without inventing a blended SEO score.
-- Daily analysis records that explain source coverage, movement, uncertainty, competing explanations, and the next discriminating evidence.
-- Exactly one new Daily Report per scheduled run, with a rolling editorial mix of 5–7 eBPF-centered reports per 10 and at most 1–2 pure Agent reports per 10.
-- Daily Reports that expose a concrete systems gap and develop implementable, testable directions rather than summarizing a trend.
+- Search Console clicks, impressions, CTR, query/page movement, and indexing
+  evidence, preserving each metric's source-native meaning.
+- Public-safe GA4 acquisition, landing-page, engagement, referral, and configured
+  outcome signals used to distinguish discovery from useful follow-through.
+- Cloudflare traffic, bot, cache, and status evidence once a supported read-only
+  route is enabled.
+- Stable crawlability, canonical ownership, language alternates, structured data,
+  internal links, rendering, and production verification enforced by repository
+  checks and exact deployed artifacts.
+- Qualified movement from relevant pages to public repositories, papers,
+  tutorials, and demos without inventing a blended SEO score.
+- Daily records that explain source coverage, movement, uncertainty, competing
+  explanations, and the next discriminating evidence.
+- Exactly one new bilingual Daily Report per scheduled run, with 5–7
+  eBPF-centered reports per newest 10 and at most 1–2 pure Agent reports.
+- Reports that expose concrete systems gaps and develop implementable, testable
+  directions rather than summarize a trend.
 
 ## Operating constraints
 
-- The external scheduler is already configured and only invokes the repository; the repository owns all operational policy and current state.
-- Data analysis runs every day. A missing private source is marked unavailable, never inferred as zero.
-- Raw analytics, private identifiers, credentials, and personal information stay outside Git.
-- Each run starts from the latest default branch and uses one fresh branch and one real non-draft pull request.
-- Every scheduled run must add exactly one new bilingual Daily Report. A weak candidate is replaced by another approved question rather than published or converted into a no-report day.
-- Technical SEO changes remain evidence-driven and may be skipped on a given day; the Daily Report may not be skipped.
-- Keep the rolling topic mix compliant and classify by the report's actual central mechanism, not by superficial keyword mentions.
-- Do not combine unrelated technical SEO and content work when that makes the daily pull request incoherent; put unrelated durable SEO work in this plan for a focused follow-up.
-- Required and expected CI must pass before a clean final automated self-review and squash merge.
-- Every daily report is a public change, so the exact squash commit must deploy successfully and both language pages must be verified.
-- Do not create a second closeout pull request. Put the verified closeout in one compact comment on the merged daily pull request, then refresh `status.md` in the next run.
-- `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics.
-- `.agents/skills/eunomia-research-report` owns Daily Report research, quality, writing, and publication gates.
-
-Short-term fixes and remediation backlogs belong in GitHub issues. Durable priorities that can guide a later daily run belong below.
+- The external recurring schedule invokes the repository; repository files own
+  operational policy and current state.
+- Analyze every enabled data source every run. Missing or partial data is marked
+  unavailable/partial, never inferred as zero.
+- Raw analytics, credentials, private source identifiers, and personal
+  information stay outside Git.
+- Each run starts from the latest default branch and uses one fresh branch and one
+  real non-draft pull request.
+- Every run publishes exactly one new bilingual Daily Report. A weak candidate is
+  replaced rather than converted into a no-report day.
+- Technical SEO changes remain evidence-driven and may be skipped when no concrete
+  defect is established.
+- Classify reports by the central mechanism, not by keywords, and preserve the
+  mechanical rolling mix.
+- Required and expected CI must be terminal-green before final automated
+  self-review and squash merge.
+- The exact squash commit must deploy successfully. Both language pages and the
+  sitemap must be verified from the production artifact/public site.
+- Do not create a second closeout PR. Put one compact verified closeout comment on
+  the merged daily PR, then reconcile `status.md` in the next run.
+- `.agents/skills/seo-geo` and `.github/seo-skills` own technical SEO mechanics;
+  `.agents/skills/eunomia-research-report` owns Daily Report research and quality.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically from the actually published archive. Before the `2026-09-10` publication the newest ten contain **5 eBPF-centered / 0 pure Agent / 5 adjacent systems**. The cross-backend operation-semantics report is genuinely eBPF-centered because BPF map semantics, offload dispatch, operation state transitions, concurrency, failures, and cross-backend refinement are the central objects. It rotates the `2026-08-29` adjacent GPU memory-placement report out, so the newest-ten mix becomes **6 / 0 / 4** after publication. Never repair the ratio through classification or by publishing an extra report.
-2. **eBPF Optimization and Execution Specialization** is the active series. September 5 established verifier safety versus optimizer equivalence and profile-assumption lifetime. September 6 established architecture-specific implementation eligibility, portable semantic witnesses, and deterministic fallback. September 7 established postmortem provenance for the exact specialization generation that executed. September 9 made the delegated native-code TCB, effect scope, assurance evidence, and artifact binding explicit. September 10 advances a fifth distinct boundary: several eligible and trusted host/NIC/DPU implementations still need to refine one observable state-transition contract under concurrency, failures, and backend handoff.
-3. Keep later optimization-series reports materially distinct from these five boundaries. Do not repackage verifier equivalence, stale-profile invalidation, architecture capability negotiation, proof-linked fallback, execution provenance, native-operation trust accounting, or cross-backend state-transition semantics with another optimizer name. With five strong reports, one additional series-closing question is allowed only if fresh evidence supports a genuinely separate optimization boundary; otherwise close the series at five and activate another approved eBPF-centered roadmap.
-4. Treat **eBPF Networking and Security** as complete at its normal six-report boundary after the `2026-08-28` proxy handoff report. Return only when fresh evidence supports a mechanism beyond policy composition, zero-copy ownership, temporal state correctness, revocation, complete mediation, or proxy identity continuity.
-5. Treat **GPU and Heterogeneous Runtime Systems** as complete at its normal six-report post-activation boundary after `2026-09-04`. Do not continue with a seventh report merely because another GPU paper exists. Its covered boundaries are memory-placement evidence, instrumentation non-interference, candidate-conditioned allocatability, membership/generation continuity, semantic observability after megakernel fusion, and application-consistent checkpoint/restore.
-6. Use all verified weekly Search Console and GA4 Drive export sets in every run. As rechecked on `2026-09-10`, the newest source set remains `2026-08-31..09-06`. Its Search Console date rows are present through `2026-09-05`, and under the configured three-day lag all observed rows through September 5 are now finalized; `2026-09-06` is absent.
-7. Record the newest finalized Search Console `2026-08-31..09-05` slice as **388 clicks / 60,880 impressions / ~0.637% CTR / ~7.35 impression-weighted position**. The equal-duration finalized `2026-08-24..29` slice is **436 / 55,594 / ~0.784% / ~10.73**. Current clicks are ~11.0% lower, impressions ~9.5% higher, CTR ~0.147 percentage points lower, and weighted average position ~3.38 positions better. Label this as a six-day source-native comparison, not a complete seven-day trend.
-8. Keep complete GSC 7-day and 28-day comparisons unavailable until source history supports them. The newest weekly export omits `2026-09-06`; the previous weekly export omits `2026-08-30`; older history includes the recorded `2026-08-23` gap and other incompleteness. Missing rows are never zero.
-9. Weekly GSC page aggregates may prioritize inspection but must not be used for page-level causal claims without date-by-page evidence. Daily Report routes show **8 clicks / 1,812 impressions** in the newest weekly page export versus **6 / 1,017** previously, but the export lacks date-by-page dimensions and spans a larger published report set.
-10. Treat the GA4 `2026-08-24..30` organic landing-page aggregate as the latest fully finalized weekly aggregate: **1,007 sessions** at about **45.88% session-weighted engagement**. The newer `2026-08-31..09-06` frozen aggregate contains **913 sessions** at about **47.54% engagement**, but it was generated while lagged dates were present and has no date dimension, so it remains partial until a refreshed source or safe date-dimensional evidence supersedes it.
-11. Use finalized date-by-page or date-by-query evidence before attributing search movement to one page, report, title, or topic family. Weekly page/query aggregates without a date dimension are prioritization evidence, not causal attribution.
-12. Treat independent crawler/search discovery as supplementary retrievability evidence. Exact-SHA Pages deployment and generated production artifacts remain the stronger publication acceptance evidence, especially immediately after a deployment when crawler refresh can lag.
-13. Treat GA4 `(not set)` and remaining legacy `/en/` traffic as measurement and technical SEO questions that require richer source-native evidence rather than as reasons to steer Daily Report topics.
-14. Add Cloudflare coverage only when a supported read-only route is enabled in repository configuration.
-15. Use search behavior, GitHub activity, primary research, kernel changes, and production evidence to order questions inside approved eBPF and adjacent systems series.
-16. The optimization series reaches five reports with the September 10 publication. The existing Daily Report index already exposes the sequence; do not create a thin public series hub without report-level acquisition or navigation evidence that it would improve retrieval.
-17. Migrate the consuming SEO contract before moving the pinned `seo-skills` submodule to a newer upstream layout. Upstream `main` is newer, but upstream movement alone is not evidence that a pointer-only bump is safe.
+1. Preserve the rolling ten-report mix mechanically. Before the `2026-09-11`
+   publication the newest ten contain **6 eBPF-centered / 0 pure Agent / 4
+   adjacent systems**. Today's optimization-evidence report is genuinely
+   eBPF-centered because BPF verifier/JIT/application/workload evidence and BPF
+   optimization promotion are the central objects. It rotates the `2026-08-30`
+   adjacent GPU-instrumentation report out, producing **7 / 0 / 3**. Never repair
+   the ratio through relabeling or an extra report.
+2. Close **eBPF Optimization and Execution Specialization** at its normal six-
+   report boundary with the September 11 publication. The sequence now covers:
+   verifier safety versus optimizer equivalence and profile lifetime; architecture
+   eligibility and portable fallback; execution-generation provenance; native-
+   operation trust/TCB accounting; cross-backend state-transition semantics; and
+   performance-evidence scope plus production promotion.
+3. Activate **eBPF Deployment Compatibility and Lifecycle** as the next normal
+   eBPF roadmap. Candidate boundaries are real-kernel/backport feature evidence,
+   verifier behavior drift, CO-RE relocation versus semantic compatibility,
+   kfunc/`struct_ops` capability negotiation, persistent-state lifecycle across
+   host upgrades, and reproducible capability/artifact manifests across
+   distributions. Keep it distinct from architecture specialization,
+   transactional application upgrade, and userspace runtime contracts.
+4. The post-September-11 mix sits at the maximum **7 eBPF / 0 Agent / 3
+   adjacent**. The next run must not publish an eighth eBPF-centered item while
+   the oldest report rotating out is adjacent. If the active eBPF series is
+   temporarily blocked by the arithmetic, use a strong approved adjacent-systems
+   detour or a quality-qualified limited Agent systems report, then resume the
+   active series when the window permits.
+5. Keep **eBPF Networking and Security**, **eBPF Observability and Profiling**,
+   **eBPF Runtime, Extensibility, and Composition**, and **GPU and Heterogeneous
+   Runtime Systems** closed at their normal boundaries unless fresh evidence
+   supports a genuinely new mechanism.
+6. Recheck all verified weekly Search Console and GA4 Drive export sets every
+   run. As rechecked on `2026-09-11`, the newest source set remains
+   `2026-08-31..09-06`. Search Console contains rows through `2026-09-05`; under
+   the configured three-day lag all observed rows are finalized, while
+   `2026-09-06` is absent.
+7. Record the newest finalized Search Console `2026-08-31..09-05` slice as **388
+   clicks / 60,880 impressions / ~0.637% CTR / ~7.35 impression-weighted
+   position**. The equal-duration `2026-08-24..29` slice is **436 / 55,594 /
+   ~0.784% / ~10.73**. Current clicks are ~11.0% lower, impressions ~9.5% higher,
+   CTR ~0.147 percentage points lower, and weighted position ~3.38 positions
+   better. This is a six-day source-native comparison, not a complete seven-day
+   trend.
+8. Keep complete GSC 7-day and 28-day comparisons unavailable until source
+   history is contiguous. The newest export omits `2026-09-06`, the preceding
+   export omits `2026-08-30`, and older history includes the recorded
+   `2026-08-23` gap. Missing rows are never zero.
+9. Weekly GSC page aggregates may prioritize inspection but cannot support
+   page-level causal claims without date-by-page evidence. Daily Report routes
+   show **8 clicks / 1,812 impressions** in the newest weekly page export versus
+   **6 / 1,017** previously, while the report set itself grew.
+10. Treat GA4 `2026-08-24..30` as the latest fully finalized weekly organic
+    landing-page aggregate: **1,007 sessions** at about **45.88% session-weighted
+    engagement**. The newer frozen `2026-08-31..09-06` aggregate contains **913
+    sessions** at about **47.54% engagement**, but remains partial because it was
+    exported while lagged dates were present and has no date dimension.
+11. Use finalized date-by-page or date-by-query evidence before attributing search
+    movement to one report, title, or topic family. Current aggregate evidence
+    does not justify a title/metadata rewrite.
+12. Treat exact-SHA Pages deployment and generated production artifacts as the
+    primary publication acceptance evidence; independent crawler/search discovery
+    is supplementary and can lag immediately after deployment.
+13. Keep Cloudflare evidence unavailable until a supported read-only route is
+    enabled in repository configuration.
+14. Keep the shared SEO skill submodule pinned until its consuming contract is
+    migrated to the newer upstream layout; do not make a pointer-only update.
+15. Do not create a thin public series hub without report-level acquisition or
+    navigation evidence that it would improve retrieval.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -32,22 +32,22 @@
 - GA4 export filename pattern: `*_ga4_*.csv`
 - Search Console export filename pattern: `*_gsc_*.csv`
 - Verified raw export window: `2026-07-27` through `2026-09-06`
-- Search Console newest observed source row: `2026-09-05`; under the configured three-day lag, finalized rows are used through `2026-09-04`; `2026-09-06` is absent
+- Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 aggregate: `2026-08-24` through `2026-08-30`
-- Newest GA4 aggregate: `2026-08-31` through `2026-09-06`, partial under the configured lag and not used as a finalized week-over-week comparison
+- Newest GA4 aggregate: `2026-08-31` through `2026-09-06`, still treated as partial because the frozen export was created while lagged dates were present and has no date dimension
 - Expected refresh cadence: weekly; verify freshness and coverage on every run
 
-The configured folder was directly reverified on `2026-09-07`. It now contains weekly Google export sets through `2026-08-31..09-06`, in addition to the previously verified sets beginning `2026-07-27..08-02`. Missing rows are not converted to zero.
+The configured folder was directly reverified on `2026-09-11`. It contains no weekly source set newer than `2026-08-31..09-06`. Missing rows are not converted to zero.
 
-For Search Console, the newest date export contains rows for `2026-08-31..09-05`; `2026-09-06` is absent. Under the configured three-day lag, the finalized contiguous slice available from the new set is `2026-08-31..09-04`. Those five rows contain **368 clicks / 53,341 impressions / about 0.690% aggregate CTR / about 7.45 impression-weighted average position**.
+For Search Console, the newest date export contains rows for `2026-08-31..09-05`; `2026-09-06` is absent. All currently observed rows are now outside the three-day finalization lag. The finalized six-day `2026-08-31..09-05` slice contains **388 clicks / 60,880 impressions / about 0.637% aggregate CTR / about 7.35 impression-weighted average position**.
 
-The equal-duration finalized `2026-08-24..28` slice contains **398 clicks / 48,044 impressions / about 0.828% CTR / about 10.04 weighted position**. Relative to that five-day slice, clicks are about **7.5% lower**, impressions about **11.0% higher**, CTR about **0.139 percentage points lower**, and weighted average position about **2.59 positions better**. This is an equal-duration source-native comparison, not a complete seven-day trend.
+The equal-duration finalized `2026-08-24..29` slice contains **436 clicks / 55,594 impressions / about 0.784% CTR / about 10.73 weighted position**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted average position about **3.38 positions better**. This is an equal-duration source-native comparison, not a complete seven-day trend.
 
-A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the required history is not contiguous: the prior weekly set omits `2026-08-30`, and older history also contains the previously recorded `2026-08-23` gap. The same historical gaps prevent the required complete 28-day versus preceding-comparable-period comparison. Missing rows are not converted to zero.
+A complete latest-seven-days versus previous-seven-days GSC comparison remains unavailable because the newest weekly set omits `2026-09-06` and the preceding set omits `2026-08-30`. Older history also contains the recorded `2026-08-23` gap, preventing the required complete 28-day versus preceding-comparable-period comparison. Missing rows are never synthesized as zero.
 
-The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly page export. The page export has no date dimension and the newest weekly set includes dates inside the finalization lag, so this is prioritization evidence only, not causal evidence for a title, topic, navigation, or metadata change.
+The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly page export. The page export has no date dimension and the published report set grew between weeks, so this is prioritization evidence only, not causal evidence for a title, topic, navigation, or metadata change.
 
-The GA4 `2026-08-24..30` organic landing-page aggregate remains the latest fully finalized weekly aggregate and contains **1,007 sessions** at about **45.88% session-weighted engagement**. The new `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**, but it includes dates inside the configured finalization lag and has no date dimension, so it is explicitly partial and is not used as a finalized week-over-week trend. The preceding finalized `2026-08-17..23` aggregate contains 984 sessions at about 49.29% engagement. Weekly aggregates do not support daily or within-week causal attribution.
+The GA4 `2026-08-24..30` organic landing-page aggregate remains the latest fully finalized weekly aggregate and contains **1,007 sessions** at about **45.88% session-weighted engagement**. The newer frozen `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains explicitly partial because it was exported while lagged dates were present and has no date dimension for safe finalized subsetting. The preceding finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29% engagement**.
 
 Public repository and live-site data supplement these exports but do not replace their source-native meanings.
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -10,17 +10,18 @@
 - Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
 - Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still partial because the frozen export was generated while lagged dates were present and has no date dimension
-- Latest completed daily record before the current run: `2026-09-10`, pending final production reconciliation at current-run start
+- Latest completed daily record before the current run: `2026-09-10`
 - Last merged Daily Report pull request: `#195`
 - Last Daily Report squash commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
 - Exact-merge `Validate SEO Operations` run for `#195`: `34618891189`, success
-- Exact-merge `Deploy Static App` run for `#195`: `34618891146`, still in progress when this run began and therefore not yet counted as verified production
+- Exact-merge `Deploy Static App` run for `#195`: `34618891146`, success
+- Static production export for `#195`: `b9bab3bfd4897272ca6264d66c450ad5236feb2a`, committed as `deploy static app for 59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
 - Current daily branch: `daily/2026-09-11-ebpf-optimization-evidence`
-- Current daily pull request: pending at record creation
+- Current daily pull request: `#196`
 - Current branch original base: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The valid September 10 delivery is PR `#195`, **Daily: define cross-backend semantics for eBPF operations**. It replaced the failed duplicate attempt `#194`. The current run must finish exact production verification for `#195` and close `#194` as superseded before closing today's work.
+The valid September 10 delivery is PR `#195`, **Daily: define cross-backend semantics for eBPF operations**. Its exact-merge validation and deployment are terminal-success, the generated bilingual production artifacts and sitemap were verified against the squash SHA, and the single compact merged-PR closeout comment was added. Failed duplicate PR `#194` is closed as superseded and was not merged.
 
 ## Current Daily Report mix
 
@@ -72,12 +73,11 @@ The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c591464
 
 ## Current focus
 
-1. Finish the September 10 `#195` exact production deployment and generated/public bilingual verification, add its single compact merged-PR closeout comment, and close failed duplicate `#194` as superseded.
-2. Complete today's optimization-evidence report through a non-draft PR, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
-3. Close **eBPF Optimization and Execution Specialization** at six reports and preserve the next **eBPF Deployment Compatibility and Lifecycle** roadmap without exceeding the rolling 7-of-10 eBPF cap.
-4. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
-5. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
-6. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
-7. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
+1. Complete today's optimization-evidence report through PR `#196`, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
+2. Close **eBPF Optimization and Execution Specialization** at six reports and preserve the next **eBPF Deployment Compatibility and Lifecycle** roadmap without exceeding the rolling 7-of-10 eBPF cap.
+3. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
+4. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
+5. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
+6. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
 
 Detailed run history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,75 +7,77 @@
 - Daily Report subtask: `.agents/skills/eunomia-research-report/SKILL.md`
 - External daily scheduler: configured and enabled
 - Verified raw Google export window: through `2026-09-06`
-- Search Console newest observed source row: `2026-09-05`; under the configured three-day lag, all observed rows through `2026-09-05` are now finalized; `2026-09-06` is absent
+- Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
-- Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still treated as partial because the frozen export was generated while lagged dates were present and has no date dimension
-- Latest completed daily record before the current run: `2026-09-09`
-- Last completed Daily Report pull request: `#193`
-- Last verified Daily Report squash commit: `e2d1203e783af37354c6f4f88872370baf45bf5b`
-- Last verified production publication from a Daily Report run: static export commit `717c4dd6e90f9176d57e472427e085f32a1820cb`
-- Current daily branch: `daily/2026-09-10-ebpf-semantic-delegation`
-- Current daily pull request: `#195`
-- Current branch original base: `2ae9350ad4be2ac88f6c71b52951688c62713caf`
-- Current default branch observed at run start: `2ae9350ad4be2ac88f6c71b52951688c62713caf`
+- Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still partial because the frozen export was generated while lagged dates were present and has no date dimension
+- Latest completed daily record before the current run: `2026-09-10`, pending final production reconciliation at current-run start
+- Last merged Daily Report pull request: `#195`
+- Last Daily Report squash commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
+- Exact-merge `Validate SEO Operations` run for `#195`: `34618891189`, success
+- Exact-merge `Deploy Static App` run for `#195`: `34618891146`, still in progress when this run began and therefore not yet counted as verified production
+- Current daily branch: `daily/2026-09-11-ebpf-optimization-evidence`
+- Current daily pull request: pending at record creation
+- Current branch original base: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-PR `#193`, **Daily: define the native-operation trust boundary for eBPF**, is fully reconciled. It squash-merged as `e2d1203e783af37354c6f4f88872370baf45bf5b`. Exact-merge `Validate SEO Operations` run `34377678850` and `Deploy Static App` run `34377678674` both succeeded. The deployment produced static export `717c4dd6e90f9176d57e472427e085f32a1820cb`, explicitly bound by commit message to the squash SHA. Its single top-level Daily closeout records verified bilingual generated artifacts, canonical and language metadata, Article JSON-LD, sitemap entries, analytics coverage, topic mix, and the independent-crawler lag that remained at closeout.
+The valid September 10 delivery is PR `#195`, **Daily: define cross-backend semantics for eBPF operations**. It replaced the failed duplicate attempt `#194`. The current run must finish exact production verification for `#195` and close `#194` as superseded before closing today's work.
 
 ## Current Daily Report mix
 
 Before today's publication, the newest ten actually published reports contain:
 
-- eBPF-centered: **5 of 10**
+- eBPF-centered: **6 of 10**
 - pure Agent-centered: **0 of 10**
-- adjacent systems: **5 of 10**
+- adjacent systems: **4 of 10**
 
-Today's selected `/research/ebpf-cross-backend-operation-semantics/` report is **eBPF-centered**. BPF map semantics, offload dispatch, state transitions, concurrency, failure outcomes, and cross-backend refinement are the central objects rather than optional instrumentation.
+Today's selected `/research/ebpf-optimization-evidence-contract/` report is **eBPF-centered**. BPF verifier/JIT/application/workload evidence and the promotion boundary for eBPF optimizations are the central technical objects.
 
-The incoming report rotates the `2026-08-29` adjacent-systems GPU memory-placement report out of the newest-ten window. After publication the mix becomes **6 eBPF-centered / 0 pure Agent / 4 adjacent systems**, still inside the normal 5–7 eBPF target band. No existing classification changes.
+The incoming report rotates the `2026-08-30` adjacent GPU-instrumentation report out. After publication the mix becomes **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**, still inside the 5–7 target band but at its upper limit. No existing classification changes.
 
-**eBPF Optimization and Execution Specialization** remains active. September 5 established verifier safety versus optimizer equivalence and profile-assumption lifetime; September 6 established architecture-specific implementation eligibility and deterministic portable fallback; September 7 established generation-aware execution provenance; September 9 made delegated native-code trust, effect scope, assurance evidence, and artifact identity explicit. September 10 advances a fifth distinct boundary: whether several eligible and trusted backends refine one observable state-transition contract under concurrency, failures, and backend handoff.
+**eBPF Optimization and Execution Specialization** closes with this sixth report. The six covered boundaries are semantic equivalence and profile lifetime, architecture-specific implementation/fallback, exact execution-generation provenance, native-operation trust/TCB accounting, cross-backend state-transition semantics, and performance-evidence scope/promotion.
+
+The next eBPF roadmap is **eBPF Deployment Compatibility and Lifecycle**, but the post-publication rolling mix is already at seven eBPF-centered reports. The next scheduled publication must use an adjacent or other quality-qualified non-eBPF-centered detour if another eBPF report would exceed the cap; the active compatibility series resumes when the window permits.
 
 ## Current signals
 
 ### Google Search Console
 
-The exact configured Drive folder was rechecked on `2026-09-10`; no source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
+The configured Drive source was rechecked on `2026-09-11`; no source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
 
-Under the configured three-day lag, every observed row through September 5 is now finalized. The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted average position about **3.38 positions better**.
+The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**.
 
-This is not a complete seven-day trend. The newest export omits `2026-09-06`, the preceding export omits `2026-08-30`, and older history includes the recorded `2026-08-23` gap, so complete latest-seven-day and 28-day comparable-period analyses remain unavailable. Missing rows are never interpreted as zero.
+This is not a complete seven-day trend. The newest export omits `2026-09-06`, the preceding export omits `2026-08-30`, and older history includes the recorded `2026-08-23` gap. Complete latest-seven-day and 28-day comparable-period analyses remain unavailable. Missing rows are never interpreted as zero.
 
-The newest weekly GSC page aggregate still contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly export. The page export has no date dimension and the published report set changed between weeks, so this remains prioritization evidence rather than causal evidence for a title, topic, navigation, or metadata change.
+The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly export. The page export has no date dimension and the published report set changed, so this is prioritization evidence rather than causal evidence for a title, topic, navigation, or metadata change.
 
 ### Google Analytics 4
 
 The finalized `2026-08-24..30` organic landing-page aggregate remains **1,007 sessions** at about **45.88% session-weighted engagement**. The preceding finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29% engagement**.
 
-The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains marked partial because the exported weekly aggregate was generated while dates inside the finalization lag were present and provides no date dimension for safe finalized subsetting. No refreshed source set supersedes it today.
+The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains partial because the frozen export was generated while lagged dates were present and provides no date dimension for safe finalized subsetting.
 
 ### Public and repository technical evidence
 
-The repository-generated `2026-09-10` data brief reports the canonical homepage at HTTP 200 in 223 ms, robots at HTTP 200, sitemap at HTTP 200, and 748 sitemap entries. It also records 99 active non-fork repositories, 9,976 current GitHub stars, 1,306 forks, and 285 open issue/PR records across the observed public portfolio. These public counters are context, not a blended SEO score.
+The latest public-safe data brief observed on `2026-09-11` reports the canonical homepage at HTTP 200 in 233 ms, robots at HTTP 200, sitemap at HTTP 200, and 748 sitemap entries. It records 99 active non-fork repositories, 9,987 stars, 1,305 forks, and 287 open issue/PR records across the observed public portfolio. These are context, not a blended SEO score.
 
-Current source, deployment, and live/public evidence does not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants a separate technical SEO implementation change today. The bilingual report and index additions are the only reader-facing site changes selected by the evidence.
+Current analytics, repository health, deployment evidence, and public-safe evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants a separate technical SEO implementation change today.
 
 Cloudflare remains disabled by repository configuration, so no Cloudflare-grounded traffic, cache, bot, country, or status-code conclusion is made.
 
 ## Current technical baseline
 
-The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, structured data, legacy redirect stubs, and static audit artifacts. Production deploys through `Deploy Static App`.
+The repository generates sitemap, robots, canonical, `hreflang`, Open Graph, Article structured data, legacy redirect stubs, and static audit artifacts. Production deploys through `Deploy Static App`.
 
-The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Its upstream default branch is newer, but the durable plan requires the consuming SEO contract to be migrated before the pointer moves. No pointer-only update is made.
+The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c5914643e9`. Upstream movement alone is not evidence that a pointer-only update is safe; the consuming contract must be migrated first.
 
 ## Current focus
 
-1. Complete PR `#195` through authoritative terminal-green CI, complete final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one compact merged-PR closeout comment.
-2. Advance **eBPF Optimization and Execution Specialization** with a backend-independent state-transition contract for higher-level operations, executable history conformance, and mixed-backend continuity testing.
-3. Keep later work materially distinct from verifier-equivalence, stale-profile invalidation, architecture capability/fallback, execution provenance, native-operation TCB accounting, and today's cross-backend state-transition semantics.
+1. Finish the September 10 `#195` exact production deployment and generated/public bilingual verification, add its single compact merged-PR closeout comment, and close failed duplicate `#194` as superseded.
+2. Complete today's optimization-evidence report through a non-draft PR, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
+3. Close **eBPF Optimization and Execution Specialization** at six reports and preserve the next **eBPF Deployment Compatibility and Lifecycle** roadmap without exceeding the rolling 7-of-10 eBPF cap.
 4. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
-5. Keep the newest GA4 weekly aggregate explicitly partial until a refreshed source or date-dimensional evidence supports finalized interpretation.
-6. Keep Cloudflare evidence unavailable until a supported read-only path is enabled in repository configuration.
+5. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
+6. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
 7. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
 
 Detailed run history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/docs/research/ebpf-optimization-evidence-contract.md
+++ b/docs/research/ebpf-optimization-evidence-contract.md
@@ -1,5 +1,6 @@
 ---
 date: 2026-09-11
+slug: ebpf-optimization-evidence-contract
 title: "When Is an eBPF Optimization Result Strong Enough to Ship?"
 description: "eBPF optimizations can win one microbenchmark and regress real applications. This report develops evidence envelopes, holdout tests, and promotion gates."
 tags:
@@ -28,7 +29,7 @@ This report closes the current optimization series after [runtime-profile specia
 
 Those reports establish five different questions: is the transformation equivalent, are runtime assumptions still valid, can the implementation run on this architecture, which specialization actually executed, and does delegated stateful behavior preserve one semantic contract? Here we assume those gates pass. The remaining question is whether the *performance evidence* justifies saying that an optimization is useful outside the exact experiment that discovered it.
 
-## The same optimization can have several different performance truths
+## Why one eBPF optimization benchmark does not define the performance truth
 
 Kops is a useful example because it reports both microbenchmark and application results. Its EInsn operations replace verifier-visible BPF instruction sequences with native machine idioms. The paper reports microbenchmark improvements up to 24%, while production applications improve by up to 12% on x86-64 and ARM64. Those numbers are not contradictory. They answer different questions.
 
@@ -42,7 +43,7 @@ That is the evidence problem in one sentence. An optimization result is not a sc
 
 ## What current evaluation still leaves underspecified
 
-The first gap is **the unit of a performance claim**. “Up to 20% faster” can mean one instruction sequence, one BPF program, one application phase, or one end-to-end workload. Without an explicit claim boundary, a valid local result can be read as a much broader result.
+The first gap is **the unit of a performance claim**. "Up to 20% faster" can mean one instruction sequence, one BPF program, one application phase, or one end-to-end workload. Without an explicit claim boundary, a valid local result can be read as a much broader result.
 
 The second gap is **profitability coverage**. Correctness can often be binary: the transformed program is equivalent or it is not. Profitability is rarely binary. A pass may help 30 programs, be neutral on 100, and regress 16. A single geomean can hide whether those regressions occur on rare utilities or on the programs consuming most fleet CPU time.
 
@@ -77,9 +78,11 @@ regression_budget = <= 1% on guarded metrics
 claim_scope = {this program, this workload family, this target class}
 ```
 
-The key difference from ordinary benchmark metadata is the final field. The artifact states what the result is allowed to justify. A microbenchmark can support “this instruction idiom is cheaper on this target.” It cannot automatically support “the application is faster.” A production replay can support an application-level claim, but only for the workload and target family represented by the replay.
+The key difference from ordinary benchmark metadata is the final field. The artifact states what the result is allowed to justify. A microbenchmark can support "this instruction idiom is cheaper on this target." It cannot automatically support "the application is faster." A production replay can support an application-level claim, but only for the workload and target family represented by the replay.
 
 The research artifact would be a schema plus a comparison engine that can combine envelopes only when their claim scopes are compatible. Evaluation should take published-style optimization summaries and ask whether the envelope prevents over-broad conclusions while remaining compact enough to generate automatically. A useful metric is *claim escape*: how often a result accepted under a weaker metadata scheme fails when rerun outside its hidden assumptions.
+
+The academic value is a testable model for the scope of systems-performance claims: which dimensions must match before two results may be aggregated or generalized. The production user is a compiler/JIT or fleet-performance team; the integration boundary is the benchmark-to-promotion pipeline, where the envelope can travel with the optimized artifact and constrain where it is eligible to run.
 
 The idea is not worthwhile if ordinary benchmark manifests already capture every condition that materially changes the result and reviewers or deployment systems consistently enforce that scope. The experiment should try to falsify the need for another artifact.
 
@@ -91,21 +94,27 @@ Split evidence into at least three groups. A development set is visible to the o
 
 The [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark) integrity model already points in this direction by treating the optimizer as untrusted and forbidding tricks such as shortening workloads, filtering failed programs, bypassing real loaders, or fabricating result files. A research system can make that principle quantitative.
 
-The primary score should not be “best speedup found.” Report at least acceptance coverage, worst guarded regression, holdout speedup distribution, invalid-result rate, and the fraction of development wins that reproduce on holdout targets. For agentic search, freeze the holdout oracle until final evaluation so the search loop cannot adapt to it.
+The primary score should not be "best speedup found." Report at least acceptance coverage, worst guarded regression, holdout speedup distribution, invalid-result rate, and the fraction of development wins that reproduce on holdout targets. For agentic search, freeze the holdout oracle until final evaluation so the search loop cannot adapt to it.
 
 An ablation can intentionally leak holdout results back to the optimizer. If the final score rises while independent reproduction gets worse, the benchmark has demonstrated the exact overfitting problem it is meant to measure.
 
-This would produce a reusable benchmark methodology rather than another optimization pass. The production analogue is equally useful: canary workloads and machines become holdouts for a newly discovered optimization policy.
+The academic contribution is a methodology for measuring adaptive-search overfit in systems optimization rather than treating the benchmark as a passive test set. In production, compiler or performance teams can use canary workloads and machines as sealed holdouts before widening an optimization policy to the fleet.
+
+This machinery should be rejected if, at a comparable measurement budget, it neither improves independent reproduction of development-set wins nor detects materially more regressions than a development-only benchmark. It also loses if the extra holdout cost is large enough that a simpler fixed validation matrix provides the same decision quality.
 
 ### 3. Promote optimizations through a profitability contract, not a global enable bit
 
 Many optimizations do not need to be universally good. They need a reliable applicability rule.
 
-A promotion system could learn or derive a small profitability predicate from the evidence envelope: target architecture, JIT capabilities, program features, code-size delta, runtime profile stability, and application/workload class. The optimization is enabled only when the predicate matches. The runtime then records whether the expected benefit appears and disables or rolls back the specialization when a guarded regression budget is exceeded.
+A promotion system could learn or derive a small profitability predicate from the evidence envelope: target architecture, JIT capabilities, program features, code-size delta, runtime profile stability, and application/workload class. The optimization is enabled only when the predicate matches. The runtime then records whether the expected benefit appears.
+
+A noisy metric should not cause an immediate rollback. The controller can require a minimum sample count and a sustained budget breach across two independent observation windows, with the optimized and baseline distributions compared at a predefined confidence level. A correctness failure still rolls back immediately. After a performance rollback, a cooldown prevents automatic re-enablement until fresh evidence extends the envelope or an operator explicitly reopens the target class. Evaluation should report false rollback rate and enable/disable flapping in addition to detection delay.
 
 This is deliberately different from the September 5 deoptimization mechanism. That report asks whether a stale runtime assumption can change program semantics. Here semantics remain valid; the predicate controls *economic usefulness*. The fallback may be triggered because p99 latency regressed 3%, because JIT size crossed an instruction-cache budget, or because the optimized program accounts for too little runtime to justify added complexity.
 
-The evaluation should compare three policies: globally enable the optimization, statically enable it on a hand-written target allowlist, and evidence-driven promotion. Test across kernel versions, x86-64 and ARM64, several CPU generations, microbenchmarks, and real application workloads. Measure realized fleet-weighted speedup, worst regression, fraction of eligible executions, decision overhead, rollback frequency, and how quickly the policy adapts after a workload or kernel change.
+The academic question is whether a compact applicability predicate can preserve most optimization benefit under non-stationary workloads while bounding regret and rollback error. The production user is the team operating the BPF loader, JIT policy, or rollout service; the integration boundary is the point where an already-correct optimized artifact is selected for a concrete program and target.
+
+The evaluation should compare three policies: globally enable the optimization, statically enable it on a hand-written target allowlist, and evidence-driven promotion. Test across kernel versions, x86-64 and ARM64, several CPU generations, microbenchmarks, and real application workloads. Measure realized fleet-weighted speedup, worst regression, fraction of eligible executions, decision overhead, rollback frequency, false rollback rate, flapping, and how quickly the policy adapts after a workload or kernel change.
 
 The system loses if a simple static allowlist achieves the same realized benefit and regression bound. That failure condition matters: not every optimization needs an online controller.
 
@@ -135,7 +144,7 @@ The argument would also weaken if existing BPF CI already provided one end-to-en
 
 Finally, a profitability contract is not justified if the optimization has negligible downside and an overwhelming benefit on every supported target. The right answer for a universally profitable transformation is still to make the compiler better, not to build a control plane around it.
 
-But for optimizations that are architecture-sensitive, profile-sensitive, or discovered by adaptive search, “the benchmark got faster” is only the beginning of the evidence. The result is strong enough to ship when the system can state **where the claim applies, which counterexamples were tested, what regressions are bounded, and what observation will revoke the optimization when reality leaves the measured envelope.**
+But for optimizations that are architecture-sensitive, profile-sensitive, or discovered by adaptive search, "the benchmark got faster" is only the beginning of the evidence. The result is strong enough to ship when the system can state **where the claim applies, which counterexamples were tested, what regressions are bounded, and what observation will revoke the optimization when reality leaves the measured envelope.**
 
 ## References
 
@@ -143,4 +152,3 @@ But for optimizations that are architecture-sensitive, profile-sensitive, or dis
 - Linux BPF CI, [kernel-patches/bpf](https://github.com/kernel-patches/bpf), accessed 2026-09-11.
 - libbpf, [`veristat`](https://github.com/libbpf/veristat), accessed 2026-09-11.
 - Eunomia, [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark), accessed 2026-09-11.
-- sched_ext, [Developer Guide](https://github.com/sched-ext/scx/blob/main/DEVELOPER_GUIDE.md), accessed 2026-09-11.

--- a/docs/research/ebpf-optimization-evidence-contract.md
+++ b/docs/research/ebpf-optimization-evidence-contract.md
@@ -1,0 +1,146 @@
+---
+date: 2026-09-11
+title: "When Is an eBPF Optimization Result Strong Enough to Ship?"
+description: "eBPF optimizations can win one microbenchmark and regress real applications. This report develops evidence envelopes, holdout tests, and promotion gates."
+tags:
+  - Daily Report
+  - eBPF
+  - Optimization
+  - JIT
+  - Benchmarking
+  - Verification
+research_question: "How can eBPF optimization evidence show that a speedup survives verifier, JIT, kernel, architecture, application, and workload variation instead of reflecting one tuned benchmark?"
+source_cutoff: 2026-09-11
+status: daily-report
+---
+
+# When Is an eBPF Optimization Result Strong Enough to Ship?
+
+Suppose an eBPF optimization makes a tight `BPF_PROG_TEST_RUN` loop 18% faster. The verifier still accepts the program, the JIT emits fewer instructions, and repeated runs on the same machine are stable. Is that enough evidence to enable the optimization for Cilium, Katran, Tracee, or a fleet of mixed x86 and ARM machines?
+
+Not really. The optimization can be completely correct and still be a poor production choice. It may speed up a hot arithmetic loop but add code size that hurts the instruction cache in a larger program. It may help one JIT backend and do nothing on another. It may optimize a program that accounts for almost none of the application's workload time. A profile-guided pass can look excellent on the workload used to tune it and lose when branch bias changes. An automated optimizer can even discover ways to improve the benchmark rather than the intended application behavior.
+
+This creates a different problem from proving semantic equivalence. **For an eBPF optimization, correctness tells us whether the transformed program is allowed to replace the original. It does not tell us how broad the performance claim is, where the optimization is profitable, or whether the evidence is strong enough to promote it into production.**
+
+<!-- more -->
+
+This report closes the current optimization series after [runtime-profile specialization](https://eunomia.dev/research/ebpf-runtime-profile-specialization/), [portable architecture specialization](https://eunomia.dev/research/ebpf-portable-architecture-specialization/), [execution provenance](https://eunomia.dev/research/ebpf-specialization-debug-provenance/), [native-operation trust](https://eunomia.dev/research/ebpf-native-operation-trust-boundary/), and [cross-backend operation semantics](https://eunomia.dev/research/ebpf-cross-backend-operation-semantics/).
+
+Those reports establish five different questions: is the transformation equivalent, are runtime assumptions still valid, can the implementation run on this architecture, which specialization actually executed, and does delegated stateful behavior preserve one semantic contract? Here we assume those gates pass. The remaining question is whether the *performance evidence* justifies saying that an optimization is useful outside the exact experiment that discovered it.
+
+## The same optimization can have several different performance truths
+
+Kops is a useful example because it reports both microbenchmark and application results. Its EInsn operations replace verifier-visible BPF instruction sequences with native machine idioms. The paper reports microbenchmark improvements up to 24%, while production applications improve by up to 12% on x86-64 and ARM64. Those numbers are not contradictory. They answer different questions.
+
+A microbenchmark can isolate whether a rotate, conditional select, extract, or similar sequence becomes cheaper. A production application additionally asks how often that sequence executes, what surrounds it, whether code layout changes, whether helper/map costs dominate, and whether the application-level workload is sensitive to the saved cycles.
+
+Linux BPF infrastructure already reflects a similar distinction. BPF CI uses `veristat` on complex programs to compare verifier behavior and catch verifier-performance regressions. `veristat` can compare properties such as processed instructions and verifier statistics between revisions. That is valuable, but a verifier regression is not the same thing as runtime throughput or tail latency. One optimization therefore needs several oracles rather than one universal score.
+
+The current [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark) framework makes this explicit for optimization research. Its current corpus contains six production eBPF applications, 146 comparable program measurements, and 42 microbenchmark tasks. It records verifier outcomes, JIT code size, application lifecycle state, workload correctness, raw workload metrics, and per-program kernel run counters. The framework also notes a practical fact that is easy to miss: static rewrite counts do not reliably predict speedup, and a pass that improves one program can regress another.
+
+That is the evidence problem in one sentence. An optimization result is not a scalar. It is a conditional claim over a program, runtime, architecture, kernel, workload, and measurement procedure.
+
+## What current evaluation still leaves underspecified
+
+The first gap is **the unit of a performance claim**. “Up to 20% faster” can mean one instruction sequence, one BPF program, one application phase, or one end-to-end workload. Without an explicit claim boundary, a valid local result can be read as a much broader result.
+
+The second gap is **profitability coverage**. Correctness can often be binary: the transformed program is equivalent or it is not. Profitability is rarely binary. A pass may help 30 programs, be neutral on 100, and regress 16. A single geomean can hide whether those regressions occur on rare utilities or on the programs consuming most fleet CPU time.
+
+The third gap is **environment generalization**. eBPF sits in a compilation pipeline with architecture-specific JITs, kernel versions, feature backports, helper implementations, map behavior, CPU microarchitecture, and application loaders. An optimization that is semantically portable can still have sharply different performance on another JIT or CPU. The September 6 report addressed safe architectural eligibility and fallback. It did not define how much evidence is required before claiming that the *performance benefit* generalizes.
+
+The fourth gap is **adaptive-search bias**. An optimizer, especially an automated or agentic optimizer, may try many transformations and repeatedly observe the same benchmark. Eventually it can overfit to measurement noise, one workload phase, a warm cache state, or even a loophole in the harness. Traditional compiler evaluation worries about benchmark selection; closed-loop search adds the risk that the benchmark itself becomes the optimization target.
+
+The fifth gap is **production promotion**. Papers normally stop after evaluation. Production systems need another decision: on which machines and programs should this optimization be enabled tomorrow, what evidence should travel with that decision, and what observation should revoke it?
+
+## Promising directions with academic and production value
+
+### 1. Make every optimization claim carry an evidence envelope
+
+Instead of publishing or storing only a speedup, treat the result as a structured artifact. An evidence envelope would bind the optimization identity to the conditions under which its benefit was measured.
+
+A minimal record might include:
+
+```text
+optimization = rotate_v3
+semantic_witness = proof-sequence-hash
+kernel = 6.x + commit
+jit = x86_64 / commit
+cpu = family-model-stepping
+program = object + program tag
+application = katran + revision
+workload = replay-manifest + digest
+baseline = exact artifact
+samples = raw run counters + workload metrics
+correctness = pass/fail + oracle identity
+performance = distribution + confidence interval
+regression_budget = <= 1% on guarded metrics
+claim_scope = {this program, this workload family, this target class}
+```
+
+The key difference from ordinary benchmark metadata is the final field. The artifact states what the result is allowed to justify. A microbenchmark can support “this instruction idiom is cheaper on this target.” It cannot automatically support “the application is faster.” A production replay can support an application-level claim, but only for the workload and target family represented by the replay.
+
+The research artifact would be a schema plus a comparison engine that can combine envelopes only when their claim scopes are compatible. Evaluation should take published-style optimization summaries and ask whether the envelope prevents over-broad conclusions while remaining compact enough to generate automatically. A useful metric is *claim escape*: how often a result accepted under a weaker metadata scheme fails when rerun outside its hidden assumptions.
+
+The idea is not worthwhile if ordinary benchmark manifests already capture every condition that materially changes the result and reviewers or deployment systems consistently enforce that scope. The experiment should try to falsify the need for another artifact.
+
+### 2. Use holdout and counterexample suites for optimizer evaluation
+
+Optimization evaluation usually asks whether a pass wins on selected programs. An adaptive optimizer needs a stronger test: can it improve the search set without learning how to game it?
+
+Split evidence into at least three groups. A development set is visible to the optimizer. A holdout set contains unseen applications, workload phases, kernels, or architectures. A counterexample set contains cases designed to punish common shortcuts: programs where code-size growth should hurt, workloads where the optimized sequence is cold, branch distributions that invert the training profile, verifier-sensitive programs, and applications whose real loader or lifecycle must remain intact.
+
+The [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark) integrity model already points in this direction by treating the optimizer as untrusted and forbidding tricks such as shortening workloads, filtering failed programs, bypassing real loaders, or fabricating result files. A research system can make that principle quantitative.
+
+The primary score should not be “best speedup found.” Report at least acceptance coverage, worst guarded regression, holdout speedup distribution, invalid-result rate, and the fraction of development wins that reproduce on holdout targets. For agentic search, freeze the holdout oracle until final evaluation so the search loop cannot adapt to it.
+
+An ablation can intentionally leak holdout results back to the optimizer. If the final score rises while independent reproduction gets worse, the benchmark has demonstrated the exact overfitting problem it is meant to measure.
+
+This would produce a reusable benchmark methodology rather than another optimization pass. The production analogue is equally useful: canary workloads and machines become holdouts for a newly discovered optimization policy.
+
+### 3. Promote optimizations through a profitability contract, not a global enable bit
+
+Many optimizations do not need to be universally good. They need a reliable applicability rule.
+
+A promotion system could learn or derive a small profitability predicate from the evidence envelope: target architecture, JIT capabilities, program features, code-size delta, runtime profile stability, and application/workload class. The optimization is enabled only when the predicate matches. The runtime then records whether the expected benefit appears and disables or rolls back the specialization when a guarded regression budget is exceeded.
+
+This is deliberately different from the September 5 deoptimization mechanism. That report asks whether a stale runtime assumption can change program semantics. Here semantics remain valid; the predicate controls *economic usefulness*. The fallback may be triggered because p99 latency regressed 3%, because JIT size crossed an instruction-cache budget, or because the optimized program accounts for too little runtime to justify added complexity.
+
+The evaluation should compare three policies: globally enable the optimization, statically enable it on a hand-written target allowlist, and evidence-driven promotion. Test across kernel versions, x86-64 and ARM64, several CPU generations, microbenchmarks, and real application workloads. Measure realized fleet-weighted speedup, worst regression, fraction of eligible executions, decision overhead, rollback frequency, and how quickly the policy adapts after a workload or kernel change.
+
+The system loses if a simple static allowlist achieves the same realized benefit and regression bound. That failure condition matters: not every optimization needs an online controller.
+
+## A practical evaluation contract
+
+These directions suggest a simple hierarchy for future eBPF optimization claims.
+
+First, prove or otherwise validate **semantic admissibility**. That is the work covered by verifier safety, equivalence, trust, and stateful operation contracts.
+
+Second, measure **local mechanism gain** with microbenchmarks. This tells us whether the intended machine-level effect exists.
+
+Third, measure **program gain** using kernel run counters, JIT size, and repeated execution of the actual BPF program. This catches interactions with surrounding bytecode.
+
+Fourth, measure **application gain** through the real loader and workload. This determines whether the optimized BPF program matters to the system using it.
+
+Fifth, test **generalization** on holdout kernels, architectures, and workload phases. This defines how broad the claim can be.
+
+Finally, measure **promotion safety**: how many regressions escape the applicability rule, how quickly they are detected, and whether rollback restores the baseline.
+
+A paper does not need every layer for every experiment. It should, however, stop its claim at the highest layer actually tested. A production rollout should be even stricter because the workload distribution, not the best benchmark, determines the realized value.
+
+## What would change this conclusion?
+
+The proposed evidence machinery would be unnecessary if local eBPF benchmark wins already predicted production benefit with high reliability. A large corpus could test that directly: correlate isolated instruction/program speedups with application throughput, latency, and BPF CPU time across architectures and workloads. If the relationship is strong and stable, elaborate evidence envelopes and holdout gates would add process without much information.
+
+The argument would also weaken if existing BPF CI already provided one end-to-end optimization contract combining verifier behavior, exact JIT output, real application lifecycle, workload correctness, runtime performance, architecture diversity, and regression promotion. Today the pieces exist, but they are normally separate: `veristat` is strong verifier evidence, application benchmark suites provide workload evidence, and individual optimization papers define their own performance matrices.
+
+Finally, a profitability contract is not justified if the optimization has negligible downside and an overwhelming benefit on every supported target. The right answer for a universally profitable transformation is still to make the compiler better, not to build a control plane around it.
+
+But for optimizations that are architecture-sensitive, profile-sensitive, or discovered by adaptive search, “the benchmark got faster” is only the beginning of the evidence. The result is strong enough to ship when the system can state **where the claim applies, which counterexamples were tested, what regressions are bounded, and what observation will revoke the optimization when reality leaves the measured envelope.**
+
+## References
+
+- Yusheng Zheng et al., [Kops: Safely Extending the eBPF Compilation Pipeline with Native Operations](https://arxiv.org/abs/2606.24213), 2026.
+- Linux BPF CI, [kernel-patches/bpf](https://github.com/kernel-patches/bpf), accessed 2026-09-11.
+- libbpf, [`veristat`](https://github.com/libbpf/veristat), accessed 2026-09-11.
+- Eunomia, [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark), accessed 2026-09-11.
+- sched_ext, [Developer Guide](https://github.com/sched-ext/scx/blob/main/DEVELOPER_GUIDE.md), accessed 2026-09-11.

--- a/docs/research/ebpf-optimization-evidence-contract.zh.md
+++ b/docs/research/ebpf-optimization-evidence-contract.zh.md
@@ -1,0 +1,152 @@
+---
+date: 2026-09-11
+title: "一个 eBPF 优化结果，到什么程度才值得上线？"
+description: "eBPF 优化可能在单个 microbenchmark 上很快，却让真实应用退化。本文讨论 evidence envelope、holdout 测试和上线 promotion gate。"
+tags:
+  - Daily Report
+  - eBPF
+  - Optimization
+  - JIT
+  - Benchmarking
+  - Verification
+research_question: "怎样证明一个 eBPF 优化的收益能跨 verifier、JIT、kernel、architecture、application 和 workload 成立，而不是只对某个被调过的 benchmark 有效？"
+source_cutoff: 2026-09-11
+status: daily-report
+---
+
+# 一个 eBPF 优化结果，到什么程度才值得上线？
+
+假设一个 eBPF 优化把某个 `BPF_PROG_TEST_RUN` tight loop 加速了 18%。Verifier 还是通过，JIT 出来的指令也更少，同一台机器重复跑结果很稳定。现在能不能把它默认打开，然后用于 Cilium、Katran、Tracee，甚至一整个同时有 x86 和 ARM 的 fleet？
+
+还不够。
+
+这个优化可能在语义上完全正确，却仍然不适合生产。它也许把一个 arithmetic loop 做快了，却因为 code size 变大，在大型 program 里造成 I-cache 压力；也许只对某一个 JIT backend 有收益；也许被优化的 program 只占 application 总运行时间的一小部分；profile-guided pass 还可能只对训练时的 branch bias 有利，一换 workload phase 就开始掉速。如果优化过程本身是自动搜索甚至 agentic search，它还可能学会“把 benchmark 做快”，而不是把真正的 application 做快。
+
+所以这里的问题已经不是 semantic equivalence。**Correctness 只能告诉我们 transformed program 能不能合法替代原程序，它不能告诉我们 performance claim 到底覆盖多大范围、优化在哪些环境里真的 profitable，也不能直接告诉我们证据是否足够支持生产上线。**
+
+<!-- more -->
+
+本文是当前 optimization series 的收尾篇。前面已经讨论过 [runtime-profile specialization](https://eunomia.dev/zh/research/ebpf-runtime-profile-specialization/)、[跨架构 specialization](https://eunomia.dev/zh/research/ebpf-portable-architecture-specialization/)、[execution provenance](https://eunomia.dev/zh/research/ebpf-specialization-debug-provenance/)、[native-operation trust boundary](https://eunomia.dev/zh/research/ebpf-native-operation-trust-boundary/) 和 [cross-backend operation semantics](https://eunomia.dev/zh/research/ebpf-cross-backend-operation-semantics/)。
+
+前五篇分别解决 transformation 是否等价、runtime assumption 是否还成立、当前 architecture 能不能执行、事故时到底是哪一代 specialization 在跑、以及 delegated stateful operation 是否保持同一份 semantic contract。这里把这些 gate 都假设为已经通过，只剩最后一个问题：**发现一个 speedup 以后，我们凭什么认为它不是某一次实验的偶然结果？**
+
+## 同一个优化，其实可以同时存在几种不同的“性能真相”
+
+Kops 是一个很好的例子，因为它同时报告了 microbenchmark 和 application 结果。EInsn 用 native machine idiom 替换 verifier-visible BPF instruction sequence。论文里 microbenchmark 最高提升 24%，production application 最高提升 12%，并且在 x86-64 与 ARM64 上做了评估。
+
+这两个数字并不矛盾，它们回答的是不同问题。
+
+Microbenchmark 可以隔离出 rotate、conditional select、extract 之类的 sequence 到底有没有变便宜。但真实 application 还要问：这个 sequence 实际执行多少次？周围 instruction layout 怎么变？helper 和 map cost 是否占主导？code size 有没有破坏 cache？最终 workload 对省下来的这些 cycle 到底敏不敏感？
+
+Linux BPF 的现有基础设施其实已经体现了这种分层。BPF CI 会用 `veristat` 跑复杂 BPF program，比较 verifier behavior，并发现 verifier-performance regression。`veristat` 很适合比较 processed instruction 等 verifier statistic，但 verifier 变快或变慢，并不等价于 runtime throughput 或 p99 latency 的变化。一个 optimization 因此不应该只有一个万能分数，而是需要几个不同的 oracle。
+
+当前 [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark) 也把这个问题显式化了。现在的 corpus 包含 6 个 production eBPF application、146 个可比较的 BPF program measurement 和 42 个 microbenchmark task。它同时记录 verifier outcome、JIT code size、application lifecycle、workload correctness、raw workload metric 和 per-program kernel run counter。更重要的是，这套 framework 直接承认两个现实：static rewrite count 并不能可靠预测 speedup，而且一个 pass 可以让某些 program 更快，同时让另一些 program 退化。
+
+这就是 evidence gap 的核心。Optimization result 不是一个 scalar，而是对 program、runtime、architecture、kernel、workload 和 measurement procedure 的条件化陈述。
+
+## 现在的 evaluation 还缺什么
+
+第一个缺口是 **performance claim 的单位不清楚**。“最高加速 20%”到底是某个 instruction sequence、某个 BPF program、某个 application phase，还是 end-to-end workload？如果 claim boundary 不显式，一个完全正确的局部结果很容易被读成更大的结论。
+
+第二个缺口是 **profitability coverage**。Correctness 往往可以做成 binary：transformed program 等价或者不等价。Profitability 通常不是。一个 pass 可能让 30 个 program 变快、100 个不变、16 个变慢。一个 geomean 很容易把真正重要的问题藏起来：这 16 个 regression 是冷门 utility，还是恰好吃掉 fleet 大部分 BPF CPU time 的 hot program？
+
+第三个缺口是 **environment generalization**。eBPF 位于一条很长的 compilation pipeline 里，architecture-specific JIT、kernel version、distribution backport、helper implementation、map behavior、CPU microarchitecture 和 application loader 都会影响结果。一个 optimization 可以 semantic portable，却在另一个 JIT 或 CPU 上没有收益。9 月 6 日那篇解决的是 architecture eligibility 和 safe fallback，而不是“需要多少 performance evidence 才能说收益也 portable”。
+
+第四个缺口是 **adaptive-search bias**。普通 compiler research 已经会担心 benchmark selection；自动优化会再多一层风险。Optimizer 可以尝试很多 transformation，反复观察同一个 benchmark，最后过拟合 measurement noise、warm-cache state、某个固定 workload phase，甚至 harness 的漏洞。闭环搜索里，benchmark 本身可能被变成真正的 optimization target。
+
+第五个缺口是 **production promotion**。Paper 做完 evaluation 通常就结束了。但生产环境必须继续回答：明天到底在哪些 machine 和 program 上 enable？这个 decision 需要携带什么证据？出现什么 observation 时应该自动撤销？
+
+## 兼具学术价值和生产价值的方向
+
+### 1. 让每一个 optimization claim 都带一份 evidence envelope
+
+不要只保存一个 speedup。把结果变成结构化 artifact，把 optimization identity 和“这个收益在什么条件下测出来”绑定在一起。
+
+最小记录可以是：
+
+```text
+optimization = rotate_v3
+semantic_witness = proof-sequence-hash
+kernel = 6.x + commit
+jit = x86_64 / commit
+cpu = family-model-stepping
+program = object + program tag
+application = katran + revision
+workload = replay-manifest + digest
+baseline = exact artifact
+samples = raw run counters + workload metrics
+correctness = pass/fail + oracle identity
+performance = distribution + confidence interval
+regression_budget = <= 1% on guarded metrics
+claim_scope = {this program, this workload family, this target class}
+```
+
+和普通 benchmark metadata 最大的区别是最后一项：artifact 明确写出这份结果**允许支持什么 claim**。
+
+Microbenchmark 可以支持“这个 instruction idiom 在这个 target 上更便宜”，但不能自动推出“application 更快”。真实 application replay 可以支持更高层 claim，但也只能覆盖被 replay 到的 workload family 与 target family。
+
+Research artifact 可以是一份 schema 加 comparison engine。只有 claim scope 相容的 envelope 才能被 aggregate。Evaluation 可以拿常见的 optimization summary，观察弱 metadata 下会被接受的结论，有多少在离开隐藏 assumption 后无法 reproduce。可以把这个指标叫做 *claim escape*。
+
+如果普通 benchmark manifest 已经能完整记录所有 materially relevant condition，而且 reviewer 和 deployment system 真的会严格限制 claim scope，那么这层 artifact 就是多余的。实验应该主动尝试证明它不需要存在。
+
+### 2. 给 optimizer 准备 holdout 和 counterexample suite
+
+传统 optimization evaluation 通常问 selected program 有没有变快。Adaptive optimizer 需要更强的测试：它能不能在看得到的 search set 上优化，同时没有学会怎么 exploit 这个测试？
+
+可以把 evidence 分成至少三部分。Development set 对 optimizer 可见。Holdout set 放它没见过的 application、workload phase、kernel 或 architecture。Counterexample set 则故意包含会惩罚常见 shortcut 的 case：code-size growth 应该带来 I-cache 代价的 program、目标 sequence 实际很冷的 workload、和 training profile 相反的 branch distribution、verifier-sensitive program，以及必须通过真实 loader/lifecycle 才算成功的 application。
+
+[`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark) 的 integrity model 已经采用类似思路：把 optimizer 当成不可信组件，禁止它缩短 workload、过滤失败 program、绕过真实 loader 或伪造 result file。Research system 可以进一步把这件事量化。
+
+Primary score 不应该只剩“找到的最好 speedup”。至少要报告 acceptance coverage、worst guarded regression、holdout speedup distribution、invalid-result rate，以及 development win 中有多少能在 holdout target 上 reproduce。对于 agentic search，holdout oracle 应该一直冻结到最终 evaluation，避免搜索过程继续对它适应。
+
+Ablation 可以故意把 holdout result 泄露回 optimizer。如果 benchmark score 上升，但独立 reproduction 变差，就直接展示了我们想捕获的 overfitting。
+
+这个方向的 artifact 不是另一个 optimization pass，而是一套可以复用的 optimization benchmark methodology。生产里的对应物也很自然：canary workload 和 canary machine 就是新 optimization policy 的 holdout。
+
+### 3. 用 profitability contract 上线，而不是只有一个 global enable bit
+
+很多 optimization 不需要 everywhere profitable，只需要一个足够可靠的 applicability rule。
+
+可以从 evidence envelope 推导或学习一个小的 profitability predicate：target architecture、JIT capability、program feature、code-size delta、runtime profile stability、application/workload class。只有 predicate match 时才 enable。Runtime 再观察实际效果，一旦 guarded regression budget 被突破，就 disable 或 rollback specialization。
+
+这和 9 月 5 日讨论的 deoptimization 不一样。那篇关心 stale runtime assumption 会不会改变 program semantics；这里 semantics 一直是合法的，predicate 只控制“这个优化值不值得”。Fallback 可以因为 p99 latency 退化 3%、JIT size 超过 I-cache budget，或者 program 的 runtime share 太低，根本不值得增加复杂度而触发。
+
+Evaluation 至少比较三种 policy：全局打开、手写 target allowlist、evidence-driven promotion。跨 kernel version、x86-64 与 ARM64、多个 CPU generation、microbenchmark 和真实 application workload 测试。指标应该包括 fleet-weighted realized speedup、worst regression、eligible execution fraction、decision overhead、rollback frequency，以及 workload/kernel 变化之后 policy 需要多久才能重新收敛。
+
+如果一个简单 static allowlist 已经能达到同样的 realized benefit 和 regression bound，那么 online controller 就没有必要。这个 failure condition 很重要，不是每个 compiler pass 都值得造一个 control plane。
+
+## 一份更实用的 eBPF optimization evaluation contract
+
+把上面的想法合起来，可以得到一个比较清晰的层次。
+
+第一层先验证 **semantic admissibility**：transformation 能不能合法替换原程序。这部分属于 verifier、equivalence、trust 与 stateful operation contract。
+
+第二层测 **local mechanism gain**：用 microbenchmark 确认目标 machine-level effect 的确存在。
+
+第三层测 **program gain**：结合 kernel run counter、JIT size 和真实 BPF program 的 repeated execution，确认 surrounding bytecode 没把收益吃掉。
+
+第四层测 **application gain**：通过真实 loader 和真实 workload，看这个 BPF program 对系统到底重要不重要。
+
+第五层测 **generalization**：在 holdout kernel、architecture 和 workload phase 上测试，决定 claim 到底能覆盖多大范围。
+
+最后一层是 **promotion safety**：applicability rule 会漏过多少 regression、多快能发现、rollback 能不能恢复 baseline。
+
+不是每篇 paper 都需要在每个 experiment 上做到所有层，但 claim 应该停在它真正测到的最高层。Production rollout 更应该这样，因为最终决定收益的是 workload distribution，而不是 benchmark 里最漂亮的那个数字。
+
+## 什么证据会改变这个结论？
+
+如果 local eBPF benchmark win 已经可以非常可靠地预测 production benefit，那么上述复杂 evidence machinery 就没有必要。可以直接用一个大 corpus 检验：在多个 architecture 和 workload 上，isolated instruction/program speedup 与 application throughput、latency、BPF CPU time 的 correlation 是否强且稳定。如果答案是肯定的，evidence envelope 和 holdout gate 可能只是增加流程成本。
+
+如果现有 BPF CI 已经提供一套完整 end-to-end optimization contract，同时覆盖 verifier behavior、exact JIT output、真实 application lifecycle、workload correctness、runtime performance、architecture diversity 和 regression promotion，这个研究空间也会大幅缩小。现在这些组件已经分别存在，但通常还没有被组合成同一个 promotion evidence chain：`veristat` 很擅长 verifier evidence，application benchmark suite 提供 workload evidence，各种 optimization paper 再各自定义 performance matrix。
+
+另外，如果某个 optimization 在所有 supported target 上都拥有压倒性收益，而且几乎没有 downside，就不应该给它再造 profitability control plane。最简单的答案仍然是把 compiler 本身做好。
+
+但对于 architecture-sensitive、profile-sensitive，或者由 adaptive search 找出来的优化，“benchmark 变快了”只能算 evidence 的起点。真正足够上线的结果应该能回答四件事：**这个 claim 在哪里成立、我们主动测过哪些反例、哪些 regression 被约束住，以及现实离开 measured envelope 后，什么 observation 会撤销这个优化。**
+
+## References
+
+- Yusheng Zheng et al., [Kops: Safely Extending the eBPF Compilation Pipeline with Native Operations](https://arxiv.org/abs/2606.24213), 2026.
+- Linux BPF CI, [kernel-patches/bpf](https://github.com/kernel-patches/bpf), accessed 2026-09-11.
+- libbpf, [`veristat`](https://github.com/libbpf/veristat), accessed 2026-09-11.
+- Eunomia, [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark), accessed 2026-09-11.
+- sched_ext, [Developer Guide](https://github.com/sched-ext/scx/blob/main/DEVELOPER_GUIDE.md), accessed 2026-09-11.

--- a/docs/research/ebpf-optimization-evidence-contract.zh.md
+++ b/docs/research/ebpf-optimization-evidence-contract.zh.md
@@ -1,5 +1,6 @@
 ---
 date: 2026-09-11
+slug: ebpf-optimization-evidence-contract
 title: "一个 eBPF 优化结果，到什么程度才值得上线？"
 description: "eBPF 优化可能在单个 microbenchmark 上很快，却让真实应用退化。本文讨论 evidence envelope、holdout 测试和上线 promotion gate。"
 tags:
@@ -30,7 +31,7 @@ status: daily-report
 
 前五篇分别解决 transformation 是否等价、runtime assumption 是否还成立、当前 architecture 能不能执行、事故时到底是哪一代 specialization 在跑、以及 delegated stateful operation 是否保持同一份 semantic contract。这里把这些 gate 都假设为已经通过，只剩最后一个问题：**发现一个 speedup 以后，我们凭什么认为它不是某一次实验的偶然结果？**
 
-## 同一个优化，其实可以同时存在几种不同的“性能真相”
+## 为什么单个 benchmark 不能定义 eBPF 优化的“性能真相”
 
 Kops 是一个很好的例子，因为它同时报告了 microbenchmark 和 application 结果。EInsn 用 native machine idiom 替换 verifier-visible BPF instruction sequence。论文里 microbenchmark 最高提升 24%，production application 最高提升 12%，并且在 x86-64 与 ARM64 上做了评估。
 
@@ -87,6 +88,8 @@ Microbenchmark 可以支持“这个 instruction idiom 在这个 target 上更�
 
 Research artifact 可以是一份 schema 加 comparison engine。只有 claim scope 相容的 envelope 才能被 aggregate。Evaluation 可以拿常见的 optimization summary，观察弱 metadata 下会被接受的结论，有多少在离开隐藏 assumption 后无法 reproduce。可以把这个指标叫做 *claim escape*。
 
+学术价值在于把 systems performance claim 的适用范围变成可验证模型：哪些维度必须一致，两个结果才允许被 aggregate 或 generalize。生产上，compiler/JIT 或 fleet performance 团队可以在 benchmark-to-promotion pipeline 接入这份 envelope，让它跟着 optimized artifact 一起传递，并限制 artifact 到底能在哪些 target 上启用。
+
 如果普通 benchmark manifest 已经能完整记录所有 materially relevant condition，而且 reviewer 和 deployment system 真的会严格限制 claim scope，那么这层 artifact 就是多余的。实验应该主动尝试证明它不需要存在。
 
 ### 2. 给 optimizer 准备 holdout 和 counterexample suite
@@ -101,17 +104,23 @@ Primary score 不应该只剩“找到的最好 speedup”。至少要报告 acc
 
 Ablation 可以故意把 holdout result 泄露回 optimizer。如果 benchmark score 上升，但独立 reproduction 变差，就直接展示了我们想捕获的 overfitting。
 
-这个方向的 artifact 不是另一个 optimization pass，而是一套可以复用的 optimization benchmark methodology。生产里的对应物也很自然：canary workload 和 canary machine 就是新 optimization policy 的 holdout。
+学术上，这个方向提供的是测量 adaptive-search overfit 的 systems optimization methodology，而不是把 benchmark 当成一个被动 test set。生产上，compiler 或 performance 团队可以把 canary workload 和 canary machine 当作 sealed holdout，在扩大 optimization policy 的 fleet 覆盖前先做独立验证。
+
+如果在相近 measurement budget 下，这套机制既不能提高 development-set win 的独立复现率，也不能比 development-only benchmark 发现更多有实际影响的 regression，就应该放弃它。如果额外 holdout 成本很高，而一个固定 validation matrix 能做出同样质量的决策，也没有必要增加这层复杂度。
 
 ### 3. 用 profitability contract 上线，而不是只有一个 global enable bit
 
 很多 optimization 不需要 everywhere profitable，只需要一个足够可靠的 applicability rule。
 
-可以从 evidence envelope 推导或学习一个小的 profitability predicate：target architecture、JIT capability、program feature、code-size delta、runtime profile stability、application/workload class。只有 predicate match 时才 enable。Runtime 再观察实际效果，一旦 guarded regression budget 被突破，就 disable 或 rollback specialization。
+可以从 evidence envelope 推导或学习一个小的 profitability predicate：target architecture、JIT capability、program feature、code-size delta、runtime profile stability、application/workload class。只有 predicate match 时才 enable。Runtime 再观察实际效果。
+
+噪声较大的 metric 不应该一次越线就立即 rollback。Controller 可以先要求最小 sample 数，再要求 regression budget 在两个独立 observation window 中持续被突破，并用预先定义的 confidence rule 比较 optimized 与 baseline distribution。Correctness failure 仍然立即回滚。Performance rollback 之后进入 cooldown，在新的 evidence 扩展 envelope 或 operator 明确重新开放该 target class 之前不自动 re-enable。Evaluation 除了 detection delay，还需要报告 false rollback rate 和 enable/disable flapping。
 
 这和 9 月 5 日讨论的 deoptimization 不一样。那篇关心 stale runtime assumption 会不会改变 program semantics；这里 semantics 一直是合法的，predicate 只控制“这个优化值不值得”。Fallback 可以因为 p99 latency 退化 3%、JIT size 超过 I-cache budget，或者 program 的 runtime share 太低，根本不值得增加复杂度而触发。
 
-Evaluation 至少比较三种 policy：全局打开、手写 target allowlist、evidence-driven promotion。跨 kernel version、x86-64 与 ARM64、多个 CPU generation、microbenchmark 和真实 application workload 测试。指标应该包括 fleet-weighted realized speedup、worst regression、eligible execution fraction、decision overhead、rollback frequency，以及 workload/kernel 变化之后 policy 需要多久才能重新收敛。
+学术问题是：在 non-stationary workload 下，一个 compact applicability predicate 能不能保留大部分 optimization benefit，同时约束 regret 和 rollback error。生产使用者是负责 BPF loader、JIT policy 或 rollout service 的团队，接入点是已经通过 correctness gate 的 optimized artifact 被映射到具体 program 与 target 的那一步。
+
+Evaluation 至少比较三种 policy：全局打开、手写 target allowlist、evidence-driven promotion。跨 kernel version、x86-64 与 ARM64、多个 CPU generation、microbenchmark 和真实 application workload 测试。指标应该包括 fleet-weighted realized speedup、worst regression、eligible execution fraction、decision overhead、rollback frequency、false rollback rate、flapping，以及 workload/kernel 变化之后 policy 需要多久才能重新收敛。
 
 如果一个简单 static allowlist 已经能达到同样的 realized benefit 和 regression bound，那么 online controller 就没有必要。这个 failure condition 很重要，不是每个 compiler pass 都值得造一个 control plane。
 
@@ -149,4 +158,3 @@ Evaluation 至少比较三种 policy：全局打开、手写 target allowlist、
 - Linux BPF CI, [kernel-patches/bpf](https://github.com/kernel-patches/bpf), accessed 2026-09-11.
 - libbpf, [`veristat`](https://github.com/libbpf/veristat), accessed 2026-09-11.
 - Eunomia, [`bpf-bench`](https://github.com/eunomia-bpf/bpf-benchmark), accessed 2026-09-11.
-- sched_ext, [Developer Guide](https://github.com/sched-ext/scx/blob/main/DEVELOPER_GUIDE.md), accessed 2026-09-11.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [When Is an eBPF Optimization Result Strong Enough to Ship?](https://eunomia.dev/research/ebpf-optimization-evidence-contract/)
+
+eBPF optimizations can be semantically correct yet win only one microbenchmark, JIT, or tuned workload. This report develops scoped evidence envelopes, holdout and counterexample suites for adaptive optimizers, and profitability-aware promotion gates that bound regressions before fleet rollout.
+
 ### [Can One eBPF Operation Mean the Same Thing on CPU, NIC, and DPU?](https://eunomia.dev/research/ebpf-cross-backend-operation-semantics/)
 
 A higher-level eBPF operation can have host, native, NIC, or DPU implementations that agree on simple results but diverge under concurrency and failures. This report develops an explicit state-transition contract, executable conformance model, and mixed-backend continuity benchmark for semantic equivalence across implementations.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [一个 eBPF 优化结果，到什么程度才值得上线？](https://eunomia.dev/zh/research/ebpf-optimization-evidence-contract/)
+
+eBPF 优化即使语义完全正确，也可能只在单个 microbenchmark、JIT 或被调过的 workload 上获胜。本文提出带 claim scope 的 evidence envelope、面向自适应 optimizer 的 holdout/counterexample suite，以及在 fleet rollout 前限制 regression 的 profitability-aware promotion gate。
+
 ### [同一个 eBPF 操作放到 CPU、NIC 和 DPU 上，语义还能一致吗？](https://eunomia.dev/zh/research/ebpf-cross-backend-operation-semantics/)
 
 一个高层 eBPF 操作可以拥有 host、native、NIC 或 DPU 实现，简单结果相同却可能在并发与故障时产生不同语义。本文提出显式 state-transition contract、可执行 conformance model，以及验证跨 backend 语义连续性的 mixed-backend benchmark。


### PR DESCRIPTION
## Daily Report

Publishes the bilingual report **When Is an eBPF Optimization Result Strong Enough to Ship? / 一个 eBPF 优化结果，到什么程度才值得上线？**.

The report closes the current eBPF Optimization and Execution Specialization series with a distinct sixth boundary: correctness and semantic equivalence do not by themselves define how broadly a performance result generalizes or when it is safe to promote. It develops scoped evidence envelopes, frozen holdout/counterexample evaluation for adaptive optimizers, and profitability-aware promotion/rollback gates.

## Operating data

- Rechecked the configured Google export source; newest set remains `2026-08-31..09-06`.
- Finalized GSC `2026-08-31..09-05`: 388 clicks / 60,880 impressions / ~0.637% CTR / ~7.35 weighted position.
- Equal-duration `2026-08-24..29`: 436 / 55,594 / ~0.784% / ~10.73.
- Complete 7-day and 28-day comparisons remain unavailable because source history is not contiguous; missing dates are not zero.
- Latest fully finalized GA4 weekly organic aggregate remains `2026-08-24..30`: 1,007 sessions / ~45.88% engagement. The newer 913-session aggregate remains partial.
- Cloudflare remains disabled.

## Editorial state

The newest-ten mix moves from **6 eBPF / 0 pure Agent / 4 adjacent** to **7 / 0 / 3**, still within the configured band. This closes the optimization series at six reports and activates the next eBPF Deployment Compatibility and Lifecycle roadmap, with a note that the next run must use a non-eBPF-centered detour if another eBPF report would exceed the cap.

No unrelated technical SEO implementation change is included because current evidence does not establish a concrete defect.

Validation and production verification remain authoritative gates before merge/closeout.