### PR TITLE
Daily: separate Linux atomic writes from crash consistency

### DIFF
--- a/.github/seo-data/daily/2026-09-12.md
+++ b/.github/seo-data/daily/2026-09-12.md
@@ -18,7 +18,9 @@ Raw analytics, private source identifiers, and credentials remain outside Git. C
 
 PR `#196`, **Daily: define evidence for eBPF optimization promotion**, was already complete at the PR-head level when this run began: both required PR-head workflows were terminal-success and the final diff/review feedback had been reconciled. It was squash-merged during this run as `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`.
 
-The exact-merge `Deploy Static App` workflow started from that SHA. September 11 is not treated as fully closed until that exact deployment reaches terminal-success, the generated bilingual production artifacts and sitemap are verified, and one compact closeout comment is added to merged PR `#196`. This run preserves that acceptance boundary rather than treating merge alone as publication.
+The exact-merge `Deploy Static App` run `34703868336` completed successfully from that SHA through static verification, production build, production-URL assertions, publication to the static `new` branch, artifact upload, and GitHub Pages deployment. The resulting production export is `128c9d43241d9258d09053e1f60278aa5e21be03`, committed as `deploy static app for 5989df8f4d05370bc9cf8bfcecf2680056c3a60d`.
+
+The generated English and Chinese production pages were verified for locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` alternates, Article JSON-LD, and Daily Report navigation. The generated sitemap contains both language routes with matching alternates. Independent crawler/search discovery had not refreshed the new route at closeout, so exact-SHA Pages deployment plus generated production artifacts were used as the acceptance evidence rather than claiming a fresh crawl. Exactly one compact closeout comment was added to merged PR `#196`.
 
 ## Data window
 
@@ -90,6 +92,7 @@ The branch is scoped to one publication plus directly coupled operating-state ch
 - prepended the English and Chinese Daily Report indexes;
 - added this September 12 operating record;
 - refreshed `status.md` and `plan.md` with current source coverage, rolling mix, current branch/PR state, and the adjacent detour;
+- reconciled September 11 through exact-merge production deployment, generated bilingual/sitemap verification, and its one merged-PR closeout comment;
 - made no unrelated technical SEO implementation change;
 - kept Cloudflare unavailable and missing analytics dates explicit rather than inventing zeros;
 - kept the SEO skill submodule pinned until its consuming-contract migration is complete.
@@ -106,7 +109,7 @@ Each direction includes a concrete artifact, evaluation, academic value, product
 
 The authoritative PR checks are `Validate SEO Operations` and `Deploy Static App`. Missing, queued, skipped, cancelled, or failed checks are not success. Any validation or review issue must be fixed on this same branch and rechecked.
 
-The first `Validate SEO Operations` attempt on PR `#197` rejected this record because it used `## Run scope` instead of the schema-required `## Scope`. The record was corrected on the same branch and retains every required operating section.
+The first `Validate SEO Operations` attempt on PR `#197` rejected this record because it used `## Run scope` instead of the schema-required `## Scope`. The record was corrected on the same branch and retains every required operating section. After the prior-run production closeout was reconciled, `status.md` and this record were updated again on the same branch; only checks for the resulting final head count for merge acceptance.
 
 Before merge, the complete final PR diff, changed-file set, report metadata, English/Chinese prose, primary-source claims, internal links, classification, rolling-window arithmetic, and generated production output will be re-read. The branch must contain exactly one new report in two language files and no unrelated site change.
 
@@ -117,8 +120,8 @@ After squash merge, the exact merge commit must pass production deployment. The 
 - Branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`
 - Pull request: `#197`
 - Current changed-file set: 7 intended files
-- PR-head validation: rerun required after the corrected daily-record schema
-- PR-head static deployment check: rerun/current-head result required
+- PR-head validation: final-head result pending after prior-run reconciliation update
+- PR-head static deployment check: final-head result pending after prior-run reconciliation update
 - Squash merge: pending
 - Exact-merge production deployment: pending
 - Production bilingual verification: pending

--- a/.github/seo-data/daily/2026-09-12.md
+++ b/.github/seo-data/daily/2026-09-12.md
@@ -1,28 +1,44 @@
-# Daily SEO operation — 2026-09-12
+# SEO operations — 2026-09-12
 
-## Run scope
+## Scope
 
-- Authoritative task: `DAILY_TASK.md` from the current default branch.
-- Daily branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`.
-- Original base: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d` after the September 11 Daily Report was squash-merged.
-- Required output: mandatory data analysis, evidence-gated technical SEO, and exactly one new bilingual Daily Report.
-- Raw analytics, private source identifiers, and credentials remain outside Git.
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Baseline default-branch commit: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
+- Delivery branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`
+- Delivery PR: `#197`
+- Run type: mandatory data analysis, technical SEO/GEO audit, and exactly one new bilingual Daily Report
+- Technical SEO outcome: no separate implementation change; current evidence does not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect.
+- Mandatory publication: one new bilingual adjacent Linux/storage Daily Report on the boundary between `RWF_ATOMIC` torn-write protection and full application crash consistency.
 
-## Prior-run reconciliation
+Raw analytics, private source identifiers, and credentials remain outside Git. Cloudflare remains disabled by repository configuration. Missing coverage is unavailable, partial, stale, or absent rather than zero.
+
+### Prior-run reconciliation
 
 PR `#196`, **Daily: define evidence for eBPF optimization promotion**, was already complete at the PR-head level when this run began: both required PR-head workflows were terminal-success and the final diff/review feedback had been reconciled. It was squash-merged during this run as `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`.
 
 The exact-merge `Deploy Static App` workflow started from that SHA. September 11 is not treated as fully closed until that exact deployment reaches terminal-success, the generated bilingual production artifacts and sitemap are verified, and one compact closeout comment is added to merged PR `#196`. This run preserves that acceptance boundary rather than treating merge alone as publication.
 
-## Data coverage and freshness
+## Data window
+
+- The configured Google Drive folder was directly rechecked on `2026-09-12`. No weekly source set newer than `2026-08-31..09-06` is present.
+- Search Console source rows in that set are present for `2026-08-31..09-05`; `2026-09-06` is absent.
+- Under the configured three-day lag, all currently observed Search Console rows through `2026-09-05` are finalized.
+- A complete latest-seven-day versus preceding-seven-day Search Console comparison remains unavailable because the newest export omits `2026-09-06` and the prior export omits `2026-08-30`.
+- Older source gaps, including the recorded `2026-08-23` gap, prevent a complete 28-day versus preceding-comparable-period Search Console comparison.
+- The GA4 organic landing-page aggregate for `2026-08-24..30` remains the latest fully finalized weekly aggregate.
+- The `2026-08-31..09-06` GA4 aggregate was exported while dates inside the finalization lag were present and has no date dimension, so it remains explicitly partial.
+- Missing rows are never synthesized as zero.
+- Cloudflare remains disabled.
+
+## Evidence collected
 
 ### Google Search Console
 
-The configured Drive source was rechecked on 2026-09-12. No weekly source set newer than `2026-08-31..09-06` is present. Its date export contains rows for `2026-08-31..09-05` and no row for `2026-09-06`.
-
 The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that prior six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**.
 
-This is not a complete seven-day comparison. `2026-09-06` is absent from the newest export, `2026-08-30` is absent from the preceding export, and older history includes the recorded `2026-08-23` gap. Complete latest-seven-day and complete 28-day comparable-period analyses therefore remain unavailable. Missing rows are not interpreted as zero.
+This is not a complete seven-day comparison. Missing dates are not converted to zero.
 
 The newest weekly query aggregate continues to show a mixture of branded, eBPF, CUDA/GPU, and long-tail discovery. Examples include `xxxbpf` at 10 clicks / 53 impressions, `ebpf` at 6 / 185, `eunomia` at 3 / 582, `nvbit` at 3 / 81, `bpftime` at 2 / 37, and `cupti` at 2 / 213. These rows have no date dimension and are used for prioritization, not causal trend claims.
 
@@ -32,70 +48,88 @@ The newest weekly page aggregate continues to show broad exposure on evergreen t
 
 The latest fully finalized organic landing-page aggregate remains `2026-08-24..30`: **1,007 sessions** at about **45.88% session-weighted engagement**. The preceding finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29% engagement**.
 
-The newer frozen `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains partial because the export was generated while lagged dates were present and it contains no date dimension for safe finalized subsetting.
+The newer frozen `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains partial because the export was generated while lagged dates were present and contains no date dimension for safe finalized subsetting.
 
 ### Cloudflare
 
 Cloudflare remains disabled by repository configuration. No Cloudflare-grounded traffic, cache, bot, country, or status-code claim is made.
 
-### Public and repository technical evidence
+### Public site and repository evidence
 
-The latest public-safe data brief generated on 2026-09-12 reports:
+The latest public-safe data brief generated on `2026-09-12` reports the homepage at HTTP 200 in **220 ms**, `robots.txt` at HTTP 200, sitemap at HTTP 200 with **752 entries**, and canonical homepage `https://eunomia.dev/`. It records **99** active non-fork repositories, **9,994** stars, **1,306** forks, and **288** open issue/PR records across the observed public portfolio, plus **63** observed DEV articles, 43 reactions, and 4 comments. These counters are project context and are not blended into a synthetic SEO score.
 
-- homepage HTTP 200 in **220 ms**;
-- `robots.txt` HTTP 200;
-- sitemap HTTP 200 with **752 entries**;
-- canonical homepage `https://eunomia.dev/`;
-- **99** active non-fork repositories, **9,994** stars, **1,306** forks, and **288** open issue/PR records in the observed public portfolio;
-- **63** observed DEV articles, 43 reactions, and 4 comments;
-- no recorded collection coverage gaps for that public-safe brief.
+The current analytics and technical evidence do not establish a separate SEO defect. The shared SEO skill pointer remains unchanged because upstream movement alone does not satisfy the repository's required consuming-contract migration.
 
-These observations are context, not a blended SEO score.
+### Rolling Daily Report mix before topic selection
 
-## Technical SEO/GEO decision
+The newest ten published reports immediately before today's publication contain **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. This is the allowed eBPF maximum. The oldest report rotating out today is the adjacent `2026-08-31` GPU-utilization report, so another eBPF-centered item would produce 8 of 10 and violate the mix contract.
 
-No separate technical SEO implementation change is made today.
+The active **eBPF Deployment Compatibility and Lifecycle** series is therefore temporarily blocked by rolling-window arithmetic rather than weak research candidates. It remains the next normal eBPF roadmap and should resume when the window permits.
 
-The current evidence does not establish a crawlability, robots, sitemap, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect. Search Console aggregate CTR opportunities are not enough to attribute a defect to metadata without finalized date-by-page or date-by-query evidence. The shared SEO skill pointer also remains unchanged: upstream movement does not satisfy the repository's required consuming-contract migration.
+### Research evidence and topic selection
 
