### PR TITLE
Daily: define Linux capability evidence beyond kernel versions

### DIFF
--- a/.github/seo-data/daily/2026-09-12.md
+++ b/.github/seo-data/daily/2026-09-12.md
@@ -1,0 +1,140 @@
+# SEO operations — 2026-09-12
+
+## Scope
+
+- Site: `https://eunomia.dev`
+- Site timezone: `America/Los_Angeles`
+- Authoritative task: `DAILY_TASK.md`
+- Baseline default-branch commit: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
+- Delivery branch: `daily/2026-09-12-linux-capability-evidence`
+- Delivery PR: pending creation
+- Run type: mandatory data analysis, technical SEO/GEO audit, and exactly one new bilingual Daily Report
+- Technical SEO outcome: no separate implementation change. Current analytics, public-safe site evidence, repository state, and prior exact-deployment evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants an unrelated change.
+- Mandatory publication: one adjacent-systems bilingual Daily Report on Linux capability detection when backports, configuration, execution policy, and semantic fixes diverge from the kernel version string.
+
+Cloudflare remains disabled by repository configuration. Missing coverage is unavailable, partial, stale, or absent rather than zero.
+
+### Prior-run reconciliation
+
+PR `#196`, **Daily: define evidence for eBPF optimization promotion**, is the valid September 11 delivery and was squash-merged as `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`. Its exact-merge `Deploy Static App` run `34703868336` completed successfully. The deployment produced static export `128c9d43241d9258d09053e1f60278aa5e21be03`, explicitly bound by commit message to the squash SHA. The generated English and Chinese report artifacts and sitemap were verified for locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` alternates, Article JSON-LD, Daily Report navigation, and both sitemap routes. Exactly one compact merged-PR closeout comment records final delivery evidence.
+
+## Data window
+
+- The exact configured Google Drive folder `eunomia.dev SEO Weekly CSV` was directly rechecked on `2026-09-12`. No weekly source set newer than `2026-08-31..09-06` is present.
+- Search Console source rows in that set are present for `2026-08-31..09-05`; `2026-09-06` is absent.
+- Under the configured three-day lag, all currently observed Search Console rows through `2026-09-05` are finalized.
+- The GA4 organic landing-page aggregate for `2026-08-24..30` remains the latest fully finalized weekly aggregate.
+- The `2026-08-31..09-06` GA4 aggregate remains explicitly partial because it was exported while lagged dates were present and has no date dimension.
+- Complete latest-seven-day and 28-day comparable-period GSC analyses remain unavailable because the newest export omits `2026-09-06`, the prior export omits `2026-08-30`, and older history includes the recorded `2026-08-23` gap.
+- Missing rows are never synthesized as zero.
+- Cloudflare remains disabled.
+
+Latest-source SHA-256 checksums used for this run:
+
+- `2026-08-31_to_2026-09-06_gsc_dates.csv`: `3392488c2180ba758c29b236404f42ebc4ad51b5f182cb6e2a5421873a1607ed`
+- `2026-08-31_to_2026-09-06_gsc_pages.csv`: `44f99872ab9f678105957a2e1ca6e8bf7cbad532a281bcf9247fbe480e9203c2`
+- `2026-08-31_to_2026-09-06_gsc_queries.csv`: `8af32bc9db250ac4020912ab632cde5714dcd7c7d6e2624d4ac5c2f164a0fd33`
+- `2026-08-31_to_2026-09-06_gsc_devices.csv`: `9c75929adac42dadeb0091708621b7b9916acb2751645ee194123846d1331740`
+- `2026-08-31_to_2026-09-06_gsc_countries.csv`: `2bae0e938ae62451d2bb1cc5df697f0fbb3d7f5f867cb3d437aff2147cf3a54e`
+- `2026-08-31_to_2026-09-06_gsc_search_appearance.csv`: `7b10e8bf7f3778e695054efc407d1339d0315dd70bf6cfe0f9c400dfaaff60bc`
+- `2026-08-31_to_2026-09-06_ga4_organic_landing_pages.csv`: `0a8a233b178ae0deb9150e4d7f0da9faa716ee89dba487b840932d79a912e4ac`
+
+No raw rows, search queries, private URLs, account IDs, Drive IDs, credentials, or user-level analytics are committed.
+
+## Evidence collected
+
+### Google Search Console
+
+The newest finalized source-native `2026-08-31..09-05` six-day slice contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**.
+
+The equal-duration finalized `2026-08-24..29` slice contains **436 clicks / 55,594 impressions / ~0.784% CTR / ~10.73 weighted position**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**. This is not a complete seven-day trend.
+
+The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly export. Because the export has no date dimension and the published report set changed, the movement is prioritization evidence rather than causal evidence for a title, topic, navigation, or metadata change.
+
+Device aggregates reinforce the need to avoid over-interpreting CTR: desktop records **339 clicks / 56,097 impressions** versus **379 / 47,399** in the preceding incomplete weekly export, while mobile records **49 / 4,730** versus **55 / 8,119**. Query and page mix are not held constant, so these numbers do not justify a device-specific intervention.
+
+### Google Analytics 4
+
+The finalized `2026-08-24..30` organic landing-page aggregate remains **1,007 sessions** at about **45.88% session-weighted engagement**. The preceding finalized `2026-08-17..23` aggregate remains **984 sessions** at about **49.29% engagement**.
+
+The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.54% session-weighted engagement**, but remains partial. It is recorded for coverage and is not presented as a finalized week-over-week decline or recovery.
+
+### Cloudflare
+
+Cloudflare analytics remains disabled by repository configuration. No traffic, cache, bot, country, or status-code conclusion is inferred from missing Cloudflare data.
+
+### Public site and repository evidence
+
+The repository-generated public-safe brief dated `2026-09-12 11:39 UTC` reports the canonical homepage at HTTP 200 in **220 ms**, robots at HTTP 200, sitemap at HTTP 200, and **752 sitemap entries**. It records **99 active non-fork repositories, 9,994 stars, 1,306 forks, and 288 open issue/PR records**, plus **63 DEV articles / 43 reactions / 4 comments**. These counters are contextual observations, not a blended SEO score.
+
+The existing public homepage is reachable with the expected canonical identity. The immediately preceding September 11 report had already completed exact-SHA production verification. No new technical defect is established strongly enough to justify a separate SEO/GEO implementation change on this run.
+
+### Rolling Daily Report mix before topic selection
+
+The ten actually published reports immediately before today's publication contain:
+
+- eBPF-centered: **7 of 10**
+- pure Agent-centered: **0 of 10**
+- adjacent systems: **3 of 10**
+
+An eBPF-centered report today would rotate out the `2026-08-31` adjacent GPU-utilization report and create an invalid **8 / 0 / 2** window. The selected report is therefore an evidence-backed adjacent-systems detour. Because one adjacent report replaces another, the resulting window remains **7 eBPF / 0 pure Agent / 3 adjacent systems** with no classification changes.
+
+### Research evidence and topic selection
+
+Selected report:
+
+- English: **Why Is Linux Capability Detection Harder Than Checking the Kernel Version?**
+- Chinese: **为什么 Linux 能力检测不能只看内核版本？**
+- Route: `/research/linux-capability-detection-contract/`
+- Classification: **adjacent systems**
+- Adjacent area: Linux userspace ABI / runtime compatibility
+
+Fresh primary evidence makes this question stronger than a generic “kernel versions are unreliable” note. Current Linux Landlock documentation, dated August 2026, requires runtime ABI detection and now exposes an errata bitmask for semantic fixes that may matter without a new coarse ABI generation. Current `io_uring_register(2)` documentation includes both opcode probing and `IORING_REGISTER_QUERY`, available since kernel 6.15, for opcodes, flags, and subsystem-specific capability queries. `openat2(2)` uses extensible structure-size negotiation and `E2BIG` rather than a release-number contract. Red Hat documents that RHEL kernels can retain an older upstream base version while backporting changes from much newer upstream kernels.
+
+The report therefore treats capability as four separate questions: implementation presence, runtime availability, semantic level, and authorization in the current execution context. It develops three testable directions: (1) typed capability receipts that preserve source-native probe meaning and bind it to a runtime decision; (2) a counterexample corpus that measures false positive and false negative version-based compatibility predictions across backports, configuration, sandboxes, and semantic errata; and (3) validity leases for cached capability evidence across boots, namespaces, policy profiles, and credential classes.
+
+A narrower `io_uring`-only capability report was rejected because the site already has a dedicated io_uring programmability report and the cross-subsystem Linux contract provides a more distinct adjacent-systems boundary. A BPF-specific capability-manifest report was rejected for today because it would violate the rolling 7-of-10 eBPF cap and would prematurely consume material reserved for the active **eBPF Deployment Compatibility and Lifecycle** roadmap.
+
+## Work performed
+
+The branch is scoped to one publication plus directly coupled operating-state changes:
+
+- added `docs/research/linux-capability-detection-contract.md`;
+- added `docs/research/linux-capability-detection-contract.zh.md`;
+- prepended the English and Chinese Daily Report indexes;
+- added this September 12 operating record;
+- refreshed `status.md` with prior-run reconciliation, analytics coverage, public-safe evidence, rolling mix, and current delivery state;
+- made no unrelated technical SEO implementation change;
+- kept Cloudflare unavailable and missing analytics dates explicit rather than inventing zeros;
+- kept the SEO skill submodule pinned at `516e9e2dcf012506a677a749049d64c5914643e9` because `plan.md` still requires consuming-contract migration before pointer movement.
+
+## Validation and self-review
+
+The authoritative PR checks are `Validate SEO Operations` and `Deploy Static App`. Missing, queued, skipped, cancelled, or failed checks are not success. Any validation or review issue must be fixed on this same branch and rechecked.
+
+Before merge, the complete final PR diff, changed-file set, metadata, English/Chinese prose, internal links, classification, rolling-window arithmetic, and generated production output must be re-read. The branch must contain exactly one new report in two language files and no unrelated site change.
+
+After squash merge, the exact merge commit must complete the production deployment. Generated and public English/Chinese pages must be checked for Daily Report navigation, locale-correct canonical URLs, reciprocal `en`/`zh` plus `x-default` hreflang, Article JSON-LD, internal links, the explicit gap section, three developed directions, the reader-facing falsification conclusion, and sitemap alternates before closeout.
+
+## Delivery
+
+- Branch: `daily/2026-09-12-linux-capability-evidence`
+- Pull request: pending creation
+- PR-head validation: pending terminal result
+- PR-head static deployment check: pending terminal result
+- Squash merge: pending
+- Exact-merge production deployment: pending
+- Production bilingual verification: pending
+- Merged-PR closeout comment: pending
+
+The recurring operations schedule remains enabled and is not modified by repository delivery state.
+
+## Decisions and follow-ups
+
+1. Do not infer a seven-day or 28-day Search Console trend until contiguous source history exists.
+2. Do not treat the partial `2026-08-31..09-06` GA4 aggregate as a finalized week-over-week result.
+3. Do not make a title or metadata change from aggregate CTR movement alone; obtain finalized date-by-page/query evidence first.
+4. Preserve the post-publication **7 / 0 / 3** rolling mix. Because the next rotating report is also adjacent, the next run must still use a quality-qualified non-eBPF detour before the active eBPF compatibility series resumes.
+5. Keep the generic Linux capability-receipt idea out of the later eBPF series; that series should focus on BPF-specific verifier, CO-RE, kfunc/`struct_ops`, attachment, and persistent-state compatibility.
+6. Keep Cloudflare unavailable until a supported read-only route is configured.
+7. Keep the SEO skill pointer unchanged until the consuming-contract migration is complete.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -10,46 +10,43 @@
 - Search Console newest observed source row: `2026-09-05`; under the configured three-day lag all observed rows through that date are finalized; `2026-09-06` is absent
 - Latest fully finalized GA4 weekly organic landing-page aggregate: `2026-08-24` through `2026-08-30`
 - Newest GA4 weekly organic landing-page aggregate: `2026-08-31` through `2026-09-06`, still partial because the frozen export was generated while lagged dates were present and has no date dimension
-- Latest completed daily record before the current run: `2026-09-10`
-- Last merged Daily Report pull request: `#195`
-- Last Daily Report squash commit: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
-- Exact-merge `Validate SEO Operations` run for `#195`: `34618891189`, success
-- Exact-merge `Deploy Static App` run for `#195`: `34618891146`, success
-- Static production export for `#195`: `b9bab3bfd4897272ca6264d66c450ad5236feb2a`, committed as `deploy static app for 59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
-- Current daily branch: `daily/2026-09-11-ebpf-optimization-evidence`
-- Current daily pull request: `#196`
-- Current branch original base: `59fc26a8599728e6e0ac3d5a6e06b993b9a63cc2`
+- Latest completed daily record before the current run: `2026-09-11`
+- Last merged Daily Report pull request: `#196`
+- Last Daily Report squash commit: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
+- Exact-merge `Deploy Static App` run for `#196`: `34703868336`, success
+- Static production export for `#196`: `128c9d43241d9258d09053e1f60278aa5e21be03`, committed as `deploy static app for 5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
+- Current daily branch: `daily/2026-09-12-linux-capability-evidence`
+- Current daily pull request: pending creation
+- Current branch original base: `5989df8f4d05370bc9cf8bfcecf2680056c3a60d`
 - Skill submodule commit: `516e9e2dcf012506a677a749049d64c5914643e9`
 
-The valid September 10 delivery is PR `#195`, **Daily: define cross-backend semantics for eBPF operations**. Its exact-merge validation and deployment are terminal-success, the generated bilingual production artifacts and sitemap were verified against the squash SHA, and the single compact merged-PR closeout comment was added. Failed duplicate PR `#194` is closed as superseded and was not merged.
+The valid September 11 delivery is PR `#196`, **Daily: define evidence for eBPF optimization promotion**. Its exact merge deployment completed successfully, the generated bilingual production artifacts and sitemap were verified against the squash SHA, and exactly one compact merged-PR closeout comment records final delivery evidence.
 
 ## Current Daily Report mix
 
 Before today's publication, the newest ten actually published reports contain:
 