-The only site-facing change in this daily PR is the required Daily Report and its bilingual index entries.
-
-## Rolling topic mix and topic selection
-
-Before topic selection, the newest ten published Daily Reports contain **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. This is the repository's allowed eBPF maximum. The oldest report that will rotate out is the adjacent `2026-08-31` GPU-utilization report, so publishing an eBPF-centered report today would produce 8 of 10 and violate the mix rule.
-
-The active **eBPF Deployment Compatibility and Lifecycle** series is therefore temporarily blocked by arithmetic, not by lack of candidate questions. It remains active and should resume when the rolling window permits.
-
-Today's required publication is an approved adjacent Linux/storage detour:
+Selected report:
 
 - English: **Does an Atomic Linux Write Mean the Data Survives a Crash?**
 - Chinese: **Linux 原子写成功后，数据就一定能抗崩溃吗？**
 - Route: `/research/linux-atomic-write-crash-semantics/`
 - Classification: **adjacent systems — Linux/storage**
 
-After publication the rolling mix remains **7 eBPF-centered / 0 pure Agent / 3 adjacent systems** because one adjacent report enters while the oldest adjacent report rotates out. No prior report is relabeled.
+After publication the rolling mix remains **7 eBPF-centered / 0 pure Agent / 3 adjacent systems** because an adjacent report enters while the oldest adjacent report rotates out. No prior report is relabeled.
 
-## Research gate
+Fresh primary/current evidence supports a distinct storage question. Linux `RWF_ATOMIC` defines torn-write protection for one eligible Direct-I/O data range. Current Linux man-pages explicitly separate that range atomicity from synchronized-I/O guarantees such as `O_SYNC`, `O_DSYNC`, or `RWF_SYNC` when storage consistency is required. `statx(STATX_WRITE_ATOMIC)` exposes per-file atomic-unit and segment capability rather than a kernel-version Boolean. Current ext4 documentation shows that atomic writes depend on hardware support, extent layout, filesystem block/cluster configuration, and journal interaction. Ext4/JBD2 documentation separately defines metadata crash-consistency and data-journaling behavior. `blktests` provides mature block-layer testing infrastructure, but an application crash protocol still needs an oracle that distinguishes torn ranges from lost whole writes, reordering, metadata/data disagreement, and invalid recovered states.
 
-The report is based primarily on current Linux and filesystem interfaces rather than a news summary:
+The thesis is not present in the existing Daily Report archive. The August 10 stateful eBPF transactional-upgrade report and September 4 GPU checkpoint report are cited only as internal analogies for local-versus-global recovery boundaries; today's central mechanism is Linux/storage atomic I/O.
 
-- Linux `RWF_ATOMIC` defines torn-write protection for one eligible Direct-I/O data range.
-- Linux man-pages explicitly separate that range atomicity from synchronized-I/O guarantees such as `O_SYNC`, `O_DSYNC`, or `RWF_SYNC` when storage consistency is required.
-- `statx(STATX_WRITE_ATOMIC)` exposes per-file atomic-unit and segment capability rather than a kernel-version Boolean.
-- Current ext4 documentation shows that atomic writes depend on hardware support, extent layout, filesystem block/cluster configuration, and journal interaction.
-- Ext4/JBD2 documentation distinguishes metadata crash consistency and data journaling modes from an application's own transaction protocol.
-- `blktests` provides a mature block-layer test framework, but an application-level crash protocol still needs an oracle that distinguishes torn ranges from lost whole writes, reordering, metadata/data disagreement, and invalid recovery states.
+## Work performed
 
-The thesis is not present in the existing Daily Report archive. It is also distinct from the August 10 eBPF transactional-upgrade report and September 4 GPU checkpoint report: those are used only as internal examples of local-versus-global recovery boundaries, while today's mechanism is Linux/storage atomic I/O.
+The branch is scoped to one publication plus directly coupled operating-state changes:
+
+- added `docs/research/linux-atomic-write-crash-semantics.md`;
+- added `docs/research/linux-atomic-write-crash-semantics.zh.md`;
+- prepended the English and Chinese Daily Report indexes;
+- added this September 12 operating record;
+- refreshed `status.md` and `plan.md` with current source coverage, rolling mix, current branch/PR state, and the adjacent detour;
+- made no unrelated technical SEO implementation change;
+- kept Cloudflare unavailable and missing analytics dates explicit rather than inventing zeros;
+- kept the SEO skill submodule pinned until its consuming-contract migration is complete.
 
 The report develops three falsifiable directions:
 
-1. a compositional crash-semantics descriptor that binds atomic-range, synchronization, filesystem, storage-path, metadata, protocol, and fallback assumptions;
-2. an application crash-cut witness that turns ordered persistence obligations into an executable recovery oracle;
-3. a failure-class benchmark that scores torn writes, lost writes, reordering, metadata disagreement, and application-forbidden recovered states separately.
+1. a compositional crash-semantics descriptor binding atomic-range, synchronization, filesystem, storage-path, metadata, protocol, and fallback assumptions;
+2. an application crash-cut witness turning ordered persistence obligations into an executable recovery oracle;
+3. a failure-class benchmark scoring torn writes, lost writes, reordering, metadata disagreement, and application-forbidden recovered states separately.
 
 Each direction includes a concrete artifact, evaluation, academic value, production integration boundary, and a condition under which the idea should be rejected.
 
-## Delivery state
+## Validation and self-review
 
-At branch creation the bilingual report and English/Chinese Daily Report index entries were added. Required PR-head CI, complete diff/generated-output review, squash merge, exact-merge production deployment, bilingual public verification, sitemap verification, and the single merged-PR closeout comment remain acceptance gates for this run.
+The authoritative PR checks are `Validate SEO Operations` and `Deploy Static App`. Missing, queued, skipped, cancelled, or failed checks are not success. Any validation or review issue must be fixed on this same branch and rechecked.
+
+The first `Validate SEO Operations` attempt on PR `#197` rejected this record because it used `## Run scope` instead of the schema-required `## Scope`. The record was corrected on the same branch and retains every required operating section.
+
+Before merge, the complete final PR diff, changed-file set, report metadata, English/Chinese prose, primary-source claims, internal links, classification, rolling-window arithmetic, and generated production output will be re-read. The branch must contain exactly one new report in two language files and no unrelated site change.
+
+After squash merge, the exact merge commit must pass production deployment. The generated and public English/Chinese pages must be checked for Daily Report navigation, locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` hreflang, Article JSON-LD, internal continuation links, explicit gap/directions/conclusion sections, and sitemap alternates before the run is closed.
+
+## Delivery
+
+- Branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`
+- Pull request: `#197`
+- Current changed-file set: 7 intended files
+- PR-head validation: rerun required after the corrected daily-record schema
+- PR-head static deployment check: rerun/current-head result required
+- Squash merge: pending
+- Exact-merge production deployment: pending
+- Production bilingual verification: pending
+- Merged-PR closeout comment: pending
+
+The recurring operations schedule remains enabled and is not modified by repository delivery state.
+
+## Decisions and follow-ups
+
+1. Do not infer a seven-day or 28-day Search Console trend until contiguous source history exists.
+2. Do not treat the partial `2026-08-31..09-06` GA4 aggregate as a finalized week-over-week result without refreshed or date-dimensional source evidence.
+3. Do not make a title/metadata change from aggregate CTR movement alone; obtain finalized date-by-page/query evidence first.
+4. Keep **eBPF Deployment Compatibility and Lifecycle** active but temporarily paused only at the publication-selection level by the rolling topic mix; resume it when an eBPF-centered report can enter without exceeding 7 of 10.
+5. Treat `RWF_ATOMIC` as a range-level torn-write guarantee in today's report and keep persistence, ordering, filesystem metadata, and application recovery claims explicitly separate.