-- eBPF-centered: **6 of 10**
+- eBPF-centered: **7 of 10**
 - pure Agent-centered: **0 of 10**
-- adjacent systems: **4 of 10**
+- adjacent systems: **3 of 10**
 
-Today's selected `/research/ebpf-optimization-evidence-contract/` report is **eBPF-centered**. BPF verifier/JIT/application/workload evidence and the promotion boundary for eBPF optimizations are the central technical objects.
+Today's selected `/research/linux-capability-detection-contract/` report is **adjacent systems**. Linux userspace capability negotiation, distribution backports, runtime configuration, and compatibility evidence are the central technical objects; eBPF is only a downstream connection.
 
-The incoming report rotates the `2026-08-30` adjacent GPU-instrumentation report out. After publication the mix becomes **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**, still inside the 5–7 target band but at its upper limit. No existing classification changes.
-
-**eBPF Optimization and Execution Specialization** closes with this sixth report. The six covered boundaries are semantic equivalence and profile lifetime, architecture-specific implementation/fallback, exact execution-generation provenance, native-operation trust/TCB accounting, cross-backend state-transition semantics, and performance-evidence scope/promotion.
-
-The next eBPF roadmap is **eBPF Deployment Compatibility and Lifecycle**, but the post-publication rolling mix is already at seven eBPF-centered reports. The next scheduled publication must use an adjacent or other quality-qualified non-eBPF-centered detour if another eBPF report would exceed the cap; the active compatibility series resumes when the window permits.
+The incoming adjacent report rotates the `2026-08-31` adjacent GPU-utilization report out. After publication the mix remains **7 eBPF-centered / 0 pure Agent / 3 adjacent systems**. Another eBPF-centered publication on the next run would still exceed the 7-of-10 cap because the next rotating report is also adjacent, so the active **eBPF Deployment Compatibility and Lifecycle** series remains paused for another quality-qualified adjacent or pure-Agent detour.
 
 ## Current signals
 
 ### Google Search Console
 
-The configured Drive source was rechecked on `2026-09-11`; no source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
+The configured Drive source was rechecked on `2026-09-12`; no source set newer than `2026-08-31..09-06` is present. Its date export has rows for `2026-08-31..09-05` and no row for `2026-09-06`.
 
 The newest finalized six-day slice `2026-08-31..09-05` contains **388 clicks / 60,880 impressions / ~0.637% aggregate CTR / ~7.35 impression-weighted average position**. The equal-duration finalized `2026-08-24..29` slice contains **436 / 55,594 / ~0.784% / ~10.73**. Relative to that six-day slice, clicks are about **11.0% lower**, impressions about **9.5% higher**, CTR about **0.147 percentage points lower**, and weighted position about **3.38 positions better**.
 
 This is not a complete seven-day trend. The newest export omits `2026-09-06`, the preceding export omits `2026-08-30`, and older history includes the recorded `2026-08-23` gap. Complete latest-seven-day and 28-day comparable-period analyses remain unavailable. Missing rows are never interpreted as zero.
 
 The newest weekly GSC page aggregate contains Daily Report routes at **8 clicks / 1,812 impressions**, compared with **6 / 1,017** in the preceding weekly export. The page export has no date dimension and the published report set changed, so this is prioritization evidence rather than causal evidence for a title, topic, navigation, or metadata change.
+
+Device evidence is also non-causal but useful for inspection: the newest six-row export attributes **339 clicks / 56,097 impressions** to desktop and **49 / 4,730** to mobile, compared with **379 / 47,399** and **55 / 8,119** in the prior incomplete weekly export. The changing query and page mix prevents a device-specific SEO intervention from being justified from these aggregates alone.
 
 ### Google Analytics 4
 
@@ -59,7 +56,7 @@ The newer `2026-08-31..09-06` aggregate contains **913 sessions** at about **47.
 
 ### Public and repository technical evidence
 
-The latest public-safe data brief observed on `2026-09-11` reports the canonical homepage at HTTP 200 in 233 ms, robots at HTTP 200, sitemap at HTTP 200, and 748 sitemap entries. It records 99 active non-fork repositories, 9,987 stars, 1,305 forks, and 287 open issue/PR records across the observed public portfolio. These are context, not a blended SEO score.
+The latest public-safe data brief generated on `2026-09-12 11:39 UTC` reports the canonical homepage at HTTP 200 in **220 ms**, robots at HTTP 200, sitemap at HTTP 200, and **752 sitemap entries**. It records **99 active non-fork repositories, 9,994 stars, 1,306 forks, and 288 open issue/PR records** across the observed public portfolio, plus **63 DEV articles / 43 public reactions / 4 comments**. These are context, not a blended SEO score.
 
 Current analytics, repository health, deployment evidence, and public-safe evidence do not establish a concrete crawlability, canonical, hreflang, structured-data, redirect, broken-link, rendering, accessibility, persistent-performance, or deployment defect that warrants a separate technical SEO implementation change today.
 
@@ -73,8 +70,8 @@ The SEO skill submodule remains pinned at `516e9e2dcf012506a677a749049d64c591464
 
 ## Current focus
 
-1. Complete today's optimization-evidence report through PR `#196`, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
-2. Close **eBPF Optimization and Execution Specialization** at six reports and preserve the next **eBPF Deployment Compatibility and Lifecycle** roadmap without exceeding the rolling 7-of-10 eBPF cap.
+1. Complete today's adjacent Linux capability-detection report through a real non-draft PR, terminal-green PR-head CI, final diff/generated-output self-review, squash merge, exact production deployment, bilingual production verification, sitemap verification, and exactly one merged-PR closeout comment.
+2. Preserve the rolling **7 eBPF / 0 pure Agent / 3 adjacent** mix; the next run still needs a quality-qualified non-eBPF detour before **eBPF Deployment Compatibility and Lifecycle** can resume without exceeding the cap.
 3. Recheck Drive freshness every run. Keep complete GSC 7-day and 28-day comparisons unavailable until source history is contiguous; never fill missing dates with zero.
 4. Keep the newest GA4 weekly aggregate explicitly partial until refreshed or date-dimensional evidence supports finalized interpretation.
 5. Keep Cloudflare evidence unavailable until a supported read-only path is enabled.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,6 +9,10 @@ Eunomia Daily Report examines concrete systems questions, compares primary evide
 
 ## Current reports
 