--- a/.github/seo-data/daily/2026-09-12.md
+++ b/.github/seo-data/daily/2026-09-12.md
@@ -1,0 +1,101 @@
+# Daily SEO operation — 2026-09-12
+
+## Run scope
+
+- Authoritative task: `DAILY_TASK.md` from the current default branch.
+- Daily branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`.
+- Original base: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d` after the September 11 Daily Report was squash-merged.
+- Required output: mandatory data analysis, evidence-gated technical SEO, and exactly one new bilingual Daily Report.
+- Raw analytics, private source identifiers, and credentials remain outside Git.
+
+## Prior-run reconciliation
+
+PR `#196`, **Daily: define evidence for eBPF optimization promotion**, was already complete at the PR-head level when this run began: both required PR-head workflows were terminal-success and the final diff/review feedback had been reconciled. It was squash-merged during this run as `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`.
+
+The exact-merge `Deploy Static App` workflow started from that SHA. September 11 is not treated as fully closed until that exact deployment reaches terminal-success, the generated bilingual production artifacts and sitemap are verified, and one compact closeout comment is added to merged PR `#196`. This run preserves that acceptance boundary rather than treating merge alone as publication.
+
+## Data coverage and freshness
+
+### Google Search Console
+
+The configured Drive source was rechecked on 2026-09-12. No weekly source set newer than `2026-08-31..09-06` is present. Its date export contains rows for `2026-08-31..09-05` and no row for `2026-09-06`.
+
+The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that prior six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**.
+
+This is not a complete seven-day comparison. `2026-09-06` is absent from the newest export, `2026-08-30` is absent from the preceding export, and older history includes the recorded `2026-08-23` gap. Complete latest-seven-day and complete 28-day comparable-period analyses therefore remain unavailable. Missing rows are not interpreted as zero.
+
+The newest weekly query aggregate continues to show a mixture of branded, eBPF, CUDA/GPU, and long-tail discovery. Examples include `xxxbpf` at 10 clicks / 53 impressions, `ebpf` at 6 / 185, `eunomia` at 3 / 582, `nvbit` at 3 / 81, `bpftime` at 2 / 37, and `cupti` at 2 / 213. These rows have no date dimension and are used for prioritization, not causal trend claims.
+
+The newest weekly page aggregate continues to show broad exposure on evergreen technical pages. For example, the WASI Component Model article has 6 clicks / 6,151 impressions and the `scx-simple` tutorial has 5 / 2,800. The export has no date dimension and does not establish that a title, description, canonical, or rendering defect caused the CTR. No metadata rewrite is justified from this aggregate alone.
+
+### Google Analytics 4
+
+The latest fully finalized organic landing-page aggregate remains `2026-08-24..30`: **1,007 sessions** at about **45.88% session-weighted engagement**. The preceding finalized `2026-08-17..23` aggregate contains **984 sessions** at about **49.29% engagement**.
+
+The newer frozen `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**. It remains partial because the export was generated while lagged dates were present and it contains no date dimension for safe finalized subsetting.
+
+### Cloudflare
+
+Cloudflare remains disabled by repository configuration. No Cloudflare-grounded traffic, cache, bot, country, or status-code claim is made.
+
+### Public and repository technical evidence
+
+The latest public-safe data brief generated on 2026-09-12 reports:
+
+- homepage HTTP 200 in **220 ms**;
+- `robots.txt` HTTP 200;
+- sitemap HTTP 200 with **752 entries**;
+- canonical homepage `https://eunomia.dev/`;
+- **99** active non-fork repositories, **9,994** stars, **1,306** forks, and **288** open issue/PR records in the observed public portfolio;
+- **63** observed DEV articles, 43 reactions, and 4 comments;
+- no recorded collection coverage gaps for that public-safe brief.
+
+These observations are context, not a blended SEO score.
+
+## Technical SEO/GEO decision
+
+No separate technical SEO implementation change is made today.
+
+The current evidence does not establish a crawlability, robots, sitemap, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect. Search Console aggregate CTR opportunities are not enough to attribute a defect to metadata without finalized date-by-page or date-by-query evidence. The shared SEO skill pointer also remains unchanged: upstream movement does not satisfy the repository's required consuming-contract migration.
+
+The only site-facing change in this daily PR is the required Daily Report and its bilingual index entries.
+
+## Rolling topic mix and topic selection
+
+Before topic selection, the newest ten published Daily Reports contain **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. This is the repository's allowed eBPF maximum. The oldest report that will rotate out is the adjacent `2026-08-31` GPU-utilization report, so publishing an eBPF-centered report today would produce 8 of 10 and violate the mix rule.
+
+The active **eBPF Deployment Compatibility and Lifecycle** series is therefore temporarily blocked by arithmetic, not by lack of candidate questions. It remains active and should resume when the rolling window permits.
+
+Today's required publication is an approved adjacent Linux/storage detour:
+
+- English: **Does an Atomic Linux Write Mean the Data Survives a Crash?**
+- Chinese: **Linux 原子写成功后，数据就一定能抗崩溃吗？**
+- Route: `/research/linux-atomic-write-crash-semantics/`
+- Classification: **adjacent systems — Linux/storage**
+
+After publication the rolling mix remains **7 eBPF-centered / 0 pure Agent / 3 adjacent systems** because one adjacent report enters while the oldest adjacent report rotates out. No prior report is relabeled.
+
+## Research gate
+
+The report is based primarily on current Linux and filesystem interfaces rather than a news summary:
+
+- Linux `RWF_ATOMIC` defines torn-write protection for one eligible Direct-I/O data range.
+- Linux man-pages explicitly separate that range atomicity from synchronized-I/O guarantees such as `O_SYNC`, `O_DSYNC`, or `RWF_SYNC` when storage consistency is required.
+- `statx(STATX_WRITE_ATOMIC)` exposes per-file atomic-unit and segment capability rather than a kernel-version Boolean.
+- Current ext4 documentation shows that atomic writes depend on hardware support, extent layout, filesystem block/cluster configuration, and journal interaction.
+- Ext4/JBD2 documentation distinguishes metadata crash consistency and data journaling modes from an application's own transaction protocol.
+- `blktests` provides a mature block-layer test framework, but an application-level crash protocol still needs an oracle that distinguishes torn ranges from lost whole writes, reordering, metadata/data disagreement, and invalid recovery states.
+
+The thesis is not present in the existing Daily Report archive. It is also distinct from the August 10 eBPF transactional-upgrade report and September 4 GPU checkpoint report: those are used only as internal examples of local-versus-global recovery boundaries, while today's mechanism is Linux/storage atomic I/O.
+
+The report develops three falsifiable directions:
+
+1. a compositional crash-semantics descriptor that binds atomic-range, synchronization, filesystem, storage-path, metadata, protocol, and fallback assumptions;
+2. an application crash-cut witness that turns ordered persistence obligations into an executable recovery oracle;
+3. a failure-class benchmark that scores torn writes, lost writes, reordering, metadata disagreement, and application-forbidden recovered states separately.
+
+Each direction includes a concrete artifact, evaluation, academic value, production integration boundary, and a condition under which the idea should be rejected.
+
+## Delivery state
+
+At branch creation the bilingual report and English/Chinese Daily Report index entries were added. Required PR-head CI, complete diff/generated-output review, squash merge, exact-merge production deployment, bilingual public verification, sitemap verification, and the single merged-PR closeout comment remain acceptance gates for this run.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -58,70 +58,60 @@ operating entrypoint; this file stores durable goals and constraints.
 
 ## Current priorities
 
-1. Preserve the rolling ten-report mix mechanically. Before the `2026-09-11`
-   publication the newest ten contain **6 eBPF-centered / 0 pure Agent / 4
-   adjacent systems**. Today's optimization-evidence report is genuinely
-   eBPF-centered because BPF verifier/JIT/application/workload evidence and BPF
-   optimization promotion are the central objects. It rotates the `2026-08-30`
-   adjacent GPU-instrumentation report out, producing **7 / 0 / 3**. Never repair
-   the ratio through relabeling or an extra report.
-2. Close **eBPF Optimization and Execution Specialization** at its normal six-
-   report boundary with the September 11 publication. The sequence now covers:
-   verifier safety versus optimizer equivalence and profile lifetime; architecture
-   eligibility and portable fallback; execution-generation provenance; native-
-   operation trust/TCB accounting; cross-backend state-transition semantics; and
-   performance-evidence scope plus production promotion.
-3. Activate **eBPF Deployment Compatibility and Lifecycle** as the next normal
-   eBPF roadmap. Candidate boundaries are real-kernel/backport feature evidence,
+1. Preserve the rolling ten-report mix mechanically. After the `2026-09-11`
+   eBPF optimization-evidence publication, the newest ten contain **7
+   eBPF-centered / 0 pure Agent / 3 adjacent systems**, which is the allowed eBPF
+   maximum. The oldest report rotating out on September 12 is the adjacent
+   `2026-08-31` GPU-utilization report, so another eBPF-centered report would
+   produce 8 of 10 and is not allowed. Never repair the ratio by relabeling.
+2. Keep **eBPF Deployment Compatibility and Lifecycle** as the active normal eBPF
+   roadmap. Candidate boundaries remain real-kernel/backport feature evidence,
    verifier behavior drift, CO-RE relocation versus semantic compatibility,
    kfunc/`struct_ops` capability negotiation, persistent-state lifecycle across
    host upgrades, and reproducible capability/artifact manifests across
-   distributions. Keep it distinct from architecture specialization,
-   transactional application upgrade, and userspace runtime contracts.
-4. The post-September-11 mix sits at the maximum **7 eBPF / 0 Agent / 3
-   adjacent**. The next run must not publish an eighth eBPF-centered item while
-   the oldest report rotating out is adjacent. If the active eBPF series is
-   temporarily blocked by the arithmetic, use a strong approved adjacent-systems
-   detour or a quality-qualified limited Agent systems report, then resume the
-   active series when the window permits.
-5. Keep **eBPF Networking and Security**, **eBPF Observability and Profiling**,
-   **eBPF Runtime, Extensibility, and Composition**, and **GPU and Heterogeneous
-   Runtime Systems** closed at their normal boundaries unless fresh evidence
-   supports a genuinely new mechanism.
-6. Recheck all verified weekly Search Console and GA4 Drive export sets every
-   run. As rechecked on `2026-09-11`, the newest source set remains
+   distributions. Resume it as soon as the rolling window permits.
+3. Use the September 12 publication as an approved adjacent Linux/storage detour:
+   `/research/linux-atomic-write-crash-semantics/`. The report separates
+   `RWF_ATOMIC` torn-write protection from persistence, ordering, filesystem
+   metadata, and application recovery. Because an adjacent report enters while an
+   adjacent report rotates out, the newest-ten mix remains **7 / 0 / 3** after
+   publication.
+4. Keep **eBPF Optimization and Execution Specialization**, **eBPF Networking and
+   Security**, **eBPF Observability and Profiling**, **eBPF Runtime,
+   Extensibility, and Composition**, and **GPU and Heterogeneous Runtime Systems**
+   closed at their normal boundaries unless fresh evidence supports a genuinely
+   new mechanism.
+5. Recheck all verified weekly Search Console and GA4 Drive export sets every run.
+   As rechecked on `2026-09-12`, the newest source set remains
    `2026-08-31..09-06`. Search Console contains rows through `2026-09-05`; under
    the configured three-day lag all observed rows are finalized, while
    `2026-09-06` is absent.
-7. Record the newest finalized Search Console `2026-08-31..09-05` slice as **388
+6. Record the newest finalized Search Console `2026-08-31..09-05` slice as **388
    clicks / 60,880 impressions / ~0.637% CTR / ~7.35 impression-weighted
    position**. The equal-duration `2026-08-24..29` slice is **436 / 55,594 /
    ~0.784% / ~10.73**. Current clicks are ~11.0% lower, impressions ~9.5% higher,
    CTR ~0.147 percentage points lower, and weighted position ~3.38 positions
    better. This is a six-day source-native comparison, not a complete seven-day
    trend.
-8. Keep complete GSC 7-day and 28-day comparisons unavailable until source
+7. Keep complete GSC 7-day and 28-day comparisons unavailable until source
    history is contiguous. The newest export omits `2026-09-06`, the preceding
    export omits `2026-08-30`, and older history includes the recorded
    `2026-08-23` gap. Missing rows are never zero.
-9. Weekly GSC page aggregates may prioritize inspection but cannot support
-   page-level causal claims without date-by-page evidence. Daily Report routes
-   show **8 clicks / 1,812 impressions** in the newest weekly page export versus
-   **6 / 1,017** previously, while the report set itself grew.
-10. Treat GA4 `2026-08-24..30` as the latest fully finalized weekly organic
-    landing-page aggregate: **1,007 sessions** at about **45.88% session-weighted
-    engagement**. The newer frozen `2026-08-31..09-06` aggregate contains **913
-    sessions** at about **47.54% engagement**, but remains partial because it was
-    exported while lagged dates were present and has no date dimension.
-11. Use finalized date-by-page or date-by-query evidence before attributing search
-    movement to one report, title, or topic family. Current aggregate evidence
-    does not justify a title/metadata rewrite.
-12. Treat exact-SHA Pages deployment and generated production artifacts as the
+8. Weekly GSC page/query aggregates may prioritize inspection but cannot support
+   causal metadata claims without date-dimensional evidence. High-impression
+   pages with low aggregate CTR are candidates for future measurement, not an
+   automatic title/description rewrite.
+9. Treat GA4 `2026-08-24..30` as the latest fully finalized weekly organic
+   landing-page aggregate: **1,007 sessions** at about **45.88% session-weighted
+   engagement**. The newer frozen `2026-08-31..09-06` aggregate contains **913
+   sessions** at about **47.54% engagement**, but remains partial because it was
+   exported while lagged dates were present and has no date dimension.
+10. Treat exact-SHA Pages deployment and generated production artifacts as the
     primary publication acceptance evidence; independent crawler/search discovery
     is supplementary and can lag immediately after deployment.