+### [Why Is Linux Capability Detection Harder Than Checking the Kernel Version?](https://eunomia.dev/research/linux-capability-detection-contract/)
+
+Linux release strings cannot reliably describe backports, boot configuration, execution policy, and semantic fixes. This report compares Landlock, io_uring, and openat2 negotiation patterns, then develops typed capability receipts, a compatibility counterexample corpus, and scoped evidence leases.
+
 ### [When Is an eBPF Optimization Result Strong Enough to Ship?](https://eunomia.dev/research/ebpf-optimization-evidence-contract/)
 
 eBPF optimizations can be semantically correct yet win only one microbenchmark, JIT, or tuned workload. This report develops scoped evidence envelopes, holdout and counterexample suites for adaptive optimizers, and profitability-aware promotion gates that bound regressions before fleet rollout.

--- a/docs/research/index.zh.md
+++ b/docs/research/index.zh.md
@@ -9,6 +9,10 @@ Eunomia 每日报告围绕具体系统问题展开，比较一手证据，分析
 
 ## 当前报告
 
+### [为什么 Linux 能力检测不能只看内核版本？](https://eunomia.dev/zh/research/linux-capability-detection-contract/)
+
+Linux 版本号无法可靠表达发行版回移植、启动配置、执行策略和语义修复。本文比较 Landlock、io_uring 与 openat2 的协商方式，并提出有类型的 capability receipt、兼容性反例语料以及带作用域的证据有效期。
+
 ### [一个 eBPF 优化结果，到什么程度才值得上线？](https://eunomia.dev/zh/research/ebpf-optimization-evidence-contract/)
 
 eBPF 优化即使语义完全正确，也可能只在单个 microbenchmark、JIT 或被调过的 workload 上获胜。本文提出带 claim scope 的 evidence envelope、面向自适应 optimizer 的 holdout/counterexample suite，以及在 fleet rollout 前限制 regression 的 profitability-aware promotion gate。

--- a/docs/research/linux-capability-detection-contract.md
+++ b/docs/research/linux-capability-detection-contract.md
@@ -1,0 +1,148 @@
+---
+date: 2026-09-12
+slug: linux-capability-detection-contract
+title: "Why Is Linux Capability Detection Harder Than Checking the Kernel Version?"
+description: "Linux capability detection fails when backports, configuration, and semantic fixes diverge from kernel versions. This report proposes capability receipts."
+tags:
+  - Daily Report
+  - Linux
+  - Compatibility
+  - System Calls
+  - Runtime
+  - Portability
+research_question: "How should portable Linux software decide that a runtime feature is actually usable when distribution backports, configuration, policy, and semantic fixes diverge from the kernel version string?"
+source_cutoff: 2026-09-12
+status: daily-report
+---
+
+# Why Is Linux Capability Detection Harder Than Checking the Kernel Version?
+
+Suppose a service starts on a machine reporting Linux 5.14. It wants a security feature, a newer `io_uring` operation, or an `openat2()` behavior. A simple deployment rule says that the feature arrived in Linux version X, compares X with `uname -r`, and chooses the fast path or fallback.
+
+That rule is attractive because it turns compatibility into one integer comparison. Real Linux deployments do not preserve that relationship. Distribution kernels backport newer subsystem changes onto older upstream version bases. Features can be compiled out or disabled at boot. A sandbox or compatibility layer can hide a system call that the host kernel implements. Even when an API exists, a later semantic fix can matter to the application without changing the API version it originally checked.
+
+**Linux capability detection therefore needs evidence from the running interface, not only a guess derived from the kernel version. The harder problem is preserving enough evidence to explain exactly which behavior was proved, in which execution context, and why the program selected one path.**
+
+<!-- more -->
+
+This is an adjacent-systems detour from the current eBPF roadmap. The newest-ten Daily Report window is already at the configured maximum of seven eBPF-centered reports, so another eBPF report would violate the editorial mix. The compatibility problem is still useful background for portable runtimes such as [bpftime](https://github.com/eunomia-bpf/bpftime), but this report is about Linux userspace interfaces in general rather than BPF-specific capability negotiation.
+
+## Linux capability detection is already a collection of different contracts
+
+The strongest evidence against version-only logic comes from Linux interfaces themselves: they have independently invented several ways to negotiate compatibility.
+
+Red Hat documents why the release string is an incomplete capability description. A RHEL 9 kernel can report a 5.14 upstream base while individual subsystems contain changes from much newer upstream kernels. The version string identifies the packaged kernel lineage; it does not enumerate every backported subsystem feature.
+
+Landlock goes further and explicitly tells userspace not to infer support from the kernel version. An application can query the Landlock ABI version with `landlock_create_ruleset(..., LANDLOCK_CREATE_RULESET_VERSION)`, then enable only access rights present in that ABI. The current August 2026 kernel documentation also exposes `LANDLOCK_CREATE_RULESET_ERRATA`: a bitmask for semantic fixes that may require userspace awareness. That distinction is important. A feature can exist, have the same broad ABI generation, and still differ in behavior because a correctness fix is present or absent.
+
+`openat2()` uses another pattern. Its `struct open_how` is explicitly extensible, and the structure size acts as an implicit version. If userspace passes fields newer than the running kernel understands, nonzero unknown extension data produces `E2BIG`. The manual page even describes probing the largest supported structure size. Here compatibility is negotiated through structure shape rather than a named ABI number.
+
+`io_uring` has accumulated still another set of mechanisms. `IORING_REGISTER_PROBE` reports supported operation codes. Feature bits on `io_uring_setup()` describe selected behavior. Current man-pages also document `IORING_REGISTER_QUERY`, available since kernel 6.15, which can query supported opcodes, flags, and subsystem-specific capabilities without first creating a ring. The subsystem has moved toward richer runtime capability queries because a single release number cannot conveniently describe the matrix.
+
+These interfaces are not inconsistent mistakes. Each reflects a different compatibility problem. The issue for portable userspace is that the evidence is fragmented across versioned ABIs, bitmaps, opcode probes, extensible structs, configuration, return codes, and execution policy.
+
+## Four different questions get collapsed into “is this feature supported?”
+
+The first question is **implementation presence**. Does this kernel or compatibility layer implement the syscall, opcode, flag, or object shape at all? `ENOSYS`, an opcode probe, or a query interface can often answer this.
+
+The second is **runtime availability**. Landlock can be compiled into a kernel yet disabled by boot configuration. `io_uring` operations may have privilege or setup-mode requirements. A feature can exist in source and remain unusable in the current boot or process environment.
+
+The third is **semantic level**. An ABI number or opcode bit may establish a coarse feature generation while a later fix changes an edge case the application cares about. Landlock's errata mechanism makes this explicit: userspace may occasionally need to know not only that the interface exists, but whether a particular semantic correction is present.
+
+The fourth is **authorization in this execution context**. Containers, seccomp policies, virtualized kernels, LSM configuration, namespaces, and credentials can make two processes on the same nominal kernel observe different usable capability sets. A host-global cache can therefore answer the wrong question for a sandboxed process.
+
+A version comparison compresses all four questions into one proxy. A direct probe is better, but even a probe is only useful if the software remembers what that probe established and which decision depended on it.
+
+## Where current work is still weak
+
+The first gap is **a common evidence model across Linux APIs**. Landlock can return an ABI and errata mask, `io_uring` can return operation and flag support, and `openat2()` can negotiate structure size. Portable applications still encode each answer as ad hoc booleans in loader code. After an incident, it can be difficult to tell whether a fallback was selected because the kernel lacked a feature, the feature was disabled, the process was denied, or the application simply did not recognize a newer interface.
+
+The second gap is **semantic confidence beyond feature presence**. Capability APIs normally answer questions defined by their own subsystem. They rarely express the higher-level guarantee the application wants, such as “this path resolution cannot escape this root under these flags” or “this sandbox correctly handles the network behavior my policy relies on.” Landlock's new errata query is evidence that behavior-level distinctions sometimes matter after an ABI already exists.
+
+The third gap is **scope and lifetime**. Some observations are stable for the boot; others depend on process credentials, namespace, seccomp state, container runtime, or a virtualized syscall surface. Capability caches seldom declare their validity scope. Reusing a host probe inside a more restricted execution context creates a stale-evidence bug rather than a missing-feature bug.
+
+The fourth gap is **reproducible fleet compatibility testing**. Distribution backports intentionally break the simple mapping from upstream version to feature set, but many CI matrices still label machines primarily by kernel release. That makes it hard to distinguish a failure caused by version lineage from one caused by a specific backport, configuration choice, semantic fix, or policy layer.
+
+## Promising directions with academic and production value
+
+### 1. Turn capability probes into typed receipts
+
+The gap is not lack of probes. Linux already has many good ones. The missing piece is a common record of what each successful or failed probe actually proves.
+
+A small capability receipt could contain:
+
+```text
+requirement = landlock.net.bind-tcp
+probe = LANDLOCK_CREATE_RULESET_VERSION
+result = abi>=4
+semantic_fixes = {erratum-1, erratum-2}
+kernel_build = package + build-id
+execution_scope = boot + userns + seccomp-profile + credentials
+observed_at = process-start
+chosen_path = landlock-network-policy-v2
+fallback = filesystem-only-policy
+```
+
+The mechanism would be a userspace library and schema that adapters populate from native subsystem probes. The library should not replace Landlock, `io_uring`, or `openat2()` negotiation. It should preserve their source-native meaning and bind the result to the application decision that consumed it.
+
+The strongest adjacent baseline is direct hand-written feature detection. Evaluate both approaches across mainline kernels, long-lived distribution kernels, different boot configurations, containers, and syscall-virtualization environments. Inject backports, disabled features, denied syscalls, and selected semantic errata. Measure false-positive enablement, unnecessary fallback, time to explain a decision, receipt size, and startup overhead.
+
+The academic value is a model of capability evidence that separates presence, availability, semantics, and authorization instead of treating support as one bit. The production user is a runtime, database, storage engine, sandbox, or agent executor that already contains kernel-version conditionals and feature probes; the integration boundary is its startup and backend-selection path.
+
+This idea loses if ordinary per-API probes plus a small amount of logging achieve the same decision accuracy and postmortem explainability at materially lower complexity. A general schema is useful only if it captures recurring structure rather than normalizing everything into vague metadata.
+
+### 2. Build a counterexample corpus for version-based compatibility rules
+
+A compatibility test suite can deliberately create cases where a release-number heuristic gives the wrong answer. One machine can use a distribution backport on an older upstream base. Another can run a newer kernel with the feature disabled. A container can deny the syscall. A virtualized kernel can omit it. Two kernels can expose the same coarse ABI while differing in a documented erratum.
+
+The artifact would contain small requirement-specific probes plus expected behavior tests, not a table claiming that “kernel X supports feature Y.” Each test records the version heuristic's prediction, the native probe result, and an operation that exercises the semantic property the application actually needs.
+
+Evaluate several real Linux libraries or runtimes that currently gate features by version, compile-time macros, or direct probes. The primary metric is not test coverage. It is the rate of **capability misprediction**: enabling an unusable or semantically unsuitable path, and unnecessarily disabling a usable one. An ablation removes backports and policy layers to show how much each source of divergence contributes.
+
+The academic contribution is a measurable taxonomy of compatibility failures in mixed Linux fleets. Production teams can run the corpus against the exact kernel images and sandbox profiles they ship before widening a rollout.
+
+This direction should be abandoned if representative production kernels and environments almost never disagree with a simple version rule, or if direct native probes already catch every meaningful counterexample. The point is to expose real divergence, not manufacture exotic failures.
+
+### 3. Give capability evidence an explicit validity lease
+
+A capability result should state how long and where it is valid. A kernel-build property may survive for a whole boot. A boot-time LSM setting should be invalidated at reboot. A seccomp or namespace-dependent result may be valid only for one process lineage. A result observed outside a sandbox should not automatically authorize a path inside it.
+
+The mechanism can be simple: attach a scope key to each receipt, such as kernel build identity, boot ID, namespace identities, sandbox-policy digest, and credential class. Cache reuse is allowed only when the requirement declares which components matter and the key still matches. A new environment either re-probes or takes the conservative fallback.
+
+The evaluation should compare global host caching, probe-on-every-use, and lease-scoped caching across container starts, sandbox changes, privilege drops, kernel upgrades, and restarts. Measure stale-positive decisions, redundant probes, startup latency, and the cost of conservative fallback. A useful adversarial test moves a process into a more restricted execution environment after a host-level probe has succeeded.
+
+The academic question is how to infer the minimum validity scope for heterogeneous OS capabilities without turning every check into a one-shot probe. Production value appears in long-running runtimes and fleet agents that cache backend choices and then create workers under different policies.
+
+This mechanism is unnecessary when all relevant capability observations are immutable for the application's lifetime and process-start probing is already cheap. In that case a lease system would add state without removing failures.
+
+## A practical rule for portable Linux software
+
+The simplest usable policy is hierarchical.
+
+Use the kernel release as **orientation**, not proof. It is useful for logging, coarse support policy, and deciding which probe code is worth attempting.
+
+Use the subsystem's native negotiation mechanism as **capability evidence**. Prefer Landlock ABI queries, `io_uring` probes and queries, extensible-structure negotiation, or the documented syscall behavior over a guessed minimum version.
+
+Then test the **semantic property that matters** when the feature is security- or correctness-sensitive. A successful syscall is not automatically proof of every property the application expects from it.
+
+Finally, bind the result to its **execution scope and fallback decision**. When an operator asks why a worker used the slow path while another did not, the system should be able to answer with evidence rather than reconstructing an `if (kernel_version >= ...)` branch from source code.
+
+This is related to the earlier report on [architecture-specific eBPF portability](https://eunomia.dev/research/ebpf-portable-architecture-specialization/), but the boundary is different. That report asks how one portable BPF semantic artifact chooses architecture-specific implementations. Here the object is ordinary Linux userspace software facing several unrelated kernel APIs and distribution backports. The lesson for the future eBPF compatibility series is narrower: BPF-specific work should focus on verifier, CO-RE, kfunc, attachment, and persistent-state semantics rather than repeat a generic Linux capability-receipt design.
+
+## What would change this conclusion?
+
+The argument weakens if distribution kernel versions become reliable capability identifiers in practice. A broad fleet study could test that: take commonly deployed RHEL, Ubuntu, Debian, cloud, mainline, and virtualized kernels, predict usable features only from release strings, and compare those predictions with native probes plus semantic tests. If false positives and false negatives are negligible, direct capability evidence may not justify its engineering cost for most applications.
+
+The conclusion also changes if Linux converges on a common machine-readable negotiation contract that already reports presence, configuration, semantic revision, and execution-policy constraints. `IORING_REGISTER_QUERY` and Landlock's ABI/errata queries move in that direction inside individual subsystems, but there is no single cross-subsystem contract today.
+
+Finally, not every feature deserves semantic testing or durable receipts. A best-effort performance optimization with a safe fallback can simply try the operation and fall back on failure. The stronger machinery is justified when a wrong positive can violate security or correctness, when a fleet decision is expensive to reverse, or when operators need to reproduce why two apparently similar Linux hosts behaved differently.
+
+The practical standard is therefore not “never check `uname`.” It is: **use version strings to locate the neighborhood, use runtime interfaces to prove capability, and keep enough scoped evidence to explain the choice when backports, configuration, or semantics make two similar-looking kernels behave differently.**
+
+## References
+
+- Linux kernel documentation, [Landlock: unprivileged access control](https://kernel.org/doc/html/latest/userspace-api/landlock.html), including ABI and errata negotiation, accessed 2026-09-12.
+- Linux man-pages, [`io_uring_register(2)`](https://man7.org/linux/man-pages/man2/io_uring_register.2.html), including `IORING_REGISTER_PROBE` and `IORING_REGISTER_QUERY`, accessed 2026-09-12.
+- Linux man-pages, [`openat2(2)`](https://man7.org/linux/man-pages/man2/openat2.2.html), including extensible-structure negotiation, accessed 2026-09-12.
+- Red Hat Enterprise Linux documentation, [Managing, monitoring, and updating the kernel](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/), including the RHEL backport model, accessed 2026-09-12.
+- Linux kernel documentation, [Linux ABI description](https://kernel.org/doc/html/latest/admin-guide/abi.html), accessed 2026-09-12.

--- a/docs/research/linux-capability-detection-contract.zh.md
+++ b/docs/research/linux-capability-detection-contract.zh.md
@@ -1,0 +1,148 @@
+---
+date: 2026-09-12
+slug: linux-capability-detection-contract
+title: "为什么 Linux 能力检测不能只看内核版本？"
+description: "Linux 能力检测不能只依赖内核版本：发行版回移植、启动配置和语义修复会让版本号与真实能力分离。本文比较运行时协商机制，并提出可追溯的能力证据回执。"
+tags:
+  - Daily Report
+  - Linux
+  - Compatibility
+  - System Calls
+  - Runtime
+  - Portability
+research_question: "当发行版回移植、启动配置、运行时策略和语义修复都可能偏离内核版本号时，可移植的 Linux 软件应该怎样判断一个功能在当前环境里是否真的可用？"
+source_cutoff: 2026-09-12
+status: daily-report
+---
+
+# 为什么 Linux 能力检测不能只看内核版本？
+
+假设一个服务启动后看到机器报告 Linux 5.14。它想使用某个安全机制、较新的 `io_uring` 操作，或者依赖 `openat2()` 的一种行为。最简单的部署逻辑是查一下“这个功能从 Linux X 开始支持”，再拿 X 和 `uname -r` 比较，决定走新路径还是 fallback。
+
+这种写法很省事，因为它把兼容性问题变成了一个版本号比较。但真实的 Linux 部署并不保持这种一一对应关系。发行版会把较新的子系统改动回移植到较老的 upstream 基线；某个功能可能编进了内核，却在启动时被关闭；沙箱或兼容层也可能让进程看不到宿主机已经实现的 syscall。即使 API 本身存在，后续的语义修复也可能改变应用真正依赖的边界行为，而应用最初检查的 ABI 版本并没有变。
+
+**所以，Linux 能力检测真正需要的是当前运行接口给出的证据，而不只是从内核版本推断出来的猜测。更难的一步，是保存足够的证据，说明究竟证明了哪种行为、这个结论在哪个执行环境中成立，以及程序为什么选择了某条路径。**
+
+<!-- more -->
+
+这篇报告是当前 eBPF 路线中的一次相邻系统 detour。最近十篇 Daily Report 已经达到配置允许的 **7 篇 eBPF-centered** 上限，今天如果继续发布 eBPF 主题就会破坏滚动比例。这个兼容性问题仍然与 [bpftime](https://github.com/eunomia-bpf/bpftime) 这类可移植 runtime 有关，但本文讨论的是一般 Linux userspace interface，而不是 BPF 专用的能力协商。
+
+## Linux 能力检测本来就是多种不同协商契约的组合
+
+反对“只看版本号”的最好证据，其实来自 Linux 接口本身：不同子系统已经各自设计了多种兼容性协商方式。
+
+Red Hat 的文档直接解释了为什么 release string 不能完整描述能力。RHEL 9 的内核可以继续报告 5.14 这一 upstream 基线，同时某些子系统已经包含来自远更新 upstream kernel 的改动。版本号能告诉你这是哪个发行版内核系列，却不能列出里面究竟回移植了哪些功能。
+
+Landlock 更明确。它要求 userspace 通过 `landlock_create_ruleset(..., LANDLOCK_CREATE_RULESET_VERSION)` 查询正在运行的 Landlock ABI，再只启用该 ABI 支持的 access rights，而不是根据 kernel version 猜测。2026 年 8 月的当前内核文档又增加了一个很有意思的层次：`LANDLOCK_CREATE_RULESET_ERRATA` 可以返回语义修复的 bitmask。也就是说，一个功能可以“已经存在”，粗粒度 ABI 也相同，但某个应用关心的边界行为仍可能因为修复是否存在而不同。
+
+`openat2()` 采用另一种办法。它的 `struct open_how` 明确允许未来追加字段，传入的结构体大小本身就是隐式版本。如果 userspace 传入了当前 kernel 不认识的扩展字段，而且这些未知字段非零，内核会返回 `E2BIG`。man page 甚至说明了如何通过 size 探测当前内核理解到什么结构版本。这里的兼容性不是一个显式 ABI 数字，而是由结构形状协商出来的。
+
+`io_uring` 又形成了另一套机制。`IORING_REGISTER_PROBE` 可以查询支持哪些 opcode，`io_uring_setup()` 的 feature bits 描述部分运行行为。当前 man-pages 还记录了从 kernel 6.15 开始提供的 `IORING_REGISTER_QUERY`：它不需要先创建 ring，就能查询 opcode、flag 和子系统相关能力。子系统逐渐走向更丰富的 runtime query，本身就说明一个 release number 很难方便地表达真实能力矩阵。
+
+这些设计并不是互相矛盾的错误。每一种机制面对的兼容性问题不同。真正麻烦的是，可移植 userspace 最终拿到的证据散落在 ABI version、bitmask、opcode probe、可扩展结构、启动配置、返回码和执行策略里。
+
+## “这个功能支持吗”实际上混在了一起的四个问题
+
+第一个问题是**实现是否存在**。当前 kernel 或兼容层到底有没有实现这个 syscall、opcode、flag 或数据结构？`ENOSYS`、opcode probe 或专门的 query interface 通常可以回答。
+
+第二个问题是**当前运行环境是否可用**。Landlock 可以已经编译进 kernel，却因为启动配置没有启用。某些 `io_uring` 操作还会受到 privilege 或 ring mode 的限制。源码里有这个功能，不等于这个进程现在就能用。
+
+第三个问题是**语义处在哪个层级**。一个 ABI number 或 opcode bit 可能只能说明粗粒度 generation，而后续 bug fix 会改变应用在意的 edge case。Landlock 新的 errata query 把这件事直接暴露出来：有时 userspace 需要知道的不只是“接口存在”，而是“某个语义修复是否已经在这台机器上生效”。
+
+第四个问题是**当前 execution context 是否有权使用**。container、seccomp policy、virtualized kernel、LSM 配置、namespace 和 credential 都可能让两条运行在同一个名义 kernel 上的进程看到不同的 usable capability set。因此，一个 host-global cache 很可能替 sandbox 里的进程回答了错误的问题。
+
+版本号比较把这四个问题压成了一个 proxy。直接 probe 已经好很多，但如果软件不记录这个 probe 到底证明了什么、哪个决策依赖它，后续仍然很难解释行为。
+
+## 现有研究还缺什么
+
+第一，**不同 Linux API 之间缺少统一的证据模型**。Landlock 能给 ABI 和 errata mask，`io_uring` 能给 opcode 与 flag support，`openat2()` 能协商结构体大小，但应用通常只是把这些结果变成 loader 代码里的几个临时 boolean。出问题以后，很难判断 fallback 到底是因为 kernel 没这个功能、功能被关闭、进程被策略拒绝，还是应用根本不认识较新的接口。
+
+第二，**feature presence 之上的语义可信度没有统一表达**。能力 API 一般只能回答本子系统定义的问题，却很少直接表达应用真正需要的高层保证，比如“在这些 flag 下，路径解析不会逃出指定 root”或者“这个 sandbox 对我依赖的网络行为处理正确”。Landlock 的 errata 机制说明，ABI 出现之后，行为级差异仍然可能值得单独表达。
+
+第三，**能力证据的作用域和寿命往往不清楚**。有些观察结果在整个 boot 内都稳定，有些取决于进程 credential、namespace、seccomp state、container runtime 或虚拟 syscall surface。很多 capability cache 不声明自己的 validity scope，把 host 外部的 probe 结果直接复用到更受限的执行环境，就会产生 stale-evidence bug。
+
+第四，**fleet compatibility 缺少可复现的反例测试**。发行版回移植本来就会打破 upstream version 与 feature set 的简单映射，但很多 CI matrix 仍主要用 kernel release 标记机器。这样一旦失败，很难分清到底是版本 lineage、具体 backport、配置差异、语义修复还是 policy layer 导致的。
+
+## 兼具学术价值和生产价值的方向
+
+### 1. 把 capability probe 变成有类型的证据回执
+
+缺的不是 probe。Linux 已经有很多不错的 probe。缺的是一个共同格式，能记录一次 probe 成功或失败到底证明了什么。
+
+一份很小的 capability receipt 可以是：
+
+```text
+requirement = landlock.net.bind-tcp
+probe = LANDLOCK_CREATE_RULESET_VERSION
+result = abi>=4
+semantic_fixes = {erratum-1, erratum-2}
+kernel_build = package + build-id
+execution_scope = boot + userns + seccomp-profile + credentials
+observed_at = process-start
+chosen_path = landlock-network-policy-v2
+fallback = filesystem-only-policy
+```
+
+机制可以是一套 userspace library 加 schema，由不同 adapter 把本地子系统的 probe 结果填进去。它不应该替代 Landlock、`io_uring` 或 `openat2()` 自己的协商方式，而是保留这些 source-native semantics，再把证据和真正消费它的 application decision 绑定起来。
+
+最强 baseline 是现在常见的手写 feature detection。可以在 mainline kernel、长期维护的发行版 kernel、不同 boot config、container 和 syscall virtualization 环境中比较两种方案，并注入 backport、feature disabled、syscall denied 与部分 semantic errata。指标包括误启用、无必要 fallback、解释一次决策所需时间、receipt 大小和启动开销。
+
+学术价值在于建立一种 capability evidence model，把 presence、availability、semantics 和 authorization 分开，而不是把“支持”压成一个 bit。生产上，runtime、database、storage engine、sandbox 或 agent executor 都可以在 startup 和 backend-selection 边界接入这套机制，替代散落的 kernel-version conditional。
+
+如果普通 per-API probe 加少量日志已经能以更低复杂度达到相同的决策准确率和事后可解释性，这个方向就不值得做。通用 schema 只有在它真的捕获了多个 API 反复出现的结构时才有价值。
+
+### 2. 为版本号兼容规则建立专门的 counterexample corpus
+
+可以故意构造一组 release-number heuristic 会答错的场景：一台机器在较老 upstream base 上带发行版 backport；另一台 kernel 更新，但功能被关闭；container 拒绝 syscall；virtualized kernel 根本没实现它；两个环境暴露相同粗粒度 ABI，却在一个已记录的 erratum 上不同。
+
+artifact 不应是“kernel X 支持 feature Y”的静态表，而应该是一组很小的 requirement-specific probe 和行为测试。每个 case 同时记录版本 heuristic 的预测、native probe 的结果，以及真正执行一次应用依赖的 semantic property 后得到的结果。
+
+评测可以选择若干真实 Linux library 或 runtime，比较它们当前使用的 version gate、compile-time macro 和 direct probe。主要指标不是测试覆盖率，而是 **capability misprediction**：误启用不可用或语义不满足的路径，以及把其实可用的功能错误关闭。再通过 ablation 去掉 backport 或 policy layer，看每类偏差贡献多少。
+
+学术贡献是一套可以量化 mixed Linux fleet 兼容性失败的 taxonomy。生产团队则可以在扩大 rollout 之前，让这套 corpus 对自己真正发布的 kernel image 和 sandbox profile 运行一次。
+
+如果代表性的生产 kernel 和运行环境几乎从不与简单版本规则发生冲突，或者 native probe 已经能抓住全部有意义的反例，这个方向应该放弃。目标是找到真实 divergence，而不是人为制造边角故障。
+
+### 3. 给 capability evidence 明确的有效期和作用域
+
+一次 capability observation 应该说明它在哪里、多久有效。kernel-build property 可能整个 boot 都不变；boot-time LSM setting 在重启后就需要失效；seccomp 或 namespace 相关结果可能只对一个 process lineage 成立；sandbox 外观察到的能力，也不能自动授权 sandbox 内继续使用。
+
+机制可以很简单：给每份 receipt 附一个 scope key，例如 kernel build identity、boot ID、namespace identity、sandbox-policy digest 和 credential class。只有 requirement 声明相关的 component 没变化时才允许复用 cache，否则重新 probe 或走保守 fallback。
+
+评测比较 host-global cache、每次使用都 probe、以及 lease-scoped cache。在 container start、sandbox policy 变化、privilege drop、kernel upgrade 和 restart 中测 stale-positive decision、重复 probe 数、启动延迟和保守 fallback 成本。一个很直接的 adversarial case 是：host-level probe 成功后，再把工作进程放进更严格的执行环境。
+
+学术问题是：面对异构 OS capability，怎样推导最小 validity scope，同时避免把每次能力检查都退化成一次性 probe。生产价值主要在长期运行的 runtime 和 fleet agent，它们会缓存 backend choice，但之后又在不同 policy 下创建 worker。
+
+如果应用关心的所有 capability 在整个进程生命周期都不可变，而且 process-start probing 本来就足够便宜，那么 lease 机制没有必要。那种情况下额外状态只会增加复杂度。
+
+## 给可移植 Linux 软件的一条实际规则
+
+最简单可用的策略是分层处理。
+
+把 kernel release 当作**方向信息**，而不是证明。它适合日志、粗粒度支持策略，以及判断哪些 probe 值得尝试。
+
+把子系统自己的协商接口当作**能力证据**。优先使用 Landlock ABI query、`io_uring` probe/query、可扩展结构协商或者文档定义的 syscall 行为，而不是猜一个 minimum kernel version。
+
+如果这个功能关系到安全或 correctness，再验证应用真正依赖的**语义性质**。一次 syscall 成功，不自动等于它证明了应用期待的全部保证。
+
+最后，把结果和它的**执行作用域以及 fallback decision** 绑在一起。以后 operator 问“为什么这个 worker 走了慢路径，另一个却没有”时，系统应该拿出证据，而不是重新从 `if (kernel_version >= ...)` 里猜答案。
+
+这和此前的[特定架构 eBPF 可移植性报告](https://eunomia.dev/zh/research/ebpf-portable-architecture-specialization/)有关，但边界不同。那篇文章问的是一个 portable BPF semantic artifact 如何选择架构相关实现；本文讨论的是普通 Linux userspace software 如何面对互不相同的 kernel API 与发行版 backport。对后续 eBPF compatibility 系列来说，这意味着应该聚焦 verifier、CO-RE、kfunc、attach 和 persistent-state 这些 BPF 特有语义，而不是重复一遍通用 Linux capability receipt。
+
+## 哪些结果会改变这个判断？
+
+如果发行版 kernel version 在实践中已经足够可靠地标识 capability，这个结论会明显变弱。可以做一个大规模 fleet study：收集常见 RHEL、Ubuntu、Debian、cloud、mainline 与 virtualized kernel，只根据 release string 预测可用功能，再与 native probe 和 semantic test 比较。如果 false positive 与 false negative 都接近零，多数应用就没有必要承担更复杂的直接能力证据机制。
+
+如果 Linux 以后收敛出一种统一的 machine-readable negotiation contract，可以同时表达 presence、configuration、semantic revision 和 execution-policy constraint，本文提出的跨子系统 receipt 也会失去价值。`IORING_REGISTER_QUERY` 以及 Landlock 的 ABI/errata query 已经在各自子系统内朝这个方向走，但今天还没有统一 contract。
+
+最后，并不是每个 feature 都值得做 semantic test 或持久保存 receipt。一个有安全 fallback 的 best-effort 性能优化，完全可以先试操作，失败就回退。只有当错误的 positive 会破坏安全或 correctness、fleet 决策很难回滚，或者 operator 必须复现两台看起来相似的 Linux host 为什么行为不同，更强的证据机制才值得付出成本。
+
+所以实际标准不是“永远不要看 `uname`”，而是：**用版本号判断大致范围，用运行时接口证明真实能力，再保存足够且带作用域的证据，解释为什么 backport、配置或语义差异会让两个看起来相似的 kernel 做出不同的行为。**
+
+## References
+
+- Linux kernel documentation, [Landlock: unprivileged access control](https://kernel.org/doc/html/latest/userspace-api/landlock.html), including ABI and errata negotiation, accessed 2026-09-12.
+- Linux man-pages, [`io_uring_register(2)`](https://man7.org/linux/man-pages/man2/io_uring_register.2.html), including `IORING_REGISTER_PROBE` and `IORING_REGISTER_QUERY`, accessed 2026-09-12.
+- Linux man-pages, [`openat2(2)`](https://man7.org/linux/man-pages/man2/openat2.2.html), including extensible-structure negotiation, accessed 2026-09-12.
+- Red Hat Enterprise Linux documentation, [Managing, monitoring, and updating the kernel](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/), including the RHEL backport model, accessed 2026-09-12.
+- Linux kernel documentation, [Linux ABI description](https://kernel.org/doc/html/latest/admin-guide/abi.html), accessed 2026-09-12.


### PR DESCRIPTION
## Summary

- publish exactly one new bilingual Daily Report: `linux-capability-detection-contract`
- classify it as adjacent systems to preserve the newest-ten `7 eBPF / 0 pure Agent / 3 adjacent` mix
- analyze current Google Drive SEO exports without synthesizing missing dates
- reconcile September 11 delivery and refresh operating status
- make no unrelated technical SEO change because current evidence does not establish a concrete defect

## Research boundary

The report compares Linux capability negotiation across Landlock ABI/errata queries, io_uring probes/queries, openat2 extensible structures, and distribution backports. It develops typed capability receipts, a compatibility counterexample corpus, and scoped evidence leases. It intentionally stays Linux-userspace-centered rather than consuming the active eBPF deployment-compatibility series.

## Validation

Please run the repository-authoritative `Validate SEO Operations` and `Deploy Static App` checks. This PR will not be merged until both are terminal green and the complete diff/generated output has been re-read.