-13. Keep Cloudflare evidence unavailable until a supported read-only route is
+11. Keep Cloudflare evidence unavailable until a supported read-only route is
     enabled in repository configuration.
-14. Keep the shared SEO skill submodule pinned until its consuming contract is
+12. Keep the shared SEO skill submodule pinned until its consuming contract is
     migrated to the newer upstream layout; do not make a pointer-only update.
-15. Do not create a thin public series hub without report-level acquisition or
+13. Do not create a thin public series hub without report-level acquisition or
     navigation evidence that it would improve retrieval.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -10,17 +10,19 @@
 - Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
 - Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still partial because the frozen export was generated while lagged dates were present and has no date dimension
-- Latest completed daily record before the current run: `2026-09-11` content was squash-merged during this run; exact production closeout remains gated on its in-flight exact-merge deployment
+- Latest completed daily record before the current run: `2026-09-11`, fully closed after exact-merge production deployment and bilingual/sitemap verification
 - Last merged Daily Report pull request: `#196`
 - Last Daily Report squash commit: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
 - PR-head `Validate SEO Operations` and `Deploy Static App` for `#196`: terminal-success before merge
-- Exact-merge `Deploy Static App` for `#196`: run `34703868336`, started from the squash SHA and still in progress when this status snapshot was written
+- Exact-merge `Deploy Static App` for `#196`: run `34703868336`, terminal-success
+- Production static export for `#196`: `128c9d43241d9258d09053e1f60278aa5e21be03`, explicitly bound to the squash SHA
+- Merged-PR closeout for `#196`: exactly one compact top-level closeout comment added after verification
 - Current daily branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`
 - Current daily pull request: `#197`
 - Current branch original base: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-September 11's publication is not treated as fully closed until the exact squash-SHA production workflow is terminal-success, the generated bilingual pages and sitemap are verified, and exactly one compact closeout comment is placed on merged PR `#196`. Merge alone is not publication acceptance.
+September 11 is fully reconciled: the exact squash-SHA deployment reached terminal-success, generated English/Chinese production pages were verified for locale-correct canonical and reciprocal language alternates plus Article JSON-LD and Daily Report navigation, both sitemap routes and alternates were verified, and one compact closeout comment was added to merged PR `#196`. Independent crawler/search discovery had not refreshed the new route at closeout, so exact-SHA deployment plus generated production artifacts were used as acceptance evidence rather than a false fresh-crawl claim.
 
 ## Current Daily Report mix
 
@@ -70,12 +72,9 @@ The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c591464
 
 ## Current focus
 
-1. Finish reconciling PR `#196` through terminal exact-merge production deployment, generated bilingual/sitemap verification, and exactly one merged-PR closeout comment.
-2. Complete PR `#197` through terminal-green PR-head CI, full diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
-3. Keep today's adjacent Linux/storage detour within the mechanical **7 / 0 / 3** rolling mix and resume **eBPF Deployment Compatibility and Lifecycle** as soon as the window permits.
-4. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
-5. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
-6. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
-7. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
-
-Detailed run history belongs in `.github/seo-data/daily/` and merged daily pull requests.
+1. Complete PR `#197` through terminal-green PR-head CI, full diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
+2. Keep today's adjacent Linux/storage detour within the mechanical **7 / 0 / 3** rolling mix and resume **eBPF Deployment Compatibility and Lifecycle** as soon as the window permits.
+3. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
+4. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
+5. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
+6. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -10,46 +10,43 @@
 - Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
 - Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still partial because the frozen export was generated while lagged dates were present and has no date dimension
-- Latest completed daily record before the current run: `2026-09-10`
-- Last merged Daily Report pull request: `#195`
-- Last Daily Report squash commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
-- Exact-merge `Validate SEO Operations` run for `#195`: `34618891189`, success
-- Exact-merge `Deploy Static App` run for `#195`: `34618891146`, success
-- Static production export for `#195`: `b9bab3bfd4897272ca6264d66c450ad5236feb2a`, committed as `deploy static app for 59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
-- Current daily branch: `daily/2026-09-11-ebpf-optimization-evidence`
-- Current daily pull request: `#196`
-- Current branch original base: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
+- Latest completed daily record before the current run: `2026-09-11` content was squash-merged during this run; exact production closeout remains gated on its in-flight exact-merge deployment
+- Last merged Daily Report pull request: `#196`
+- Last Daily Report squash commit: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
+- PR-head `Validate SEO Operations` and `Deploy Static App` for `#196`: terminal-success before merge
+- Exact-merge `Deploy Static App` for `#196`: run `34703868336`, started from the squash SHA and still in progress when this status snapshot was written
+- Current daily branch: `daily/2026-09-12-linux-atomic-write-crash-semantics`
+- Current daily pull request: `#197`
+- Current branch original base: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The valid September 10 delivery is PR `#195`, **Daily: define cross-backend semantics for eBPF operations**. Its exact-merge validation and deployment are terminal-success, the generated bilingual production artifacts and sitemap were verified against the squash SHA, and the single compact merged-PR closeout comment was added. Failed duplicate PR `#194` is closed as superseded and was not merged.
+September 11's publication is not treated as fully closed until the exact squash-SHA production workflow is terminal-success, the generated bilingual pages and sitemap are verified, and exactly one compact closeout comment is placed on merged PR `#196`. Merge alone is not publication acceptance.
 
 ## Current Daily Report mix
 
 Before today's publication, the newest ten actually published reports contain:
 
-- eBPF-centered: **6 of 10**
+- eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
-- adjacent systems: **4 of 10**
+- adjacent systems: **3 of 10**
 
-Today's selected `/research/ebpf-optimization-evidence-contract/` report is **eBPF-centered**. BPF verifier/JIT/application/workload evidence and the promotion boundary for eBPF optimizations are the central technical objects.
+The current active series is **eBPF Deployment Compatibility and Lifecycle**, but the rolling eBPF count is already at the allowed maximum. The oldest report rotating out today is the adjacent `2026-08-31` GPU-utilization report, so another eBPF-centered publication would produce 8 of 10 and violate the editorial contract.
 
-The incoming report rotates the `2026-08-30` adjacent GPU-instrumentation report out. After publication the mix becomes **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**, still inside the 5–7 target band but at its upper limit. No existing classification changes.
+Today's selected `/research/linux-atomic-write-crash-semantics/` report is therefore a deliberate **adjacent systems — Linux/storage** detour. It asks how `RWF_ATOMIC` torn-write protection composes with persistence, ordering, filesystem metadata, and application recovery. The incoming adjacent report rotates an adjacent report out, so after publication the mix remains **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. No existing classification changes.
 
-**eBPF Optimization and Execution Specialization** closes with this sixth report. The six covered boundaries are semantic equivalence and profile lifetime, architecture-specific implementation/fallback, exact execution-generation provenance, native-operation trust/TCB accounting, cross-backend state-transition semantics, and performance-evidence scope/promotion.
-
-The next eBPF roadmap is **eBPF Deployment Compatibility and Lifecycle**, but the post-publication rolling mix is already at seven eBPF-centered reports. The next scheduled publication must use an adjacent or other quality-qualified non-eBPF-centered detour if another eBPF report would exceed the cap; the active compatibility series resumes when the window permits.
+The active eBPF compatibility series remains queued and resumes when the rolling window permits an eBPF-centered report.
 
 ## Current signals
 
 ### Google Search Console
 
-The configured Drive source was rechecked on `2026-09-11`; no source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
+The configured Drive source was rechecked on `2026-09-12`; no weekly source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
 
 The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**.
 
 This is not a complete seven-day trend. The newest export omits `2026-09-06`, the preceding export omits `2026-08-30`, and older history includes the recorded `2026-08-23` gap. Complete latest-seven-day and 28-day comparable-period analyses remain unavailable. Missing rows are never interpreted as zero.
 
-The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly export. The page export has no date dimension and the published report set changed, so this is prioritization evidence rather than causal evidence for a title, topic, navigation, or metadata change.
+The weekly query and page aggregates remain prioritization evidence only because they have no date dimension. Broad-exposure/low-CTR examples such as the WASI Component Model article and `scx-simple` tutorial are not enough to attribute a title or metadata defect without finalized date-by-page or date-by-query evidence.
 
 ### Google Analytics 4
 
@@ -59,7 +56,7 @@ The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.
 
 ### Public and repository technical evidence
 
-The latest public-safe data brief observed on `2026-09-11` reports the canonical homepage at HTTP 200 in 233 ms, robots at HTTP 200, sitemap at HTTP 200, and 748 sitemap entries. It records 99 active non-fork repositories, 9,987 stars, 1,305 forks, and 287 open issue/PR records across the observed public portfolio. These are context, not a blended SEO score.
+The latest public-safe data brief generated on `2026-09-12` reports the canonical homepage at HTTP 200 in **220 ms**, robots at HTTP 200, sitemap at HTTP 200, and **752** sitemap entries. It records **99** active non-fork repositories, **9,994** stars, **1,306** forks, and **288** open issue/PR records across the observed public portfolio. DEV coverage contains **63** observed articles, 43 reactions, and 4 comments. These are context, not a blended SEO score.
 
 Current analytics, repository health, deployment evidence, and public-safe evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants a separate technical SEO implementation change today.
 
@@ -73,11 +70,12 @@ The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c591464
 
 ## Current focus
 
-1. Complete today's optimization-evidence report through PR `#196`, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
-2. Close **eBPF Optimization and Execution Specialization** at six reports and preserve the next **eBPF Deployment Compatibility and Lifecycle** roadmap without exceeding the rolling 7-of-10 eBPF cap.
-3. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
-4. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
-5. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
-6. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
+1. Finish reconciling PR `#196` through terminal exact-merge production deployment, generated bilingual/sitemap verification, and exactly one merged-PR closeout comment.
+2. Complete PR `#197` through terminal-green PR-head CI, full diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
+3. Keep today's adjacent Linux/storage detour within the mechanical **7 / 0 / 3** rolling mix and resume **eBPF Deployment Compatibility and Lifecycle** as soon as the window permits.
+4. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
+5. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
+6. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.
+7. Keep the shared SEO skill pointer unchanged until the consuming-contract migration required by `plan.md` is completed.
 
 Detailed run history belongs in `.github/seo-data/daily/` and merged daily pull requests.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Does an Atomic Linux Write Mean the Data Survives a Crash?](https://eunomia.dev/research/linux-atomic-write-crash-semantics/)
+
+Linux `RWF_ATOMIC` can prevent torn writes for one supported data range without defining persistence, ordering, metadata, or multi-object recovery. This report separates those guarantees and develops crash-semantics descriptors, crash-cut witnesses, and failure-class benchmarks for atomic I/O.
+
 ### [When Is an eBPF Optimization Result Strong Enough to Ship?](https://eunomia.dev/research/ebpf-optimization-evidence-contract/)
 
 eBPF optimizations can be semantically correct yet win only one microbenchmark, JIT, or tuned workload. This report develops scoped evidence envelopes, holdout and counterexample suites for adaptive optimizers, and profitability-aware promotion gates that bound regressions before fleet rollout.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [Linux 原子写成功后，数据就一定能抗崩溃吗？](https://eunomia.dev/zh/research/linux-atomic-write-crash-semantics/)
+
+Linux `RWF_ATOMIC` 可以让一个受支持的数据范围不被 torn，却没有同时定义持久化、写入顺序、metadata 和 multi-object recovery。本文把这些 guarantee 分开，并提出 crash-semantics descriptor、crash-cut witness 和按 failure class 评测 atomic I/O 的 benchmark。
+
 ### [一个 eBPF 优化结果，到什么程度才值得上线？](https://eunomia.dev/zh/research/ebpf-optimization-evidence-contract/)
 
 eBPF 优化即使语义完全正确，也可能只在单个 microbenchmark、JIT 或被调过的 workload 上获胜。本文提出带 claim scope 的 evidence envelope、面向自适应 optimizer 的 holdout/counterexample suite，以及在 fleet rollout 前限制 regression 的 profitability-aware promotion gate。

--- a/docs/research/linux-atomic-write-crash-semantics.md
+++ b/docs/research/linux-atomic-write-crash-semantics.md
@@ -1,0 +1,158 @@
+---
+date: 2026-09-12
+slug: linux-atomic-write-crash-semantics
+title: "Does an Atomic Linux Write Mean the Data Survives a Crash?"
+description: "Linux atomic writes prevent torn data ranges, but crash-safe applications also need persistence, ordering, metadata, and recovery guarantees."
+tags:
+  - Daily Report
+  - Linux
+  - Storage
+  - Atomic I/O
+  - Crash Consistency
+research_question: "How should Linux applications compose atomic-write, persistence, ordering, filesystem-metadata, and recovery guarantees so that RWF_ATOMIC is not mistaken for a complete crash-consistency contract?"
+source_cutoff: 2026-09-12
+status: daily-report
+---
+
+# Does an Atomic Linux Write Mean the Data Survives a Crash?
+
+Linux now has a real atomic-write interface for regular files. With `pwritev2(..., RWF_ATOMIC)`, a supported block filesystem can ask the storage stack for torn-write protection: after a power failure or hardware failure, the target range must contain either the old data or the new data, not a mixture of both.
+
+That sounds close to the property a database wants from a page update. It is also easy to over-read it.
+
+An untorn write answers one narrow question: **can one eligible data range be observed half old and half new after failure?** It does not, by itself, answer whether the new data was durable when the syscall returned, whether two atomic writes reached stable storage in the intended order, whether a directory entry or file-size update is consistent with the data, or whether several files form one recoverable application transaction.
+
+The distinction matters because Linux exposes these properties through different mechanisms. `RWF_ATOMIC` controls torn-write protection. `O_SYNC`, `O_DSYNC`, `RWF_SYNC`, `fsync()`, and filesystem journaling address different persistence and metadata boundaries. An application that compresses all of these into one Boolean called `atomic_write_supported` can still recover into a state that no application-level transaction ever intended.
+
+<!-- more -->
+
+This report is an adjacent Linux/storage detour from the active eBPF deployment-compatibility roadmap. The current rolling Daily Report window is already at the normal seven-of-ten eBPF ceiling, so another eBPF-centered report would violate the repository's topic-mix contract. The storage question is nevertheless directly relevant to systems software: it asks how a new kernel capability should be exposed without letting a narrow lower-layer guarantee silently expand into a broader application guarantee.
+
+## Linux atomic writes solve torn writes, not every crash-consistency problem
+
+The current Linux manual page defines `RWF_ATOMIC` as torn-write protection for regular files in block-based filesystems. If the storage path supports the operation, a hardware failure must leave all or none of the written data, never a mixture of old and new bytes. The same manual page also says the write must use `O_DIRECT`, obey the atomic-unit and alignment limits reported through `statx()`, and use synchronized I/O such as `O_SYNC`, `O_DSYNC`, or `RWF_SYNC` when the application needs consistency between in-core state and the storage device.
+
+That last sentence is the important one. Atomicity and synchronization are separate dimensions in the API.
+
+The `statx()` interface exposes `stx_atomic_write_unit_min`, `stx_atomic_write_unit_max`, `stx_atomic_write_segments_max`, and `stx_atomic_write_unit_max_opt`. Those fields tell a program what range shapes the current file and filesystem can submit atomically. They do not describe an application transaction, nor do they say that two separately submitted writes form one atomic unit.
+
+Ext4 makes the lower-layer dependencies visible. Its current atomic-write documentation requires Direct I/O on regular extent-based files and hardware atomic-write support from the underlying block device. Single-filesystem-block atomic writes have been supported since Linux 6.13; multi-block atomic writes use bigalloc and are bounded by filesystem and device atomic-write units. For a mixed mapped/unwritten region, ext4 first normalizes the target into a single contiguous extent and can force the current journal transaction to commit before issuing the data I/O. That work exists precisely because an apparently simple range guarantee crosses allocation metadata, unwritten-extent conversion, the journal, iomap, and the device.
+
+Ext4 journaling is another different contract. JBD2 primarily protects filesystem metadata from ending up halfway through a metadata transaction. In the default `data=ordered` mode, file data is not generally journaled even though related data is ordered before metadata commit. `data=journal` is stronger and more expensive. Therefore "the filesystem has a journal" is no more equivalent to "my application transaction is durable" than `RWF_ATOMIC` is.
+
+A useful way to reason about crash behavior is to separate at least five properties:
+
+| Property | Example mechanism | Question it answers |
+| --- | --- | --- |
+| Range atomicity | `RWF_ATOMIC` + supported storage | Can this one write tear? |
+| Completion/persistence | `O_SYNC`, `O_DSYNC`, `RWF_SYNC`, `fsync()` | What must be stable before completion is reported? |
+| Ordering | flush/barrier and application protocol | If A must precede B, can recovery observe B without A? |
+| Filesystem metadata consistency | ext4/JBD2 modes and metadata rules | Are allocation, size, rename, and directory state recoverable? |
+| Application transaction consistency | WAL, commit record, copy-on-write, recovery logic | Which combinations of several objects are legal after a crash? |
+
+A system can satisfy the first property and fail the fifth. For example, imagine a database that atomically overwrites data page P and then atomically overwrites commit record C, but does not establish the intended persistence order. Neither write can tear, yet a crash may still leave an application-invalid combination if C is durable while P is not. Conversely, a WAL protocol may deliberately tolerate a missing data-page write because recovery knows how to replay it. The application's legal crash states come from the protocol, not from the word "atomic" on one syscall.
+
+This is similar to the distinction in the earlier [GPU checkpoint recovery report](https://eunomia.dev/research/gpu-checkpoint-recovery-consistency/): making one component restorable does not prove the whole application resumes from one legal cut. The storage problem is different in mechanism, but the systems lesson is the same: a local guarantee must not be silently promoted into a global recovery guarantee.
+
+## Where current work is still weak
+
+The first gap is **capability description**. Linux gives applications strong per-file facts through `statx()`, and filesystems document their requirements, but the application usually has to reconstruct a larger crash contract from open flags, mount/filesystem behavior, device properties, and its own recovery protocol. "Atomic write available" is too small a summary for a storage engine choosing a safe layout.
+
+The second gap is **composition**. There is no general object that says, for one application commit, "these two atomic data ranges, this metadata update, this directory operation, and this commit record must produce only these post-crash states." Filesystem journals and database WALs each implement composition internally, but the boundary between them is still mostly encoded in bespoke code and assumptions.
+
+The third gap is **failure taxonomy in evaluation**. A test that detects torn sectors can validate an atomic-write mechanism while missing lost whole writes, reordering, metadata/data disagreement, or a recovery protocol that accepts an impossible generation. Linux has mature filesystem and block-layer test frameworks, including blktests, but an application-level atomic-I/O evaluation needs an oracle above "the device did not tear this range."
+
+The fourth gap is **portable deployment evidence**. Atomic-write support is intentionally capability-based rather than a simple kernel-version check. The same application binary can encounter different `statx()` limits, filesystem configurations, and storage hardware. A storage engine needs to explain why it selected an atomic fast path on one host and a WAL/fsync fallback on another, and it should be able to reproduce that decision after an incident.
+
+## Promising directions with academic and production value
+
+### 1. Build a compositional crash-semantics descriptor
+
+Instead of exposing atomic-write support to the application as a Boolean, generate a machine-readable descriptor for the actual storage path. It could bind together:
+
+```text
+file = inode/mount identity
+atomic_range = statx min/max/segments/alignment
+io_mode = O_DIRECT + sync semantics
+filesystem = ext4 + relevant feature/mount mode
+metadata_scope = what rename/size/allocation updates require
+storage_path = device/controller capability identity
+application_protocol = expected recovery contract version
+fallback = WAL/fsync or copy-on-write path
+```
+
+The descriptor would not claim to replace filesystem or device specifications. Its job is to make the application's *assumed* crash semantics explicit and versioned at the integration point where an I/O engine chooses a protocol.
+
+A research prototype could compare descriptor predictions with observed outcomes under controlled crash injection across several kernels, ext4 configurations, and device capability profiles. The primary metric should be **false confidence**: cases where the descriptor says a protocol is safe but fault injection reaches a forbidden state. Secondary metrics include false rejection, descriptor-generation cost, and how often the selected fast path differs from a conservative baseline.
+
+The academic contribution is a compositional model for crash guarantees that normally live in separate API and filesystem documents. The production user is a database, object store, or storage runtime; the integration boundary is its I/O-backend initialization and protocol-selection path.
+
+This direction should be rejected if existing `statx()` fields, open flags, ordinary filesystem discovery, and current storage-engine configuration already determine every relevant recovery state without ambiguity. If the descriptor never changes a safe/unsafe decision or catches an invalid assumption, it is only another manifest.
+
+### 2. Turn each application commit into a crash-cut witness
+
+A second direction is to describe an application commit as a small ordered graph of persistence obligations rather than as a sequence of syscalls whose intended semantics exist only in code comments.
+
+For a page-oriented database, a witness could say:
+
+```text
+WAL record W must be durable before page P may become authoritative
+P may use one RWF_ATOMIC write if its range is eligible
+commit marker C may become durable only after W's persistence edge
+metadata operation M is required only when allocation/layout changes
+recovery may accept cuts {old, W-only, W+P, W+P+C}
+recovery must reject every other visible combination
+```
+
+The runtime could emit this witness in debug/test builds and a checker could enumerate crash cuts at each persistence edge. The point is not to put a transaction manager into the kernel. It is to give application-level tests a precise oracle for what lower-level guarantees are supposed to compose into.
+
+Evaluation should compare an atomic-write-aware protocol against a conventional WAL plus `fsync()` baseline. Inject failures before submission, after device completion, around synchronization operations, and around metadata changes. Measure forbidden recovered states first, then barrier count, write amplification, commit latency, and recovery work. The strongest result would show that atomic writes safely remove some logging or copy cost without widening the legal recovery-state set.
+
+The academic contribution is a concrete semantics for composing untorn ranges with persistence ordering and application recovery. The production integration point is the commit path of a database or storage engine, with the witness primarily used in CI, qualification, and incident reproduction rather than on every production I/O.
+
+The idea loses if a fixed WAL/`fsync()` protocol remains simpler while matching or beating the witness-guided design in latency and write amplification with zero forbidden recovery states. Atomic I/O is not automatically worth extra protocol machinery.
+
+### 3. Benchmark crash guarantees by failure class, not one pass/fail bit
+
+A useful benchmark should deliberately distinguish at least these failures:
+
+- torn data inside one requested range;
+- an entire completed-but-unsynchronized write being absent after power loss;
+- two individually valid writes becoming persistent in an application-invalid order;
+- data and filesystem metadata describing different generations;
+- namespace operations such as create/rename reaching a different cut from file data;
+- process crash, kernel crash, controller reset, and full power-loss models.
+
+The benchmark can reuse existing kernel infrastructure where it fits. `blktests` already provides a framework for Linux block-layer and storage-stack testing, and filesystem test tooling can exercise atomic-write paths. The missing piece is an application-level oracle that labels each observed recovered state as allowed or forbidden under a declared protocol.
+
+Run the same protocol across multiple atomic-unit sizes, extent layouts, sync modes, filesystem modes, and emulated or physical failure models. Report torn-write escapes, forbidden recovered states, false accepts/rejects by the capability selector, recovery time, and performance overhead separately. A single "crash test passed" number hides exactly the distinctions this report is trying to preserve.
+
+The academic value is a measurement methodology for separating atomicity, durability, ordering, metadata consistency, and transaction recovery. The production user is a storage-engine or platform qualification team; the integration boundary is the kernel/filesystem/device matrix used before enabling a fast path in a fleet.
+
+This benchmark is unnecessary if an existing block/filesystem test suite already predicts application recovery across the same failure classes and target matrix at comparable cost. The experiment should explicitly try to demonstrate that the application-level oracle finds no additional failures.
+
+## A practical deployment rule
+
+For now, an application should treat `RWF_ATOMIC` as a capability to simplify one part of a crash protocol, not as permission to delete the protocol.
+
+First query the actual file capability with `statx()` rather than infer it from the kernel version. Respect Direct I/O, alignment, range, and segment constraints. Decide separately whether completion needs synchronized I/O. Keep ordering requirements explicit between writes. Treat filesystem metadata and namespace operations according to the filesystem's own persistence rules. Finally, validate the application's recovery state machine with crash injection before replacing a WAL, copy-on-write step, or barrier.
+
+The earlier [stateful eBPF transactional-upgrade report](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/) used generation-gated commit and recovery to avoid interpreting a partially applied multi-object update as a valid new generation. Storage software faces the same class of composition mistake even though the primitives are different: one locally atomic operation does not make a multi-object transition atomic.
+
+## What would change this conclusion?
+
+The argument would weaken if Linux grew one end-to-end interface that explicitly combined untorn writes, persistence completion, cross-write ordering, relevant filesystem metadata, and a multi-object transaction boundary with documented recovery semantics. In that world, the application would not need to compose as many independently scoped guarantees.
+
+It would also weaken if real storage engines using `RWF_ATOMIC` showed that a much smaller contract is sufficient in practice: for example, if their application state truly fits inside one eligible atomic range and no other metadata or object participates in the commit. Then a single atomic-and-synchronized write can be the transaction boundary, and additional composition machinery is unnecessary.
+
+Finally, fault-injection evidence could falsify the proposed research directions. If current capability discovery plus conventional WAL/fsync practice already predicts every observed post-crash state across diverse kernels, filesystems, and devices, a new descriptor or witness language would add process rather than safety.
+
+The useful mental model is therefore narrow: **Linux atomic writes can eliminate torn writes for a supported range. Crash consistency remains a protocol property whose persistence, ordering, metadata, and recovery boundaries must be stated separately.**
+
+## References
+
+- Linux kernel documentation, [Atomic Block Writes](https://www.kernel.org/doc/html/latest/filesystems/ext4/atomic_writes.html), accessed 2026-09-12.
+- Linux man-pages, [`pwritev2(2)` / `RWF_ATOMIC`](https://man7.org/linux/man-pages/man2/pwritev2.2.html), man-pages 6.19, accessed 2026-09-12.
+- Linux man-pages, [`statx(2)` / `STATX_WRITE_ATOMIC`](https://man7.org/linux/man-pages/man2/statx.2.html), accessed 2026-09-12.
+- Linux kernel documentation, [ext4 Journal (jbd2)](https://www.kernel.org/doc/html/latest/filesystems/ext4/journal.html), accessed 2026-09-12.
+- linux-blktests, [blktests](https://github.com/linux-blktests/blktests), accessed 2026-09-12.

--- a/docs/research/linux-atomic-write-crash-semantics.md
+++ b/docs/research/linux-atomic-write-crash-semantics.md
@@ -2,7 +2,7 @@
 date: 2026-09-12
 slug: linux-atomic-write-crash-semantics
 title: "Does an Atomic Linux Write Mean the Data Survives a Crash?"
-description: "Linux atomic writes prevent torn data ranges, but crash-safe applications also need persistence, ordering, metadata, and recovery guarantees."
+description: "Linux atomic writes prevent torn ranges, but crash-safe applications still need durability, ordering, metadata, and recovery guarantees before removing a WAL."
 tags:
   - Daily Report
   - Linux
@@ -16,7 +16,7 @@ status: daily-report
 
 # Does an Atomic Linux Write Mean the Data Survives a Crash?
 
-Linux now has a real atomic-write interface for regular files. With `pwritev2(..., RWF_ATOMIC)`, a supported block filesystem can ask the storage stack for torn-write protection: after a power failure or hardware failure, the target range must contain either the old data or the new data, not a mixture of both.
+Linux now has a real atomic-write interface for regular files. With `pwritev2(..., RWF_ATOMIC)`, an application can ask a supported block filesystem and storage path for torn-write protection: after a power failure or hardware failure, the target range must contain either the old data or the new data, not a mixture of both.
 
 That sounds close to the property a database wants from a page update. It is also easy to over-read it.
 
@@ -25,8 +25,6 @@ An untorn write answers one narrow question: **can one eligible data range be ob
 The distinction matters because Linux exposes these properties through different mechanisms. `RWF_ATOMIC` controls torn-write protection. `O_SYNC`, `O_DSYNC`, `RWF_SYNC`, `fsync()`, and filesystem journaling address different persistence and metadata boundaries. An application that compresses all of these into one Boolean called `atomic_write_supported` can still recover into a state that no application-level transaction ever intended.
 
 <!-- more -->
-
-This report is an adjacent Linux/storage detour from the active eBPF deployment-compatibility roadmap. The current rolling Daily Report window is already at the normal seven-of-ten eBPF ceiling, so another eBPF-centered report would violate the repository's topic-mix contract. The storage question is nevertheless directly relevant to systems software: it asks how a new kernel capability should be exposed without letting a narrow lower-layer guarantee silently expand into a broader application guarantee.
 
 ## Linux atomic writes solve torn writes, not every crash-consistency problem
 
@@ -98,7 +96,7 @@ For a page-oriented database, a witness could say:
 ```text
 WAL record W must be durable before page P may become authoritative
 P may use one RWF_ATOMIC write if its range is eligible
-commit marker C may become durable only after W's persistence edge
+commit marker C may become durable only after both W and P are durable
 metadata operation M is required only when allocation/layout changes
 recovery may accept cuts {old, W-only, W+P, W+P+C}
 recovery must reject every other visible combination
@@ -135,7 +133,7 @@ This benchmark is unnecessary if an existing block/filesystem test suite already
 
 For now, an application should treat `RWF_ATOMIC` as a capability to simplify one part of a crash protocol, not as permission to delete the protocol.
 
-First query the actual file capability with `statx()` rather than infer it from the kernel version. Respect Direct I/O, alignment, range, and segment constraints. Decide separately whether completion needs synchronized I/O. Keep ordering requirements explicit between writes. Treat filesystem metadata and namespace operations according to the filesystem's own persistence rules. Finally, validate the application's recovery state machine with crash injection before replacing a WAL, copy-on-write step, or barrier.
+First request `STATX_WRITE_ATOMIC` with `statx()` for the actual file rather than infer support from the kernel version. Verify that the returned `stx_mask` contains `STATX_WRITE_ATOMIC` before reading the atomic-write fields, then respect their Direct I/O, alignment, range, and segment constraints. Decide separately whether completion needs synchronized I/O. Keep ordering requirements explicit between writes. Treat filesystem metadata and namespace operations according to the filesystem's own persistence rules. Finally, validate the application's recovery state machine with crash injection before replacing a WAL, copy-on-write step, or barrier.
 
 The earlier [stateful eBPF transactional-upgrade report](https://eunomia.dev/research/stateful-ebpf-transactional-upgrade/) used generation-gated commit and recovery to avoid interpreting a partially applied multi-object update as a valid new generation. Storage software faces the same class of composition mistake even though the primitives are different: one locally atomic operation does not make a multi-object transition atomic.
 

--- a/docs/research/linux-atomic-write-crash-semantics.zh.md
+++ b/docs/research/linux-atomic-write-crash-semantics.zh.md
@@ -2,7 +2,7 @@
 date: 2026-09-12
 slug: linux-atomic-write-crash-semantics
 title: "Linux 原子写成功后，数据就一定能抗崩溃吗？"
-description: "Linux 原子写可以防止单个数据范围被撕裂，但真正的 crash consistency 还要分别处理持久化、顺序、文件系统元数据和应用恢复。"
+description: "Linux 原子写可以防止单个数据范围被撕裂，但崩溃一致性仍需组合持久化、写入顺序、文件系统元数据与应用恢复，应用只有验证这些边界后才能安全简化 WAL 或同步屏障。"
 tags:
   - Daily Report
   - Linux
@@ -27,8 +27,6 @@ Untorn write 只回答一个很窄的问题：**一个满足条件的数据范�
 Linux 也正是把这些性质拆成不同机制暴露出来的。`RWF_ATOMIC` 负责 torn-write protection；`O_SYNC`、`O_DSYNC`、`RWF_SYNC`、`fsync()` 以及文件系统 journal 分别处理不同层次的持久化和元数据问题。如果应用最后只留下一个 `atomic_write_supported=true`，就很可能把一条窄的底层 guarantee 放大成并不存在的应用级 guarantee。
 
 <!-- more -->
-
-本文是当前 eBPF deployment-compatibility roadmap 中的一次 adjacent Linux/storage detour。最新十篇 Daily Report 已经达到正常规则允许的 **7 篇 eBPF-centered** 上限，如果今天继续发布 eBPF-centered 报告就会超过比例约束。这个存储问题仍然符合系统方向：它讨论的是一个新 kernel capability 应该怎样被上层安全消费，而不是怎样把局部机制的名字直接当成全局语义。
 
 ## Linux 原子写解决的是 torn write，不是全部 crash consistency
 
@@ -106,7 +104,7 @@ fallback = WAL/fsync 或 copy-on-write path
 ```text
 WAL record W 必须 durable 后，page P 才能成为 authoritative
 P 满足 range constraint 时可以使用一次 RWF_ATOMIC
-commit marker C 只能在 W 的 persistence edge 之后 durable
+commit marker C 只能在 W 和 P 都持久化之后 durable
 只有 allocation/layout 改变时才需要 metadata operation M
 recovery 可以接受 {old, W-only, W+P, W+P+C}
 其他所有 visible combination 都必须拒绝
@@ -143,7 +141,7 @@ Evaluation 至少拿 atomic-write-aware protocol 和传统 WAL + `fsync()` basel
 
 现在更合理的做法，是把 `RWF_ATOMIC` 当作简化 crash protocol 某一个局部步骤的 capability，而不是删除 crash protocol 的许可证。
 
-先用 `statx()` 查询这个具体文件的能力，不要根据 kernel version 猜。严格满足 Direct I/O、alignment、range 和 segment constraint。然后单独决定 completion 是否需要 synchronized I/O。多次 write 之间的 ordering 要继续显式表达。Filesystem metadata 和 namespace operation 按 filesystem 自己的 persistence rule 处理。最后在真的删除 WAL、COW step 或 barrier 之前，用 crash injection 验证 application recovery state machine。
+先对这个具体文件调用 `statx()` 并请求 `STATX_WRITE_ATOMIC`，不要根据 kernel version 猜。读取 atomic-write 字段前，必须确认返回的 `stx_mask` 包含 `STATX_WRITE_ATOMIC`，随后严格满足 Direct I/O、alignment、range 和 segment constraint。然后单独决定 completion 是否需要 synchronized I/O。多次 write 之间的 ordering 要继续显式表达。Filesystem metadata 和 namespace operation 按 filesystem 自己的 persistence rule 处理。最后在真的删除 WAL、COW step 或 barrier 之前，用 crash injection 验证 application recovery state machine。
 
 此前的 [有状态 eBPF 原子升级报告](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/) 用 generation-gated commit 和 recovery 避免把 multi-object update 的中间状态误认成新 generation。Storage software 虽然使用完全不同的 primitive，但会犯同一类 composition mistake：**一个 locally atomic operation 并不会自动让 multi-object transition 也 atomic。**
 

--- a/docs/research/linux-atomic-write-crash-semantics.zh.md
+++ b/docs/research/linux-atomic-write-crash-semantics.zh.md
@@ -1,0 +1,166 @@
+---
+date: 2026-09-12
+slug: linux-atomic-write-crash-semantics
+title: "Linux 原子写成功后，数据就一定能抗崩溃吗？"
+description: "Linux 原子写可以防止单个数据范围被撕裂，但真正的 crash consistency 还要分别处理持久化、顺序、文件系统元数据和应用恢复。"
+tags:
+  - Daily Report
+  - Linux
+  - Storage
+  - Atomic I/O
+  - Crash Consistency
+research_question: "Linux 应用应该怎样组合 atomic write、持久化、写入顺序、文件系统元数据和 recovery guarantee，避免把 RWF_ATOMIC 误解成完整的 crash-consistency contract？"
+source_cutoff: 2026-09-12
+status: daily-report
+---
+
+# Linux 原子写成功后，数据就一定能抗崩溃吗？
+
+Linux 现在已经有了真正面向普通文件的 atomic write 接口。应用可以通过 `pwritev2(..., RWF_ATOMIC)` 请求 torn-write protection：只要文件系统和底层存储支持，在掉电或硬件故障后，这一段数据必须全部保持旧值，或者全部变成新值，不能一半新、一半旧。
+
+听起来，这已经很像数据库更新一个 page 时想要的性质了。但这里很容易多走一步，把“这一段不会被撕裂”理解成“这次事务已经安全落盘”。
+
+其实两者差得很远。
+
+Untorn write 只回答一个很窄的问题：**一个满足条件的数据范围，在故障后会不会出现新旧字节混在一起？** 它本身并没有回答 syscall 返回时新数据是否已经持久化、两个 atomic write 是否按应用需要的顺序进入稳定存储、目录项或文件长度是否和数据属于同一代，也没有保证跨多个文件和对象的更新构成一个可恢复的应用事务。
+
+Linux 也正是把这些性质拆成不同机制暴露出来的。`RWF_ATOMIC` 负责 torn-write protection；`O_SYNC`、`O_DSYNC`、`RWF_SYNC`、`fsync()` 以及文件系统 journal 分别处理不同层次的持久化和元数据问题。如果应用最后只留下一个 `atomic_write_supported=true`，就很可能把一条窄的底层 guarantee 放大成并不存在的应用级 guarantee。
+
+<!-- more -->
+
+本文是当前 eBPF deployment-compatibility roadmap 中的一次 adjacent Linux/storage detour。最新十篇 Daily Report 已经达到正常规则允许的 **7 篇 eBPF-centered** 上限，如果今天继续发布 eBPF-centered 报告就会超过比例约束。这个存储问题仍然符合系统方向：它讨论的是一个新 kernel capability 应该怎样被上层安全消费，而不是怎样把局部机制的名字直接当成全局语义。
+
+## Linux 原子写解决的是 torn write，不是全部 crash consistency
+
+当前 Linux manual 对 `RWF_ATOMIC` 的定义非常明确：在 block-based filesystem 的普通文件上请求 torn-write protection。存储路径支持时，即使发生掉电或其他 hardware failure，也应该是整个 write 全部生效或者全部不生效，而不能同时看到 old/new data。
+
+同一份 manual 紧接着又规定了几个重要条件：它只支持 `O_DIRECT`，write size 和 offset 必须满足 `statx()` 返回的 atomic unit 与 alignment 约束；如果应用还需要保证文件的 in-core state 和 storage device 之间一致，就要另外使用 `O_SYNC`、`O_DSYNC`、`RWF_SYNC` 等 synchronized I/O 语义。
+
+这句话实际上已经把最容易混淆的两件事拆开了：**atomicity 和 synchronization 不是同一个维度。**
+
+`statx()` 会暴露 `stx_atomic_write_unit_min`、`stx_atomic_write_unit_max`、`stx_atomic_write_segments_max` 和 `stx_atomic_write_unit_max_opt`。它们告诉应用，当前这个文件在当前 filesystem/storage path 上，什么形状的数据范围可以做 atomic write。它们并没有定义应用事务，更不会把两次独立提交的 atomic write 自动合并成一个 atomic unit。
+
+Ext4 的实现更能说明为什么这个边界不能省略。最新文档要求 atomic write 使用 Direct I/O、regular extent file，并依赖底层 block device 的硬件 atomic write。Linux 6.13 开始支持 single-fsblock atomic write；multi-fsblock 则依赖 bigalloc，而且最大/最小 atomic unit 同时受 filesystem 和 device 限制。如果目标范围同时包含 mapped 和 unwritten extent，ext4 还要先把它整理成一个连续 extent，并可能在真正 data I/O 前强制提交当前 journal transaction。否则 crash 后可能同时出现已经更新的 mapped 区和还没有完成 extent conversion 的区域，直接破坏原子性。
+
+也就是说，一个看起来只是“这次 write 不要撕裂”的接口，实际上已经横跨 allocation metadata、unwritten extent conversion、journal、iomap 和 storage device。
+
+Ext4 journal 又是另一层 guarantee。JBD2 的核心目标是避免 filesystem metadata 在 crash 后停在一个半完成的 metadata transaction 里。默认 `data=ordered` 并不会把普通 file data 全部写进 journal；`data=journal` 更强，但代价也更高。所以“文件系统有 journal”同样不能直接推出“我的应用事务已经 durable”。
+
+更实用的思考方式，是把 crash behavior 至少拆成下面五个性质：
+
+| 性质 | 典型机制 | 它真正回答的问题 |
+| --- | --- | --- |
+| Range atomicity | `RWF_ATOMIC` + supported storage | 这一段 write 会不会 torn？ |
+| Completion / persistence | `O_SYNC`、`O_DSYNC`、`RWF_SYNC`、`fsync()` | syscall/同步点完成时，哪些数据必须已经稳定？ |
+| Ordering | flush/barrier + application protocol | A 必须先于 B 时，recovery 会不会看到 B 却看不到 A？ |
+| Filesystem metadata consistency | ext4/JBD2 mode 与 metadata rule | allocation、size、rename、directory state 能否恢复到合法 filesystem 状态？ |
+| Application transaction consistency | WAL、commit record、COW、recovery logic | 多个对象组合后，哪些 post-crash state 才是合法事务状态？ |
+
+第一项完全成立，第五项仍然可能失败。
+
+比如数据库先 atomic overwrite 数据页 P，再 atomic overwrite commit record C，但没有建立需要的 persistence ordering。两次 write 都永远不会 torn，并不代表 crash 后不会出现 C 已经 durable、P 却没有 durable 的组合。反过来，一个 WAL protocol 可能完全允许数据页还没写下去，因为 recovery 会从 log 重放。**应用允许哪些 crash cut，是由 recovery protocol 定义的，不是由某一个 syscall 里出现了 `ATOMIC` 这个名字定义的。**
+
+这和此前的 [GPU checkpoint recovery 报告](https://eunomia.dev/zh/research/gpu-checkpoint-recovery-consistency/) 有一个相似的系统边界：某一个 component 可以恢复，并不等于整个应用已经回到一个合法 global cut。这里的底层机制完全不同，但局部 guarantee 不能自动放大成全局 guarantee 这一点是一样的。
+
+## 现有工作还缺什么
+
+第一个缺口是 **capability description 不够完整**。Linux 已经能通过 `statx()` 给出很有用的 per-file atomic-write 参数，filesystem 也会记录自己的 requirement。但 storage engine 真正决定 protocol 时，仍然要把 open flags、filesystem mode、device capability、metadata operation 和自己的 recovery assumption 拼起来。“支持 atomic write”这个 Boolean 太小了。
+
+第二个缺口是 **composition**。现在没有一个通用 artifact 能表达：一次 application commit 包含这两段 atomic data write、一个 metadata update、一次 rename 和一个 commit record，故障后只允许出现哪些组合。Filesystem journal 和 database WAL 各自在自己的边界里做了 composition，但跨两层的 contract 很大程度上还是藏在 bespoke implementation 和经验里。
+
+第三个缺口是 **evaluation 对 failure class 的区分不够**。能检测 torn sector 的测试可以很好地验证 atomic-write mechanism，却可能完全看不到 whole write 丢失、write reordering、metadata/data generation 不一致，或者 recovery 接受了一个本来不可能存在的 transaction state。Linux 已经有成熟的 filesystem/block test framework，包括 blktests，但 application-level atomic I/O 仍需要一个高于“这次 range 没 torn”的 oracle。
+
+第四个缺口是 **deployment evidence 的可移植性**。Atomic write 本来就应该按 capability 检测，而不是按 kernel version 猜。同一个 application binary 放到不同 host 上，可能面对不同的 `statx()` limit、filesystem 配置和 storage hardware。Storage engine 不但要选择 fast path，还应该能在事故后解释：为什么这台机器走 atomic path，那台机器走 WAL/fsync fallback。
+
+## 兼具学术价值和生产价值的方向
+
+### 1. 做一份可组合的 crash-semantics descriptor
+
+不要把 atomic write support 暴露成一个 bool，而是为真实 storage path 生成一份机器可读的 descriptor，把应用真正依赖的条件绑定在一起，例如：
+
+```text
+file = inode/mount identity
+atomic_range = statx min/max/segments/alignment
+io_mode = O_DIRECT + sync semantics
+filesystem = ext4 + relevant feature/mount mode
+metadata_scope = rename/size/allocation 需要的持久化规则
+storage_path = device/controller capability identity
+application_protocol = expected recovery contract version
+fallback = WAL/fsync 或 copy-on-write path
+```
+
+它不是用来替代 filesystem spec 或 device spec，而是在 I/O engine 选择 protocol 的 integration boundary，把“应用认为现在拥有什么 crash semantics”显式记录下来，并且可以版本化。
+
+研究 prototype 可以在多种 kernel、ext4 config 和 device capability profile 上，比较 descriptor 预测的 crash state 与 fault injection 真正观测到的结果。Primary metric 不应该是 coverage，而是 **false confidence**：descriptor 认为 protocol 安全，却实际到达 forbidden state 的次数。还可以测 false rejection、生成成本，以及它相对 conservative baseline 有多少次真正改变 fast-path selection。
+
+学术价值在于把分散在不同 API、filesystem 和 device contract 里的 crash guarantee 变成可组合模型。生产使用者是 database、object store 或 storage runtime，接入点就是 I/O backend 初始化和 protocol selection。
+
+如果只用现有 `statx()`、open flags、filesystem discovery 和 storage-engine config 就已经能够无歧义推导所有重要 recovery state，而且 descriptor 从不改变 safe/unsafe decision，也发现不了错误 assumption，那这个方向应该直接放弃。否则只是多了一份 manifest。
+
+### 2. 给每次 application commit 生成 crash-cut witness
+
+第二个方向是把一次 commit 写成一张很小的 persistence obligation graph，而不是让真正的语义只存在于 syscall sequence 和代码注释里。
+
+例如一个 page-oriented database 可以描述：
+
+```text
+WAL record W 必须 durable 后，page P 才能成为 authoritative
+P 满足 range constraint 时可以使用一次 RWF_ATOMIC
+commit marker C 只能在 W 的 persistence edge 之后 durable
+只有 allocation/layout 改变时才需要 metadata operation M
+recovery 可以接受 {old, W-only, W+P, W+P+C}
+其他所有 visible combination 都必须拒绝
+```
+
+Runtime 可以只在 debug/test build 输出这份 witness，checker 则在每个 persistence edge 枚举 crash cut。这里并不是要把 transaction manager 塞进 kernel，而是让 application test 第一次拥有一个明确 oracle，知道底层 untorn-write、sync、ordering 和 metadata guarantee 最终应该组合成什么。
+
+Evaluation 至少拿 atomic-write-aware protocol 和传统 WAL + `fsync()` baseline 比。故障点覆盖 submission 前、device completion 后、sync operation 周围和 metadata change 周围。第一指标必须是 forbidden recovered state，然后再比较 barrier 数、write amplification、commit latency 和 recovery work。最有价值的结果不是“atomic write 更快”，而是证明它确实能删掉一部分 logging/copy 成本，同时没有扩大 legal recovery-state set。
+
+学术贡献是给 untorn range、persistence ordering 和 application recovery 一个具体的 composition semantics。生产接入点是 database/storage engine 的 commit path，witness 更适合 CI、hardware qualification 和 incident reproduction，不一定需要让每次 production I/O 都付出额外成本。
+
+如果固定的 WAL/`fsync()` protocol 更简单，而且在 latency、write amplification 上一样好或更好，同时始终保持零 forbidden recovery state，那么 witness-guided design 没有存在价值。Atomic I/O 不应该为了“新”而增加 protocol complexity。
+
+### 3. 按 failure class 测 crash guarantee，而不是一个 pass/fail
+
+一个有用的 benchmark 应该故意把下面几类失败拆开：
+
+- 同一个 requested range 里面出现 torn data；
+- syscall 已完成但没有同步的 whole write 在 power loss 后完全消失；
+- 两次各自合法的 write 以 application-invalid ordering 持久化；
+- data 与 filesystem metadata 属于不同 generation；
+- create/rename 等 namespace operation 与 file data 落在不同 crash cut；
+- process crash、kernel crash、controller reset 和 full power-loss model。
+
+现有 kernel infrastructure 可以继续复用。`blktests` 已经是 Linux block layer 和 storage stack 的测试框架，filesystem tooling 也可以直接驱动 atomic-write path。真正缺的是 application-level oracle：在一个声明好的 protocol 下，把每种 recovered state 标成 allowed 或 forbidden。
+
+同一 protocol 要跨多种 atomic-unit size、extent layout、sync mode、filesystem mode，以及模拟/真实 failure model 测试。结果不要合成一个“crash test passed”。分别报告 torn-write escape、forbidden recovered state、capability selector 的 false accept/reject、recovery time 和 overhead，这样才不会把不同 guarantee 再次混到一起。
+
+学术价值是形成一套能分辨 atomicity、durability、ordering、metadata consistency 和 transaction recovery 的 measurement methodology。生产使用者是 storage engine 或 platform qualification team，接入点是 fleet 上线 fast path 之前的 kernel/filesystem/device matrix。
+
+如果已有 block/filesystem test suite 在相同成本下已经能预测 application recovery，而且覆盖完全相同的 failure class 和 target matrix，那么不需要再做一套新 benchmark。实验应该主动证明 application oracle 是否真的能发现额外错误。
+
+## 一个更稳妥的上线规则
+
+现在更合理的做法，是把 `RWF_ATOMIC` 当作简化 crash protocol 某一个局部步骤的 capability，而不是删除 crash protocol 的许可证。
+
+先用 `statx()` 查询这个具体文件的能力，不要根据 kernel version 猜。严格满足 Direct I/O、alignment、range 和 segment constraint。然后单独决定 completion 是否需要 synchronized I/O。多次 write 之间的 ordering 要继续显式表达。Filesystem metadata 和 namespace operation 按 filesystem 自己的 persistence rule 处理。最后在真的删除 WAL、COW step 或 barrier 之前，用 crash injection 验证 application recovery state machine。
+
+此前的 [有状态 eBPF 原子升级报告](https://eunomia.dev/zh/research/stateful-ebpf-transactional-upgrade/) 用 generation-gated commit 和 recovery 避免把 multi-object update 的中间状态误认成新 generation。Storage software 虽然使用完全不同的 primitive，但会犯同一类 composition mistake：**一个 locally atomic operation 并不会自动让 multi-object transition 也 atomic。**
+
+## 什么证据会改变这个结论？
+
+如果未来 Linux 提供一套 end-to-end interface，明确把 untorn write、persistence completion、cross-write ordering、相关 filesystem metadata，以及 multi-object transaction boundary 组合在一个有正式 recovery semantics 的接口里，那么应用当然不需要自己组合这么多独立 guarantee。
+
+另一个会削弱本文结论的情况，是实际 storage engine 证明一个更小的 contract 已经足够。例如某个 application 的全部 authoritative state 真正只落在一个 eligible atomic range 里，没有额外 metadata/object 参与 commit，那么一次 atomic + synchronized write 本身就可以成为 transaction boundary，不需要额外 composition layer。
+
+最后，fault injection 也可能直接否定上面的研究方向。如果现有 capability discovery 加传统 WAL/fsync practice 已经能在不同 kernel、filesystem、device 上准确预测所有 post-crash state，那么新 descriptor 和 witness language 只是在增加流程，而不是增加安全性。
+
+因此最有用的 mental model 其实很窄：**Linux atomic write 能保证一个受支持的 range 不被 torn；真正的 crash consistency 仍然是 protocol property，持久化、顺序、metadata 和 recovery boundary 都要分别说清楚。**
+
+## 参考资料
+
+- Linux kernel documentation, [Atomic Block Writes](https://www.kernel.org/doc/html/latest/filesystems/ext4/atomic_writes.html)，访问于 2026-09-12。
+- Linux man-pages, [`pwritev2(2)` / `RWF_ATOMIC`](https://man7.org/linux/man-pages/man2/pwritev2.2.html)，man-pages 6.19，访问于 2026-09-12。
+- Linux man-pages, [`statx(2)` / `STATX_WRITE_ATOMIC`](https://man7.org/linux/man-pages/man2/statx.2.html)，访问于 2026-09-12。
+- Linux kernel documentation, [ext4 Journal (jbd2)](https://www.kernel.org/doc/html/latest/filesystems/ext4/journal.html)，访问于 2026-09-12。
+- linux-blktests, [blktests](https://github.com/linux-blktests/blktests)，访问于 2026-09-12。


### PR DESCRIPTION
## Summary

- publish one new bilingual Daily Report on Linux `RWF_ATOMIC` and crash-consistency composition
- keep the active eBPF deployment-compatibility series queued because the newest-ten window is already at the 7-of-10 eBPF ceiling
- record the September 12 analytics/source limitations and the evidence-based decision to make no unrelated technical SEO change
- add the new report to both Daily Report indexes

## Classification

Adjacent systems — Linux/storage. The rolling newest-ten mix remains 7 eBPF-centered / 0 pure Agent / 3 adjacent after publication.

## Data constraints

The newest verified Search Console source remains `2026-08-31..09-06` with `2026-09-06` absent. Complete 7-day and 28-day comparable windows remain unavailable and missing dates are not treated as zero. GA4 `2026-08-31..09-06` remains a partial frozen aggregate without a date dimension. Cloudflare remains disabled by repository configuration.

## Validation

This PR must pass the repository's required PR-head workflows, complete diff/generated-output self-review, squash merge, exact-merge production deployment, bilingual production verification, sitemap verification, and one merged-PR closeout comment before the run is complete.